### PR TITLE
feat: 6-type cognitive memory system

### DIFF
--- a/src/amplihack_memory/__init__.py
+++ b/src/amplihack_memory/__init__.py
@@ -1,7 +1,8 @@
 """amplihack-memory-lib: Standalone memory system for goal-seeking agents."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
+from .cognitive_memory import CognitiveMemory
 from .connector import MemoryConnector
 from .exceptions import (
     ExperienceNotFoundError,
@@ -10,6 +11,16 @@ from .exceptions import (
     MemoryQuotaExceededError,
 )
 from .experience import Experience, ExperienceType
+from .memory_types import (
+    ConsolidatedEpisode,
+    EpisodicMemory,
+    MemoryCategory,
+    ProceduralMemory,
+    ProspectiveMemory,
+    SemanticFact,
+    SensoryItem,
+    WorkingMemorySlot,
+)
 from .security import (
     AgentCapabilities,
     CredentialScrubber,
@@ -22,15 +33,28 @@ from .security import (
 from .store import ExperienceStore
 
 __all__ = [
+    # Cognitive memory (new)
+    "CognitiveMemory",
+    "MemoryCategory",
+    "SensoryItem",
+    "WorkingMemorySlot",
+    "EpisodicMemory",
+    "SemanticFact",
+    "ProceduralMemory",
+    "ProspectiveMemory",
+    "ConsolidatedEpisode",
+    # Experience store (existing)
     "Experience",
     "ExperienceType",
     "MemoryConnector",
     "ExperienceStore",
+    # Security (existing)
     "AgentCapabilities",
     "ScopeLevel",
     "CredentialScrubber",
     "QueryValidator",
     "SecureMemoryBackend",
+    # Exceptions (existing)
     "MemoryError",
     "ExperienceNotFoundError",
     "InvalidExperienceError",

--- a/src/amplihack_memory/cognitive_memory.py
+++ b/src/amplihack_memory/cognitive_memory.py
@@ -1,0 +1,1180 @@
+"""Cognitive memory system with six memory types.
+
+Provides a single CognitiveMemory class that manages all six cognitive memory
+types (sensory, working, episodic, semantic, procedural, prospective) backed
+by a Kuzu graph database.
+
+Each agent gets full isolation via an ``agent_id`` column stored in every
+node table.
+"""
+
+import json
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+import kuzu
+
+from .memory_types import (
+    ConsolidatedEpisode,
+    EpisodicMemory,
+    MemoryCategory,
+    ProceduralMemory,
+    ProspectiveMemory,
+    SemanticFact,
+    SensoryItem,
+    WorkingMemorySlot,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WORKING_MEMORY_CAPACITY = 20
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _new_id(prefix: str = "mem") -> str:
+    """Generate a short unique id with a human-readable prefix."""
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+def _ts_now() -> int:
+    """Current Unix timestamp as integer."""
+    return int(time.time())
+
+
+def _safe_execute(conn: kuzu.Connection, query: str, params: dict | None = None):
+    """Execute a Kuzu query, returning the QueryResult or None on error."""
+    if params is None:
+        params = {}
+    return conn.execute(query, params)
+
+
+# ---------------------------------------------------------------------------
+# Schema initialisation
+# ---------------------------------------------------------------------------
+
+_NODE_TABLES = [
+    """
+    CREATE NODE TABLE IF NOT EXISTS SensoryMemory(
+        node_id STRING,
+        agent_id STRING,
+        modality STRING,
+        raw_data STRING,
+        observation_order INT64,
+        expires_at INT64,
+        created_at INT64,
+        PRIMARY KEY(node_id)
+    )
+    """,
+    """
+    CREATE NODE TABLE IF NOT EXISTS WorkingMemory(
+        node_id STRING,
+        agent_id STRING,
+        slot_type STRING,
+        content STRING,
+        relevance DOUBLE,
+        task_id STRING,
+        created_at INT64,
+        PRIMARY KEY(node_id)
+    )
+    """,
+    """
+    CREATE NODE TABLE IF NOT EXISTS EpisodicMemory(
+        node_id STRING,
+        agent_id STRING,
+        content STRING,
+        source_label STRING,
+        temporal_index INT64,
+        compressed BOOLEAN,
+        metadata STRING,
+        created_at INT64,
+        PRIMARY KEY(node_id)
+    )
+    """,
+    """
+    CREATE NODE TABLE IF NOT EXISTS SemanticMemory(
+        node_id STRING,
+        agent_id STRING,
+        concept STRING,
+        content STRING,
+        confidence DOUBLE,
+        source_id STRING,
+        tags STRING,
+        metadata STRING,
+        created_at INT64,
+        PRIMARY KEY(node_id)
+    )
+    """,
+    """
+    CREATE NODE TABLE IF NOT EXISTS ProceduralMemory(
+        node_id STRING,
+        agent_id STRING,
+        name STRING,
+        steps STRING,
+        prerequisites STRING,
+        usage_count INT64,
+        created_at INT64,
+        PRIMARY KEY(node_id)
+    )
+    """,
+    """
+    CREATE NODE TABLE IF NOT EXISTS ProspectiveMemory(
+        node_id STRING,
+        agent_id STRING,
+        desc_text STRING,
+        trigger_condition STRING,
+        action_on_trigger STRING,
+        status STRING,
+        priority INT64,
+        created_at INT64,
+        PRIMARY KEY(node_id)
+    )
+    """,
+    """
+    CREATE NODE TABLE IF NOT EXISTS ConsolidatedEpisode(
+        node_id STRING,
+        agent_id STRING,
+        summary STRING,
+        original_count INT64,
+        created_at INT64,
+        PRIMARY KEY(node_id)
+    )
+    """,
+]
+
+_REL_TABLES = [
+    """
+    CREATE REL TABLE IF NOT EXISTS SIMILAR_TO(
+        FROM SemanticMemory TO SemanticMemory,
+        similarity_score DOUBLE
+    )
+    """,
+    """
+    CREATE REL TABLE IF NOT EXISTS DERIVES_FROM(
+        FROM SemanticMemory TO EpisodicMemory,
+        derived_at INT64
+    )
+    """,
+    """
+    CREATE REL TABLE IF NOT EXISTS PROCEDURE_DERIVES_FROM(
+        FROM ProceduralMemory TO EpisodicMemory,
+        derived_at INT64
+    )
+    """,
+    """
+    CREATE REL TABLE IF NOT EXISTS CONSOLIDATES(
+        FROM ConsolidatedEpisode TO EpisodicMemory,
+        consolidated_at INT64
+    )
+    """,
+    """
+    CREATE REL TABLE IF NOT EXISTS ATTENDED_TO(
+        FROM SensoryMemory TO EpisodicMemory,
+        attended_at INT64
+    )
+    """,
+]
+
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+class CognitiveMemory:
+    """Six-type cognitive memory backed by Kuzu.
+
+    Args:
+        agent_name: Identifier for the agent (used for row isolation).
+        db_path: Filesystem path for the Kuzu database directory.
+    """
+
+    WORKING_MEMORY_CAPACITY = WORKING_MEMORY_CAPACITY
+
+    def __init__(self, agent_name: str, db_path: str | Path) -> None:
+        if not agent_name or not agent_name.strip():
+            raise ValueError("agent_name cannot be empty")
+
+        self.agent_name = agent_name.strip()
+        self.db_path = Path(db_path)
+        # Ensure the *parent* directory exists; Kuzu creates the db dir itself.
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._db = kuzu.Database(str(self.db_path))
+        self._conn = kuzu.Connection(self._db)
+        self._initialize_schema()
+
+        # Monotonic counters (loaded from DB at startup)
+        self._sensory_order = self._load_max_order("SensoryMemory", "observation_order")
+        self._temporal_index = self._load_max_order("EpisodicMemory", "temporal_index")
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def _initialize_schema(self) -> None:
+        for ddl in _NODE_TABLES + _REL_TABLES:
+            try:
+                self._conn.execute(ddl)
+            except Exception as exc:
+                if "already exists" not in str(exc).lower():
+                    raise
+
+    def _load_max_order(self, table: str, column: str) -> int:
+        result = self._conn.execute(
+            f"MATCH (n:{table}) WHERE n.agent_id = $aid "
+            f"RETURN max(n.{column})",
+            {"aid": self.agent_name},
+        )
+        if result.has_next():
+            val = result.get_next()[0]
+            if val is not None:
+                return int(val)
+        return 0
+
+    # ==================================================================
+    # SENSORY MEMORY
+    # ==================================================================
+
+    def record_sensory(
+        self,
+        modality: str,
+        raw_data: str,
+        ttl_seconds: int = 300,
+    ) -> str:
+        """Record a short-lived sensory observation.
+
+        Args:
+            modality: Channel name (e.g. "text", "code", "error").
+            raw_data: The raw observation payload.
+            ttl_seconds: Time-to-live in seconds (default 300 = 5 min).
+
+        Returns:
+            The node_id of the newly created sensory item.
+        """
+        node_id = _new_id("sen")
+        now = _ts_now()
+        self._sensory_order += 1
+        self._conn.execute(
+            """
+            CREATE (:SensoryMemory {
+                node_id: $nid,
+                agent_id: $aid,
+                modality: $mod,
+                raw_data: $data,
+                observation_order: $ord,
+                expires_at: $exp,
+                created_at: $ts
+            })
+            """,
+            {
+                "nid": node_id,
+                "aid": self.agent_name,
+                "mod": modality,
+                "data": raw_data,
+                "ord": self._sensory_order,
+                "exp": now + ttl_seconds,
+                "ts": now,
+            },
+        )
+        return node_id
+
+    def get_recent_sensory(self, limit: int = 10) -> list[SensoryItem]:
+        """Return the most recent sensory items (not yet expired).
+
+        Args:
+            limit: Maximum items to return.
+
+        Returns:
+            List of SensoryItem ordered by observation_order descending.
+        """
+        now = _ts_now()
+        result = self._conn.execute(
+            """
+            MATCH (s:SensoryMemory)
+            WHERE s.agent_id = $aid AND s.expires_at > $now
+            RETURN s.node_id, s.modality, s.raw_data,
+                   s.observation_order, s.expires_at, s.created_at
+            ORDER BY s.observation_order DESC
+            LIMIT $lim
+            """,
+            {"aid": self.agent_name, "now": now, "lim": limit},
+        )
+        items: list[SensoryItem] = []
+        while result.has_next():
+            row = result.get_next()
+            items.append(SensoryItem(
+                node_id=row[0],
+                modality=row[1],
+                raw_data=row[2],
+                observation_order=int(row[3]),
+                expires_at=float(row[4]),
+                created_at=datetime.fromtimestamp(row[5]),
+            ))
+        return items
+
+    def attend_to_sensory(self, sensory_id: str, reason: str) -> str | None:
+        """Promote a sensory item to an episodic memory and link them.
+
+        Args:
+            sensory_id: node_id of the sensory item to promote.
+            reason: Why this observation is noteworthy.
+
+        Returns:
+            The node_id of the new episodic memory, or None if the
+            sensory item was not found / already expired.
+        """
+        now = _ts_now()
+        # Fetch the sensory item
+        result = self._conn.execute(
+            """
+            MATCH (s:SensoryMemory)
+            WHERE s.node_id = $sid AND s.agent_id = $aid AND s.expires_at > $now
+            RETURN s.modality, s.raw_data
+            """,
+            {"sid": sensory_id, "aid": self.agent_name, "now": now},
+        )
+        if not result.has_next():
+            return None
+
+        modality, raw_data = result.get_next()
+        content = f"[{modality}] {raw_data} -- attended: {reason}"
+
+        ep_id = self.store_episode(content=content, source_label="sensory-attention")
+
+        # Create ATTENDED_TO edge
+        try:
+            self._conn.execute(
+                """
+                MATCH (s:SensoryMemory), (e:EpisodicMemory)
+                WHERE s.node_id = $sid AND e.node_id = $eid
+                CREATE (s)-[:ATTENDED_TO {attended_at: $ts}]->(e)
+                """,
+                {"sid": sensory_id, "eid": ep_id, "ts": now},
+            )
+        except Exception:
+            pass  # edge creation is best-effort
+
+        return ep_id
+
+    def prune_expired_sensory(self) -> int:
+        """Delete sensory items past their expiry time.
+
+        Returns:
+            Number of items pruned.
+        """
+        now = _ts_now()
+        # Count first
+        result = self._conn.execute(
+            """
+            MATCH (s:SensoryMemory)
+            WHERE s.agent_id = $aid AND s.expires_at <= $now
+            RETURN count(s)
+            """,
+            {"aid": self.agent_name, "now": now},
+        )
+        count = 0
+        if result.has_next():
+            count = int(result.get_next()[0])
+
+        if count > 0:
+            self._conn.execute(
+                """
+                MATCH (s:SensoryMemory)
+                WHERE s.agent_id = $aid AND s.expires_at <= $now
+                DELETE s
+                """,
+                {"aid": self.agent_name, "now": now},
+            )
+        return count
+
+    # ==================================================================
+    # WORKING MEMORY
+    # ==================================================================
+
+    def push_working(
+        self,
+        slot_type: str,
+        content: str,
+        task_id: str,
+        relevance: float = 1.0,
+    ) -> str:
+        """Push a slot into working memory for a given task.
+
+        If the task already has WORKING_MEMORY_CAPACITY slots, the
+        least-relevant slot is evicted.
+
+        Args:
+            slot_type: Categorisation (e.g. "goal", "constraint").
+            content: Payload.
+            task_id: Task identifier.
+            relevance: Priority weight (default 1.0).
+
+        Returns:
+            node_id of the new working-memory slot.
+        """
+        # Evict if at capacity
+        existing = self.get_working(task_id)
+        if len(existing) >= self.WORKING_MEMORY_CAPACITY:
+            # Remove the lowest-relevance slot
+            lowest = min(existing, key=lambda s: s.relevance)
+            self._conn.execute(
+                "MATCH (w:WorkingMemory) WHERE w.node_id = $nid DELETE w",
+                {"nid": lowest.node_id},
+            )
+
+        node_id = _new_id("wrk")
+        now = _ts_now()
+        self._conn.execute(
+            """
+            CREATE (:WorkingMemory {
+                node_id: $nid,
+                agent_id: $aid,
+                slot_type: $st,
+                content: $cnt,
+                relevance: $rel,
+                task_id: $tid,
+                created_at: $ts
+            })
+            """,
+            {
+                "nid": node_id,
+                "aid": self.agent_name,
+                "st": slot_type,
+                "cnt": content,
+                "rel": relevance,
+                "tid": task_id,
+                "ts": now,
+            },
+        )
+        return node_id
+
+    def get_working(self, task_id: str) -> list[WorkingMemorySlot]:
+        """Retrieve working memory slots for a task.
+
+        Args:
+            task_id: Task identifier.
+
+        Returns:
+            List of WorkingMemorySlot ordered by relevance descending.
+        """
+        result = self._conn.execute(
+            """
+            MATCH (w:WorkingMemory)
+            WHERE w.agent_id = $aid AND w.task_id = $tid
+            RETURN w.node_id, w.slot_type, w.content,
+                   w.relevance, w.task_id, w.created_at
+            ORDER BY w.relevance DESC
+            """,
+            {"aid": self.agent_name, "tid": task_id},
+        )
+        slots: list[WorkingMemorySlot] = []
+        while result.has_next():
+            row = result.get_next()
+            slots.append(WorkingMemorySlot(
+                node_id=row[0],
+                slot_type=row[1],
+                content=row[2],
+                relevance=float(row[3]),
+                task_id=row[4],
+                created_at=datetime.fromtimestamp(row[5]),
+            ))
+        return slots
+
+    def clear_working(self, task_id: str) -> int:
+        """Clear all working memory slots for a task.
+
+        Args:
+            task_id: Task identifier.
+
+        Returns:
+            Number of slots cleared.
+        """
+        result = self._conn.execute(
+            """
+            MATCH (w:WorkingMemory)
+            WHERE w.agent_id = $aid AND w.task_id = $tid
+            RETURN count(w)
+            """,
+            {"aid": self.agent_name, "tid": task_id},
+        )
+        count = 0
+        if result.has_next():
+            count = int(result.get_next()[0])
+
+        if count > 0:
+            self._conn.execute(
+                """
+                MATCH (w:WorkingMemory)
+                WHERE w.agent_id = $aid AND w.task_id = $tid
+                DELETE w
+                """,
+                {"aid": self.agent_name, "tid": task_id},
+            )
+        return count
+
+    # ==================================================================
+    # EPISODIC MEMORY
+    # ==================================================================
+
+    def store_episode(
+        self,
+        content: str,
+        source_label: str,
+        temporal_index: int | None = None,
+        metadata: dict | None = None,
+    ) -> str:
+        """Store an episodic memory.
+
+        Args:
+            content: Episode description.
+            source_label: Origin label (e.g. "user-session").
+            temporal_index: Explicit ordering index. If None, auto-increments.
+            metadata: Optional structured data.
+
+        Returns:
+            node_id of the stored episode.
+        """
+        node_id = _new_id("epi")
+        now = _ts_now()
+        if temporal_index is None:
+            self._temporal_index += 1
+            temporal_index = self._temporal_index
+        else:
+            # Keep our counter up to date
+            if temporal_index > self._temporal_index:
+                self._temporal_index = temporal_index
+
+        meta_json = json.dumps(metadata) if metadata else "{}"
+
+        self._conn.execute(
+            """
+            CREATE (:EpisodicMemory {
+                node_id: $nid,
+                agent_id: $aid,
+                content: $cnt,
+                source_label: $src,
+                temporal_index: $tidx,
+                compressed: false,
+                metadata: $meta,
+                created_at: $ts
+            })
+            """,
+            {
+                "nid": node_id,
+                "aid": self.agent_name,
+                "cnt": content,
+                "src": source_label,
+                "tidx": temporal_index,
+                "meta": meta_json,
+                "ts": now,
+            },
+        )
+        return node_id
+
+    def consolidate_episodes(
+        self,
+        batch_size: int = 10,
+        summarizer: Callable[[list[str]], str] | None = None,
+    ) -> str | None:
+        """Consolidate the oldest un-compressed episodes into a summary.
+
+        Args:
+            batch_size: Number of episodes to consolidate per call.
+            summarizer: Optional function ``(list[str]) -> str`` that
+                produces a summary.  If None a simple concatenation is used.
+
+        Returns:
+            node_id of the ConsolidatedEpisode, or None if fewer than
+            ``batch_size`` episodes are available.
+        """
+        result = self._conn.execute(
+            """
+            MATCH (e:EpisodicMemory)
+            WHERE e.agent_id = $aid AND e.compressed = false
+            RETURN e.node_id, e.content
+            ORDER BY e.temporal_index ASC
+            LIMIT $bs
+            """,
+            {"aid": self.agent_name, "bs": batch_size},
+        )
+        episodes: list[tuple[str, str]] = []
+        while result.has_next():
+            row = result.get_next()
+            episodes.append((row[0], row[1]))
+
+        if len(episodes) < batch_size:
+            return None
+
+        contents = [c for _, c in episodes]
+        if summarizer is not None:
+            summary = summarizer(contents)
+        else:
+            summary = " | ".join(contents)
+
+        # Create consolidated node
+        cons_id = _new_id("con")
+        now = _ts_now()
+        self._conn.execute(
+            """
+            CREATE (:ConsolidatedEpisode {
+                node_id: $nid,
+                agent_id: $aid,
+                summary: $sum,
+                original_count: $cnt,
+                created_at: $ts
+            })
+            """,
+            {
+                "nid": cons_id,
+                "aid": self.agent_name,
+                "sum": summary,
+                "cnt": len(episodes),
+                "ts": now,
+            },
+        )
+
+        # Mark originals as compressed and create edges
+        for ep_id, _ in episodes:
+            self._conn.execute(
+                """
+                MATCH (e:EpisodicMemory)
+                WHERE e.node_id = $eid
+                SET e.compressed = true
+                """,
+                {"eid": ep_id},
+            )
+            try:
+                self._conn.execute(
+                    """
+                    MATCH (c:ConsolidatedEpisode), (e:EpisodicMemory)
+                    WHERE c.node_id = $cid AND e.node_id = $eid
+                    CREATE (c)-[:CONSOLIDATES {consolidated_at: $ts}]->(e)
+                    """,
+                    {"cid": cons_id, "eid": ep_id, "ts": now},
+                )
+            except Exception:
+                pass  # edge creation is best-effort
+
+        return cons_id
+
+    def get_episodes(
+        self,
+        limit: int = 20,
+        include_compressed: bool = False,
+    ) -> list[EpisodicMemory]:
+        """Retrieve episodic memories.
+
+        Args:
+            limit: Maximum number of episodes.
+            include_compressed: If False (default), exclude compressed episodes.
+
+        Returns:
+            List of EpisodicMemory sorted by temporal_index descending.
+        """
+        compressed_clause = "" if include_compressed else " AND e.compressed = false"
+        result = self._conn.execute(
+            f"""
+            MATCH (e:EpisodicMemory)
+            WHERE e.agent_id = $aid{compressed_clause}
+            RETURN e.node_id, e.content, e.source_label,
+                   e.temporal_index, e.compressed, e.created_at, e.metadata
+            ORDER BY e.temporal_index DESC
+            LIMIT $lim
+            """,
+            {"aid": self.agent_name, "lim": limit},
+        )
+        episodes: list[EpisodicMemory] = []
+        while result.has_next():
+            row = result.get_next()
+            meta = {}
+            if row[6]:
+                try:
+                    meta = json.loads(row[6])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            episodes.append(EpisodicMemory(
+                node_id=row[0],
+                content=row[1],
+                source_label=row[2],
+                temporal_index=int(row[3]),
+                compressed=bool(row[4]),
+                created_at=datetime.fromtimestamp(row[5]),
+                metadata=meta,
+            ))
+        return episodes
+
+    # ==================================================================
+    # SEMANTIC MEMORY
+    # ==================================================================
+
+    def store_fact(
+        self,
+        concept: str,
+        content: str,
+        confidence: float = 1.0,
+        source_id: str = "",
+        tags: list[str] | None = None,
+        temporal_metadata: dict | None = None,
+    ) -> str:
+        """Store a semantic fact.
+
+        Args:
+            concept: The concept or topic.
+            content: Factual content.
+            confidence: Confidence score (0.0 - 1.0).
+            source_id: Origin reference.
+            tags: Categorisation tags.
+            temporal_metadata: Optional structured metadata.
+
+        Returns:
+            node_id of the stored fact.
+        """
+        node_id = _new_id("sem")
+        now = _ts_now()
+        tags_json = json.dumps(tags) if tags else "[]"
+        meta_json = json.dumps(temporal_metadata) if temporal_metadata else "{}"
+
+        self._conn.execute(
+            """
+            CREATE (:SemanticMemory {
+                node_id: $nid,
+                agent_id: $aid,
+                concept: $con,
+                content: $cnt,
+                confidence: $conf,
+                source_id: $src,
+                tags: $tags,
+                metadata: $meta,
+                created_at: $ts
+            })
+            """,
+            {
+                "nid": node_id,
+                "aid": self.agent_name,
+                "con": concept,
+                "cnt": content,
+                "conf": confidence,
+                "src": source_id,
+                "tags": tags_json,
+                "meta": meta_json,
+                "ts": now,
+            },
+        )
+        return node_id
+
+    def search_facts(
+        self,
+        query: str,
+        limit: int = 10,
+        min_confidence: float = 0.0,
+    ) -> list[SemanticFact]:
+        """Search semantic facts by keyword matching on concept and content.
+
+        Args:
+            query: Search string (keywords matched via CONTAINS).
+            limit: Maximum results.
+            min_confidence: Minimum confidence threshold.
+
+        Returns:
+            List of matching SemanticFact ordered by confidence descending.
+        """
+        # Tokenise query and build OR conditions
+        keywords = [w.strip() for w in query.split() if w.strip()]
+        if not keywords:
+            return self.get_all_facts(limit=limit)
+
+        conditions = []
+        params: dict = {
+            "aid": self.agent_name,
+            "minc": min_confidence,
+            "lim": limit,
+        }
+        for i, kw in enumerate(keywords[:6]):
+            pname = f"kw{i}"
+            conditions.append(
+                f"(lower(s.concept) CONTAINS lower(${pname}) "
+                f"OR lower(s.content) CONTAINS lower(${pname}))"
+            )
+            params[pname] = kw
+
+        where_kw = " OR ".join(conditions)
+        result = self._conn.execute(
+            f"""
+            MATCH (s:SemanticMemory)
+            WHERE s.agent_id = $aid
+              AND s.confidence >= $minc
+              AND ({where_kw})
+            RETURN s.node_id, s.concept, s.content, s.confidence,
+                   s.source_id, s.tags, s.metadata, s.created_at
+            ORDER BY s.confidence DESC
+            LIMIT $lim
+            """,
+            params,
+        )
+        return self._rows_to_facts(result)
+
+    def get_all_facts(self, limit: int = 50) -> list[SemanticFact]:
+        """Return all semantic facts for this agent.
+
+        Args:
+            limit: Maximum number of facts.
+
+        Returns:
+            List of SemanticFact ordered by confidence descending.
+        """
+        result = self._conn.execute(
+            """
+            MATCH (s:SemanticMemory)
+            WHERE s.agent_id = $aid
+            RETURN s.node_id, s.concept, s.content, s.confidence,
+                   s.source_id, s.tags, s.metadata, s.created_at
+            ORDER BY s.confidence DESC
+            LIMIT $lim
+            """,
+            {"aid": self.agent_name, "lim": limit},
+        )
+        return self._rows_to_facts(result)
+
+    @staticmethod
+    def _rows_to_facts(result) -> list[SemanticFact]:
+        facts: list[SemanticFact] = []
+        while result.has_next():
+            row = result.get_next()
+            tags: list[str] = []
+            if row[5]:
+                try:
+                    tags = json.loads(row[5])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            meta: dict = {}
+            if row[6]:
+                try:
+                    meta = json.loads(row[6])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            facts.append(SemanticFact(
+                node_id=row[0],
+                concept=row[1],
+                content=row[2],
+                confidence=float(row[3]),
+                source_id=row[4] or "",
+                tags=tags,
+                metadata=meta,
+                created_at=datetime.fromtimestamp(row[7]),
+            ))
+        return facts
+
+    # ==================================================================
+    # PROCEDURAL MEMORY
+    # ==================================================================
+
+    def store_procedure(
+        self,
+        name: str,
+        steps: list[str],
+        prerequisites: list[str] | None = None,
+        source_id: str = "",
+        tags: list[str] | None = None,
+    ) -> str:
+        """Store a reusable procedure.
+
+        Args:
+            name: Human-readable procedure name.
+            steps: Ordered list of step descriptions.
+            prerequisites: Conditions required before executing.
+            source_id: Origin reference (unused in storage but kept for API compat).
+            tags: Categorisation tags (unused in storage but kept for API compat).
+
+        Returns:
+            node_id of the stored procedure.
+        """
+        node_id = _new_id("proc")
+        now = _ts_now()
+        steps_json = json.dumps(steps)
+        prereqs_json = json.dumps(prerequisites) if prerequisites else "[]"
+
+        self._conn.execute(
+            """
+            CREATE (:ProceduralMemory {
+                node_id: $nid,
+                agent_id: $aid,
+                name: $name,
+                steps: $steps,
+                prerequisites: $prereqs,
+                usage_count: 0,
+                created_at: $ts
+            })
+            """,
+            {
+                "nid": node_id,
+                "aid": self.agent_name,
+                "name": name,
+                "steps": steps_json,
+                "prereqs": prereqs_json,
+                "ts": now,
+            },
+        )
+        return node_id
+
+    def recall_procedure(
+        self,
+        query: str,
+        limit: int = 5,
+    ) -> list[ProceduralMemory]:
+        """Recall procedures matching a query and increment their usage count.
+
+        Args:
+            query: Search keywords (matched against name and steps).
+            limit: Maximum results.
+
+        Returns:
+            List of matching ProceduralMemory sorted by usage_count desc.
+        """
+        keywords = [w.strip() for w in query.split() if w.strip()]
+        if not keywords:
+            # Return most-used procedures
+            result = self._conn.execute(
+                """
+                MATCH (p:ProceduralMemory)
+                WHERE p.agent_id = $aid
+                RETURN p.node_id, p.name, p.steps,
+                       p.prerequisites, p.usage_count, p.created_at
+                ORDER BY p.usage_count DESC
+                LIMIT $lim
+                """,
+                {"aid": self.agent_name, "lim": limit},
+            )
+        else:
+            conditions = []
+            params: dict = {"aid": self.agent_name, "lim": limit}
+            for i, kw in enumerate(keywords[:6]):
+                pname = f"kw{i}"
+                conditions.append(
+                    f"(lower(p.name) CONTAINS lower(${pname}) "
+                    f"OR lower(p.steps) CONTAINS lower(${pname}))"
+                )
+                params[pname] = kw
+
+            where_kw = " OR ".join(conditions)
+            result = self._conn.execute(
+                f"""
+                MATCH (p:ProceduralMemory)
+                WHERE p.agent_id = $aid AND ({where_kw})
+                RETURN p.node_id, p.name, p.steps,
+                       p.prerequisites, p.usage_count, p.created_at
+                ORDER BY p.usage_count DESC
+                LIMIT $lim
+                """,
+                params,
+            )
+
+        procs: list[ProceduralMemory] = []
+        while result.has_next():
+            row = result.get_next()
+            steps: list[str] = []
+            if row[2]:
+                try:
+                    steps = json.loads(row[2])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            prereqs: list[str] = []
+            if row[3]:
+                try:
+                    prereqs = json.loads(row[3])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            procs.append(ProceduralMemory(
+                node_id=row[0],
+                name=row[1],
+                steps=steps,
+                prerequisites=prereqs,
+                usage_count=int(row[4]),
+                created_at=datetime.fromtimestamp(row[5]),
+            ))
+
+        # Increment usage_count for all recalled procedures
+        for proc in procs:
+            self._conn.execute(
+                """
+                MATCH (p:ProceduralMemory)
+                WHERE p.node_id = $nid
+                SET p.usage_count = p.usage_count + 1
+                """,
+                {"nid": proc.node_id},
+            )
+
+        return procs
+
+    # ==================================================================
+    # PROSPECTIVE MEMORY
+    # ==================================================================
+
+    def store_prospective(
+        self,
+        description: str,
+        trigger_condition: str,
+        action_on_trigger: str,
+        priority: int = 1,
+    ) -> str:
+        """Store a trigger-action pair for future evaluation.
+
+        Args:
+            description: What this prospective memory is about.
+            trigger_condition: Text description of the trigger.
+            action_on_trigger: What to do when fired.
+            priority: Priority level (higher = more important).
+
+        Returns:
+            node_id of the stored prospective memory.
+        """
+        node_id = _new_id("pro")
+        now = _ts_now()
+
+        self._conn.execute(
+            """
+            CREATE (:ProspectiveMemory {
+                node_id: $nid,
+                agent_id: $aid,
+                desc_text: $dtxt,
+                trigger_condition: $trig,
+                action_on_trigger: $act,
+                status: $stat,
+                priority: $pri,
+                created_at: $ts
+            })
+            """,
+            {
+                "nid": node_id,
+                "aid": self.agent_name,
+                "dtxt": description,
+                "trig": trigger_condition,
+                "act": action_on_trigger,
+                "stat": "pending",
+                "pri": priority,
+                "ts": now,
+            },
+        )
+        return node_id
+
+    def check_triggers(self, content: str) -> list[ProspectiveMemory]:
+        """Check pending prospective memories against provided content.
+
+        A simple keyword-overlap heuristic: if any word from the
+        trigger_condition appears in ``content``, the prospective memory
+        is considered triggered.
+
+        Args:
+            content: Text to evaluate against triggers.
+
+        Returns:
+            List of triggered ProspectiveMemory items (status set to "triggered").
+        """
+        result = self._conn.execute(
+            """
+            MATCH (p:ProspectiveMemory)
+            WHERE p.agent_id = $aid AND p.status = $stat
+            RETURN p.node_id, p.desc_text, p.trigger_condition,
+                   p.action_on_trigger, p.status, p.priority, p.created_at
+            ORDER BY p.priority DESC
+            """,
+            {"aid": self.agent_name, "stat": "pending"},
+        )
+
+        candidates: list[ProspectiveMemory] = []
+        while result.has_next():
+            row = result.get_next()
+            candidates.append(ProspectiveMemory(
+                node_id=row[0],
+                description=row[1],
+                trigger_condition=row[2],
+                action_on_trigger=row[3],
+                status=row[4],
+                priority=int(row[5]),
+                created_at=datetime.fromtimestamp(row[6]),
+            ))
+
+        content_lower = content.lower()
+        triggered: list[ProspectiveMemory] = []
+        for pm in candidates:
+            trigger_words = {w.lower() for w in pm.trigger_condition.split() if w.strip()}
+            if any(w in content_lower for w in trigger_words):
+                # Mark as triggered in the DB
+                self._conn.execute(
+                    """
+                    MATCH (p:ProspectiveMemory)
+                    WHERE p.node_id = $nid
+                    SET p.status = $stat
+                    """,
+                    {"nid": pm.node_id, "stat": "triggered"},
+                )
+                pm.status = "triggered"
+                triggered.append(pm)
+
+        return triggered
+
+    def resolve_prospective(self, node_id: str) -> None:
+        """Mark a prospective memory as resolved.
+
+        Args:
+            node_id: The node_id to resolve.
+        """
+        self._conn.execute(
+            """
+            MATCH (p:ProspectiveMemory)
+            WHERE p.node_id = $nid AND p.agent_id = $aid
+            SET p.status = $stat
+            """,
+            {"nid": node_id, "aid": self.agent_name, "stat": "resolved"},
+        )
+
+    # ==================================================================
+    # STATISTICS
+    # ==================================================================
+
+    def get_statistics(self) -> dict:
+        """Return counts per memory type.
+
+        Returns:
+            Dictionary with keys for each MemoryCategory and their counts,
+            plus a ``total`` key.
+        """
+        tables = {
+            MemoryCategory.SENSORY: "SensoryMemory",
+            MemoryCategory.WORKING: "WorkingMemory",
+            MemoryCategory.EPISODIC: "EpisodicMemory",
+            MemoryCategory.SEMANTIC: "SemanticMemory",
+            MemoryCategory.PROCEDURAL: "ProceduralMemory",
+            MemoryCategory.PROSPECTIVE: "ProspectiveMemory",
+        }
+
+        stats: dict = {}
+        total = 0
+        for category, table in tables.items():
+            result = self._conn.execute(
+                f"MATCH (n:{table}) WHERE n.agent_id = $aid RETURN count(n)",
+                {"aid": self.agent_name},
+            )
+            count = 0
+            if result.has_next():
+                count = int(result.get_next()[0])
+            stats[category.value] = count
+            total += count
+
+        stats["total"] = total
+        return stats
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the Kuzu connection."""
+        self._conn = None
+        self._db = None

--- a/src/amplihack_memory/memory_types.py
+++ b/src/amplihack_memory/memory_types.py
@@ -1,0 +1,177 @@
+"""Cognitive memory type definitions.
+
+Defines the six memory categories modeled after human cognition:
+  SENSORY    - Raw, short-lived observations (auto-expire)
+  WORKING    - Active task context with bounded capacity
+  EPISODIC   - Autobiographical events (consolidatable)
+  SEMANTIC   - Distilled facts and knowledge
+  PROCEDURAL - Reusable step-by-step procedures
+  PROSPECTIVE - Future-oriented trigger-action pairs
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+
+class MemoryCategory(Enum):
+    """Six cognitive memory types."""
+
+    SENSORY = "sensory"
+    WORKING = "working"
+    EPISODIC = "episodic"
+    SEMANTIC = "semantic"
+    PROCEDURAL = "procedural"
+    PROSPECTIVE = "prospective"
+
+
+@dataclass
+class SensoryItem:
+    """Short-lived raw observation.
+
+    Attributes:
+        node_id: Unique identifier in the graph.
+        modality: Observation channel (e.g. "text", "code", "error", "log").
+        raw_data: The raw observation content.
+        observation_order: Monotonically increasing insertion order.
+        expires_at: Unix timestamp after which this item may be pruned.
+        created_at: When the item was recorded.
+    """
+
+    node_id: str
+    modality: str
+    raw_data: str
+    observation_order: int
+    expires_at: float
+    created_at: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class WorkingMemorySlot:
+    """Active task-context slot (bounded capacity).
+
+    Attributes:
+        node_id: Unique identifier in the graph.
+        slot_type: Categorisation of the slot (e.g. "goal", "constraint", "context").
+        content: The payload stored in this slot.
+        relevance: Priority weight (higher = more relevant). Defaults to 1.0.
+        task_id: The task this slot is associated with.
+        created_at: When the slot was created.
+    """
+
+    node_id: str
+    slot_type: str
+    content: str
+    relevance: float
+    task_id: str
+    created_at: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class EpisodicMemory:
+    """Autobiographical event record.
+
+    Attributes:
+        node_id: Unique identifier in the graph.
+        content: The episode description.
+        source_label: Origin label (e.g. "user-session", "ci-run").
+        temporal_index: Monotonic ordering index across episodes.
+        compressed: Whether this episode has been consolidated.
+        created_at: When the episode was stored.
+        metadata: Optional structured data attached to the episode.
+    """
+
+    node_id: str
+    content: str
+    source_label: str
+    temporal_index: int
+    compressed: bool = False
+    created_at: datetime = field(default_factory=datetime.now)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SemanticFact:
+    """Distilled knowledge fact.
+
+    Attributes:
+        node_id: Unique identifier in the graph.
+        concept: The concept or topic this fact is about.
+        content: The factual content.
+        confidence: Confidence score (0.0 - 1.0).
+        source_id: Reference to the source that produced this fact.
+        tags: Categorisation tags.
+        metadata: Additional structured metadata.
+        created_at: When the fact was stored.
+    """
+
+    node_id: str
+    concept: str
+    content: str
+    confidence: float
+    source_id: str = ""
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class ProceduralMemory:
+    """Reusable step-by-step procedure.
+
+    Attributes:
+        node_id: Unique identifier in the graph.
+        name: Human-readable procedure name.
+        steps: Ordered list of step descriptions.
+        prerequisites: Conditions that must be met before execution.
+        usage_count: How many times this procedure has been recalled.
+        created_at: When the procedure was stored.
+    """
+
+    node_id: str
+    name: str
+    steps: list[str] = field(default_factory=list)
+    prerequisites: list[str] = field(default_factory=list)
+    usage_count: int = 0
+    created_at: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class ProspectiveMemory:
+    """Future-oriented trigger-action pair.
+
+    Attributes:
+        node_id: Unique identifier in the graph.
+        description: What this prospective memory is about.
+        trigger_condition: Text description of the trigger.
+        action_on_trigger: What to do when the trigger fires.
+        status: One of "pending", "triggered", "resolved".
+        priority: Priority level (higher = more important). Defaults to 1.
+        created_at: When this was stored.
+    """
+
+    node_id: str
+    description: str
+    trigger_condition: str
+    action_on_trigger: str
+    status: str = "pending"
+    priority: int = 1
+    created_at: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class ConsolidatedEpisode:
+    """Summary produced by consolidating multiple episodes.
+
+    Attributes:
+        node_id: Unique identifier in the graph.
+        summary: The consolidated summary text.
+        original_count: How many episodes were consolidated.
+        created_at: When consolidation was performed.
+    """
+
+    node_id: str
+    summary: str
+    original_count: int
+    created_at: datetime = field(default_factory=datetime.now)

--- a/tests/test_cognitive_memory.py
+++ b/tests/test_cognitive_memory.py
@@ -1,0 +1,551 @@
+"""Tests for the six-type cognitive memory system."""
+
+import time
+
+import pytest
+
+from amplihack_memory import CognitiveMemory
+from amplihack_memory.memory_types import (
+    ConsolidatedEpisode,
+    EpisodicMemory,
+    MemoryCategory,
+    ProceduralMemory,
+    ProspectiveMemory,
+    SemanticFact,
+    SensoryItem,
+    WorkingMemorySlot,
+)
+
+
+@pytest.fixture
+def cm(tmp_path):
+    """Create a CognitiveMemory instance with an isolated temp database."""
+    db = tmp_path / "test_cognitive_db"
+    mem = CognitiveMemory(agent_name="test-agent", db_path=db)
+    yield mem
+    mem.close()
+
+
+@pytest.fixture
+def cm_other(tmp_path):
+    """Second CognitiveMemory instance for agent-isolation tests."""
+    db = tmp_path / "test_cognitive_db"
+    mem = CognitiveMemory(agent_name="other-agent", db_path=db)
+    yield mem
+    mem.close()
+
+
+# ==================================================================
+# Initialisation
+# ==================================================================
+
+
+class TestInit:
+    def test_empty_agent_name_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="agent_name"):
+            CognitiveMemory(agent_name="", db_path=tmp_path / "db")
+
+    def test_whitespace_agent_name_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="agent_name"):
+            CognitiveMemory(agent_name="   ", db_path=tmp_path / "db")
+
+    def test_creates_db_directory(self, tmp_path):
+        db_path = tmp_path / "new_dir" / "db"
+        cm = CognitiveMemory(agent_name="a", db_path=db_path)
+        assert db_path.exists()
+        cm.close()
+
+
+# ==================================================================
+# SENSORY MEMORY
+# ==================================================================
+
+
+class TestSensoryMemory:
+    def test_record_and_retrieve(self, cm):
+        nid = cm.record_sensory("text", "Hello world")
+        assert nid.startswith("sen_")
+
+        items = cm.get_recent_sensory(limit=5)
+        assert len(items) == 1
+        assert items[0].node_id == nid
+        assert items[0].modality == "text"
+        assert items[0].raw_data == "Hello world"
+
+    def test_ordering(self, cm):
+        cm.record_sensory("a", "first")
+        cm.record_sensory("b", "second")
+        cm.record_sensory("c", "third")
+
+        items = cm.get_recent_sensory(limit=10)
+        assert len(items) == 3
+        # Most recent first
+        assert items[0].raw_data == "third"
+        assert items[2].raw_data == "first"
+
+    def test_expired_not_returned(self, cm):
+        cm.record_sensory("text", "ephemeral", ttl_seconds=0)
+        # TTL=0 means expires_at == created_at; already expired
+        time.sleep(0.1)
+        items = cm.get_recent_sensory()
+        assert len(items) == 0
+
+    def test_prune_expired(self, cm):
+        cm.record_sensory("text", "will expire", ttl_seconds=0)
+        cm.record_sensory("text", "will survive", ttl_seconds=600)
+        time.sleep(0.1)
+        pruned = cm.prune_expired_sensory()
+        assert pruned == 1
+        items = cm.get_recent_sensory()
+        assert len(items) == 1
+        assert items[0].raw_data == "will survive"
+
+    def test_attend_to_sensory_promotes_to_episode(self, cm):
+        sid = cm.record_sensory("error", "segfault detected", ttl_seconds=600)
+        ep_id = cm.attend_to_sensory(sid, "critical error")
+        assert ep_id is not None
+        assert ep_id.startswith("epi_")
+
+        episodes = cm.get_episodes()
+        assert len(episodes) == 1
+        assert "segfault detected" in episodes[0].content
+        assert "critical error" in episodes[0].content
+
+    def test_attend_to_missing_returns_none(self, cm):
+        result = cm.attend_to_sensory("nonexistent", "reason")
+        assert result is None
+
+
+# ==================================================================
+# WORKING MEMORY
+# ==================================================================
+
+
+class TestWorkingMemory:
+    def test_push_and_get(self, cm):
+        nid = cm.push_working("goal", "finish report", "task-1")
+        assert nid.startswith("wrk_")
+
+        slots = cm.get_working("task-1")
+        assert len(slots) == 1
+        assert slots[0].content == "finish report"
+        assert slots[0].task_id == "task-1"
+
+    def test_relevance_ordering(self, cm):
+        cm.push_working("a", "low", "t1", relevance=0.1)
+        cm.push_working("b", "high", "t1", relevance=0.9)
+        cm.push_working("c", "mid", "t1", relevance=0.5)
+
+        slots = cm.get_working("t1")
+        assert slots[0].content == "high"
+        assert slots[-1].content == "low"
+
+    def test_capacity_eviction(self, cm):
+        # Fill to capacity
+        for i in range(CognitiveMemory.WORKING_MEMORY_CAPACITY):
+            cm.push_working("item", f"slot-{i}", "t1", relevance=float(i))
+
+        slots = cm.get_working("t1")
+        assert len(slots) == CognitiveMemory.WORKING_MEMORY_CAPACITY
+
+        # Push one more -- the slot with relevance 0.0 should be evicted
+        cm.push_working("item", "new-slot", "t1", relevance=100.0)
+        slots = cm.get_working("t1")
+        assert len(slots) == CognitiveMemory.WORKING_MEMORY_CAPACITY
+        contents = {s.content for s in slots}
+        assert "new-slot" in contents
+        assert "slot-0" not in contents  # lowest relevance evicted
+
+    def test_clear_working(self, cm):
+        cm.push_working("a", "x", "t1")
+        cm.push_working("b", "y", "t1")
+        cm.push_working("c", "z", "t2")
+
+        cleared = cm.clear_working("t1")
+        assert cleared == 2
+        assert len(cm.get_working("t1")) == 0
+        assert len(cm.get_working("t2")) == 1
+
+    def test_task_isolation(self, cm):
+        cm.push_working("a", "for t1", "t1")
+        cm.push_working("b", "for t2", "t2")
+
+        assert len(cm.get_working("t1")) == 1
+        assert len(cm.get_working("t2")) == 1
+
+
+# ==================================================================
+# EPISODIC MEMORY
+# ==================================================================
+
+
+class TestEpisodicMemory:
+    def test_store_and_retrieve(self, cm):
+        eid = cm.store_episode("User asked about weather", "user-session")
+        assert eid.startswith("epi_")
+
+        episodes = cm.get_episodes()
+        assert len(episodes) == 1
+        assert episodes[0].content == "User asked about weather"
+        assert episodes[0].source_label == "user-session"
+        assert episodes[0].compressed is False
+
+    def test_temporal_ordering(self, cm):
+        cm.store_episode("first", "s")
+        cm.store_episode("second", "s")
+        cm.store_episode("third", "s")
+
+        episodes = cm.get_episodes()
+        assert episodes[0].content == "third"
+        assert episodes[2].content == "first"
+
+    def test_explicit_temporal_index(self, cm):
+        cm.store_episode("a", "s", temporal_index=100)
+        cm.store_episode("b", "s", temporal_index=50)
+
+        episodes = cm.get_episodes()
+        assert episodes[0].temporal_index == 100
+        assert episodes[1].temporal_index == 50
+
+    def test_metadata_roundtrip(self, cm):
+        cm.store_episode("meta test", "s", metadata={"key": "value", "n": 42})
+        ep = cm.get_episodes()[0]
+        assert ep.metadata == {"key": "value", "n": 42}
+
+    def test_consolidation(self, cm):
+        # Store exactly batch_size episodes
+        for i in range(5):
+            cm.store_episode(f"episode-{i}", "batch-test")
+
+        cons_id = cm.consolidate_episodes(batch_size=5)
+        assert cons_id is not None
+        assert cons_id.startswith("con_")
+
+        # Compressed episodes excluded by default
+        remaining = cm.get_episodes(include_compressed=False)
+        assert len(remaining) == 0
+
+        # Including compressed shows them
+        all_eps = cm.get_episodes(include_compressed=True)
+        assert len(all_eps) == 5
+        assert all(e.compressed for e in all_eps)
+
+    def test_consolidation_with_custom_summarizer(self, cm):
+        for i in range(3):
+            cm.store_episode(f"ep-{i}", "s")
+
+        def my_summarizer(texts):
+            return f"Summary of {len(texts)} items"
+
+        cons_id = cm.consolidate_episodes(batch_size=3, summarizer=my_summarizer)
+        assert cons_id is not None
+
+    def test_consolidation_returns_none_when_insufficient(self, cm):
+        cm.store_episode("only one", "s")
+        assert cm.consolidate_episodes(batch_size=5) is None
+
+
+# ==================================================================
+# SEMANTIC MEMORY
+# ==================================================================
+
+
+class TestSemanticMemory:
+    def test_store_and_retrieve(self, cm):
+        fid = cm.store_fact("Python", "Python is a programming language", confidence=0.95)
+        assert fid.startswith("sem_")
+
+        facts = cm.get_all_facts()
+        assert len(facts) == 1
+        assert facts[0].concept == "Python"
+        assert facts[0].confidence == 0.95
+
+    def test_search_by_keyword(self, cm):
+        cm.store_fact("Python", "Python is interpreted", confidence=0.9)
+        cm.store_fact("Rust", "Rust is compiled", confidence=0.8)
+        cm.store_fact("Go", "Go has goroutines", confidence=0.7)
+
+        results = cm.search_facts("Python")
+        assert len(results) >= 1
+        assert results[0].concept == "Python"
+
+    def test_search_min_confidence(self, cm):
+        cm.store_fact("A", "low conf fact", confidence=0.2)
+        cm.store_fact("B", "high conf fact", confidence=0.9)
+
+        results = cm.search_facts("fact", min_confidence=0.5)
+        assert len(results) == 1
+        assert results[0].concept == "B"
+
+    def test_tags_roundtrip(self, cm):
+        cm.store_fact("X", "tagged fact", tags=["tag1", "tag2"])
+        fact = cm.get_all_facts()[0]
+        assert fact.tags == ["tag1", "tag2"]
+
+    def test_metadata_roundtrip(self, cm):
+        cm.store_fact("X", "meta fact", temporal_metadata={"year": 2025})
+        fact = cm.get_all_facts()[0]
+        assert fact.metadata == {"year": 2025}
+
+
+# ==================================================================
+# PROCEDURAL MEMORY
+# ==================================================================
+
+
+class TestProceduralMemory:
+    def test_store_and_recall(self, cm):
+        pid = cm.store_procedure(
+            name="deploy to prod",
+            steps=["run tests", "build image", "push to registry", "deploy"],
+            prerequisites=["all tests pass"],
+        )
+        assert pid.startswith("proc_")
+
+        procs = cm.recall_procedure("deploy")
+        assert len(procs) == 1
+        assert procs[0].name == "deploy to prod"
+        assert len(procs[0].steps) == 4
+        assert procs[0].prerequisites == ["all tests pass"]
+
+    def test_usage_count_increments(self, cm):
+        cm.store_procedure("test proc", ["step1"])
+
+        # First recall
+        procs = cm.recall_procedure("test proc")
+        assert len(procs) == 1
+        # After recall, usage_count in DB is incremented
+        # The returned object still has the pre-increment value (0)
+
+        # Second recall should show incremented count
+        procs2 = cm.recall_procedure("test proc")
+        assert procs2[0].usage_count == 1  # was 0, incremented by first recall
+
+    def test_empty_query_returns_most_used(self, cm):
+        cm.store_procedure("often used", ["a"])
+        cm.store_procedure("rarely used", ["b"])
+
+        # Recall "often used" to bump its count
+        cm.recall_procedure("often used")
+
+        procs = cm.recall_procedure("")
+        assert procs[0].name == "often used"
+
+
+# ==================================================================
+# PROSPECTIVE MEMORY
+# ==================================================================
+
+
+class TestProspectiveMemory:
+    def test_store_and_check_trigger(self, cm):
+        nid = cm.store_prospective(
+            description="Remind about meeting",
+            trigger_condition="meeting calendar",
+            action_on_trigger="Send reminder email",
+            priority=5,
+        )
+        assert nid.startswith("pro_")
+
+        triggered = cm.check_triggers("Check the calendar for today's meeting")
+        assert len(triggered) == 1
+        assert triggered[0].status == "triggered"
+        assert triggered[0].description == "Remind about meeting"
+
+    def test_no_trigger_on_unrelated_content(self, cm):
+        cm.store_prospective(
+            description="Deploy when ready",
+            trigger_condition="deployment approval",
+            action_on_trigger="Run deploy script",
+        )
+
+        triggered = cm.check_triggers("The weather is nice today")
+        assert len(triggered) == 0
+
+    def test_resolve_prospective(self, cm):
+        nid = cm.store_prospective(
+            description="Test resolve",
+            trigger_condition="trigger word",
+            action_on_trigger="do something",
+        )
+
+        # Trigger it
+        cm.check_triggers("the trigger word appeared")
+
+        # Resolve it
+        cm.resolve_prospective(nid)
+
+        # Should not trigger again
+        triggered = cm.check_triggers("trigger word again")
+        assert len(triggered) == 0
+
+    def test_priority_ordering(self, cm):
+        cm.store_prospective("low", "alpha", "act-low", priority=1)
+        cm.store_prospective("high", "alpha", "act-high", priority=10)
+
+        triggered = cm.check_triggers("alpha word")
+        assert len(triggered) == 2
+        assert triggered[0].priority > triggered[1].priority
+
+
+# ==================================================================
+# STATISTICS
+# ==================================================================
+
+
+class TestStatistics:
+    def test_empty_stats(self, cm):
+        stats = cm.get_statistics()
+        assert stats["total"] == 0
+        assert stats["sensory"] == 0
+        assert stats["working"] == 0
+        assert stats["episodic"] == 0
+        assert stats["semantic"] == 0
+        assert stats["procedural"] == 0
+        assert stats["prospective"] == 0
+
+    def test_counts_after_inserts(self, cm):
+        cm.record_sensory("text", "hello")
+        cm.push_working("goal", "x", "t1")
+        cm.store_episode("episode", "s")
+        cm.store_fact("concept", "content")
+        cm.store_procedure("proc", ["step"])
+        cm.store_prospective("desc", "trig", "act")
+
+        stats = cm.get_statistics()
+        assert stats["total"] == 6
+        assert stats["sensory"] == 1
+        assert stats["working"] == 1
+        assert stats["episodic"] == 1
+        assert stats["semantic"] == 1
+        assert stats["procedural"] == 1
+        assert stats["prospective"] == 1
+
+
+# ==================================================================
+# AGENT ISOLATION
+# ==================================================================
+
+
+class TestAgentIsolation:
+    def test_different_agents_see_own_data(self, tmp_path):
+        db = tmp_path / "shared_db"
+        agent_a = CognitiveMemory(agent_name="agent-a", db_path=db)
+        agent_b = CognitiveMemory(agent_name="agent-b", db_path=db)
+
+        agent_a.store_fact("A-concept", "A-content")
+        agent_b.store_fact("B-concept", "B-content")
+
+        a_facts = agent_a.get_all_facts()
+        b_facts = agent_b.get_all_facts()
+
+        assert len(a_facts) == 1
+        assert a_facts[0].concept == "A-concept"
+        assert len(b_facts) == 1
+        assert b_facts[0].concept == "B-concept"
+
+        agent_a.close()
+        agent_b.close()
+
+    def test_sensory_isolation(self, tmp_path):
+        db = tmp_path / "shared_db"
+        a = CognitiveMemory(agent_name="a", db_path=db)
+        b = CognitiveMemory(agent_name="b", db_path=db)
+
+        a.record_sensory("text", "a-data")
+        b.record_sensory("text", "b-data")
+
+        assert len(a.get_recent_sensory()) == 1
+        assert a.get_recent_sensory()[0].raw_data == "a-data"
+        assert len(b.get_recent_sensory()) == 1
+        assert b.get_recent_sensory()[0].raw_data == "b-data"
+
+        a.close()
+        b.close()
+
+    def test_working_memory_isolation(self, tmp_path):
+        db = tmp_path / "shared_db"
+        a = CognitiveMemory(agent_name="a", db_path=db)
+        b = CognitiveMemory(agent_name="b", db_path=db)
+
+        a.push_working("goal", "a-goal", "t1")
+        b.push_working("goal", "b-goal", "t1")
+
+        assert len(a.get_working("t1")) == 1
+        assert len(b.get_working("t1")) == 1
+
+        a.close()
+        b.close()
+
+    def test_episode_isolation(self, tmp_path):
+        db = tmp_path / "shared_db"
+        a = CognitiveMemory(agent_name="a", db_path=db)
+        b = CognitiveMemory(agent_name="b", db_path=db)
+
+        a.store_episode("a-ep", "s")
+        b.store_episode("b-ep", "s")
+
+        assert len(a.get_episodes()) == 1
+        assert len(b.get_episodes()) == 1
+
+        a.close()
+        b.close()
+
+    def test_stats_isolation(self, tmp_path):
+        db = tmp_path / "shared_db"
+        a = CognitiveMemory(agent_name="a", db_path=db)
+        b = CognitiveMemory(agent_name="b", db_path=db)
+
+        a.store_fact("x", "y")
+        a.store_fact("x2", "y2")
+        b.store_fact("z", "w")
+
+        assert a.get_statistics()["semantic"] == 2
+        assert b.get_statistics()["semantic"] == 1
+
+        a.close()
+        b.close()
+
+
+# ==================================================================
+# BACKWARD COMPATIBILITY
+# ==================================================================
+
+
+class TestBackwardCompatibility:
+    """Verify that existing ExperienceStore and MemoryConnector still work."""
+
+    def test_experience_store_still_works(self, tmp_path):
+        from amplihack_memory import Experience, ExperienceStore, ExperienceType
+
+        store = ExperienceStore(
+            agent_name="compat-test",
+            storage_path=tmp_path / "compat_store",
+            backend="kuzu",
+        )
+        exp = Experience(
+            experience_type=ExperienceType.SUCCESS,
+            context="test context",
+            outcome="test outcome",
+            confidence=0.8,
+        )
+        exp_id = store.add(exp)
+        assert exp_id is not None
+
+    def test_memory_connector_still_works(self, tmp_path):
+        from amplihack_memory import Experience, ExperienceType, MemoryConnector
+
+        conn = MemoryConnector(
+            agent_name="compat-test",
+            storage_path=tmp_path / "compat_conn",
+            backend="kuzu",
+        )
+        exp = Experience(
+            experience_type=ExperienceType.INSIGHT,
+            context="insight context",
+            outcome="insight outcome",
+            confidence=0.7,
+        )
+        exp_id = conn.store_experience(exp)
+        assert exp_id is not None
+        conn.close()


### PR DESCRIPTION
## Summary

- Adds a complete cognitive memory system with 6 memory types modeled after human cognition: **Sensory** (auto-expiring raw observations), **Working** (bounded-capacity task context with LRU eviction), **Episodic** (autobiographical events with consolidation/compression), **Semantic** (distilled facts with keyword search), **Procedural** (step-by-step procedures with usage tracking), and **Prospective** (trigger-action pairs with keyword-overlap matching).
- New `CognitiveMemory` class backed by Kuzu with 7 node tables + 5 edge tables (SIMILAR_TO, DERIVES_FROM, PROCEDURE_DERIVES_FROM, CONSOLIDATES, ATTENDED_TO), full agent isolation via `agent_id` column in every table.
- 42 new tests covering all memory types, agent isolation, statistics, and backward compatibility with existing `ExperienceStore`/`MemoryConnector`.

## New files

| File | Purpose |
|------|---------|
| `src/amplihack_memory/memory_types.py` | `MemoryCategory` enum + 7 dataclasses (`SensoryItem`, `WorkingMemorySlot`, `EpisodicMemory`, `SemanticFact`, `ProceduralMemory`, `ProspectiveMemory`, `ConsolidatedEpisode`) |
| `src/amplihack_memory/cognitive_memory.py` | `CognitiveMemory` class with methods for all 6 types + schema init + statistics |
| `tests/test_cognitive_memory.py` | 42 tests across 9 test classes |

## Modified files

| File | Change |
|------|--------|
| `src/amplihack_memory/__init__.py` | Export new classes, bump version to 0.2.0 |

## Test plan

- [x] All 42 new tests pass (`pytest tests/test_cognitive_memory.py`)
- [x] All existing tests pass (222 of 229 pass; 7 pre-existing failures unrelated to this change)
- [x] Backward compatibility verified: `ExperienceStore` and `MemoryConnector` tests included and passing
- [x] Agent isolation verified: multiple agents sharing same DB path see only their own data

Generated with [Claude Code](https://claude.com/claude-code)