### PR TITLE
docs: add missing doc comments to all public items across crate

### DIFF
--- a/rust/amplihack-memory/src/backends/base.rs
+++ b/rust/amplihack-memory/src/backends/base.rs
@@ -42,9 +42,11 @@ pub trait MemoryBackend {
     ) -> crate::Result<()>;
 }
 
-/// Trait alias for experience storage operations used by SecureMemoryBackend.
+/// Trait alias for experience storage operations used by [`crate::security::SecureMemoryBackend`].
 pub trait ExperienceBackend {
+    /// Store an experience and return its assigned id.
     fn add(&mut self, experience: &Experience) -> crate::Result<String>;
+    /// Search experiences by text query with optional type and confidence filters.
     fn search(
         &self,
         query: &str,
@@ -52,16 +54,22 @@ pub trait ExperienceBackend {
         min_confidence: f64,
         limit: usize,
     ) -> crate::Result<Vec<Experience>>;
+    /// Return aggregate storage statistics.
     fn get_statistics(&self) -> crate::Result<StorageStatistics>;
 }
 
-/// Storage statistics.
+/// Aggregate statistics about the storage backend's contents.
 #[derive(Debug, Clone)]
 pub struct StorageStatistics {
+    /// Total number of stored experiences across all types.
     pub total_experiences: usize,
+    /// Breakdown of experience counts by type.
     pub by_type: std::collections::HashMap<ExperienceType, usize>,
+    /// Approximate on-disk size in kilobytes.
     pub storage_size_kb: f64,
+    /// Number of experiences that have been compressed.
     pub compressed_experiences: usize,
+    /// Ratio of compressed to total experiences (1.0 = none compressed).
     pub compression_ratio: f64,
 }
 

--- a/rust/amplihack-memory/src/backends/mod.rs
+++ b/rust/amplihack-memory/src/backends/mod.rs
@@ -1,15 +1,23 @@
 //! Backend abstraction layer for memory storage.
 
+/// Abstract base traits for memory storage backends.
 pub mod base;
+/// Kùzu graph-database backend (requires the `kuzu` feature).
 #[cfg(feature = "kuzu")]
 pub mod kuzu_backend;
+/// Ladybug graph backend (requires the `ladybug` feature).
 #[cfg(feature = "ladybug")]
 pub mod ladybug_backend;
+/// SQLite-based persistent storage backend with FTS5 full-text search.
 pub mod sqlite_backend;
 
+/// Core storage traits re-exported for convenience.
 pub use base::{ExperienceBackend, MemoryBackend};
+/// Kùzu backend implementation.
 #[cfg(feature = "kuzu")]
 pub use kuzu_backend::KuzuBackend;
+/// Ladybug backend implementation.
 #[cfg(feature = "ladybug")]
 pub use ladybug_backend::LadybugBackend;
+/// SQLite backend implementation.
 pub use sqlite_backend::SqliteBackend;

--- a/rust/amplihack-memory/src/cognitive_memory/types.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/types.rs
@@ -46,16 +46,27 @@ pub(crate) fn agent_filter(agent_id: &str) -> HashMap<String, String> {
 // Node-type labels (matching the Python schema table names)
 // ---------------------------------------------------------------------------
 
+/// Node-type label for sensory memory nodes.
 pub(crate) const NT_SENSORY: &str = "SensoryMemory";
+/// Node-type label for working memory nodes.
 pub(crate) const NT_WORKING: &str = "WorkingMemory";
+/// Node-type label for episodic memory nodes.
 pub(crate) const NT_EPISODIC: &str = "EpisodicMemory";
+/// Node-type label for semantic memory nodes.
 pub(crate) const NT_SEMANTIC: &str = "SemanticMemory";
+/// Node-type label for procedural memory nodes.
 pub(crate) const NT_PROCEDURAL: &str = "ProceduralMemory";
+/// Node-type label for prospective memory nodes.
 pub(crate) const NT_PROSPECTIVE: &str = "ProspectiveMemory";
+/// Node-type label for consolidated episode nodes.
 pub(crate) const NT_CONSOLIDATED: &str = "ConsolidatedEpisode";
 
 // Edge-type labels
+/// Edge-type label for sensory-to-working attention transitions.
 pub(crate) const ET_ATTENDED_TO: &str = "ATTENDED_TO";
+/// Edge-type label for episode consolidation relationships.
 pub(crate) const ET_CONSOLIDATES: &str = "CONSOLIDATES";
+/// Edge-type label for similarity links between nodes.
 pub(crate) const ET_SIMILAR_TO: &str = "SIMILAR_TO";
+/// Edge-type label indicating one node derives from another.
 pub(crate) const ET_DERIVES_FROM: &str = "DERIVES_FROM";

--- a/rust/amplihack-memory/src/graph/mod.rs
+++ b/rust/amplihack-memory/src/graph/mod.rs
@@ -1,18 +1,31 @@
 //! Common graph abstraction layer for agent graphs and hive mind.
 
+/// Federated multi-graph query aggregation.
 pub mod federated_store;
+/// Hive-mind shared graph store.
 pub mod hive_store;
+/// In-memory graph store for testing and lightweight use.
 pub mod in_memory_store;
+/// Kùzu-backed persistent graph store (requires the `kuzu` feature).
 #[cfg(feature = "kuzu")]
 pub mod kuzu_store;
+/// Common graph store trait defining the storage protocol.
 pub mod protocol;
+/// Multi-hop graph traversal algorithms.
 pub mod traversal;
+/// Core graph data types (nodes, edges, directions, traversal results).
 pub mod types;
 
+/// Annotated query result and federated graph store.
 pub use federated_store::{AnnotatedResult, FederatedGraphStore, FederatedQueryResult};
+/// Hive-mind shared graph store implementation.
 pub use hive_store::HiveGraphStore;
+/// In-memory graph store implementation.
 pub use in_memory_store::InMemoryGraphStore;
+/// Kùzu-backed graph store implementation.
 #[cfg(feature = "kuzu")]
 pub use kuzu_store::KuzuGraphStore;
+/// The common `GraphStore` trait all backends implement.
 pub use protocol::GraphStore;
+/// Core graph primitives re-exported for convenience.
 pub use types::{Direction, GraphEdge, GraphNode, TraversalItem, TraversalResult};

--- a/rust/amplihack-memory/src/graph/types.rs
+++ b/rust/amplihack-memory/src/graph/types.rs
@@ -7,12 +7,16 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Direction {
+    /// Follow edges leaving the node.
     Outgoing,
+    /// Follow edges arriving at the node.
     Incoming,
+    /// Follow edges in either direction.
     Both,
 }
 
 impl Direction {
+    /// Return the lowercase string representation of the direction.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Outgoing => "outgoing",
@@ -25,15 +29,20 @@ impl Direction {
 /// An immutable node in the graph.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GraphNode {
+    /// Unique identifier for this node.
     pub node_id: String,
+    /// Semantic type label (e.g. `"Fact"`, `"Episode"`).
     pub node_type: String,
+    /// Arbitrary key-value properties attached to the node.
     #[serde(default)]
     pub properties: HashMap<String, String>,
+    /// Origin graph identifier for federated queries.
     #[serde(default)]
     pub graph_origin: String,
 }
 
 impl GraphNode {
+    /// Create a new node with the given id and type, empty properties and origin.
     pub fn new(node_id: String, node_type: String) -> Self {
         Self {
             node_id,
@@ -47,21 +56,28 @@ impl GraphNode {
 /// An immutable edge in the graph.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GraphEdge {
+    /// Unique identifier for this edge (may be empty for auto-generated edges).
     #[serde(default)]
     pub edge_id: String,
+    /// Node id of the edge source.
     #[serde(default)]
     pub source_id: String,
+    /// Node id of the edge target.
     #[serde(default)]
     pub target_id: String,
+    /// Relationship type label (e.g. `"SIMILAR_TO"`, `"SUPERSEDES"`).
     #[serde(default)]
     pub edge_type: String,
+    /// Arbitrary key-value properties attached to the edge.
     #[serde(default)]
     pub properties: HashMap<String, String>,
+    /// Origin graph identifier for federated queries.
     #[serde(default)]
     pub graph_origin: String,
 }
 
 impl GraphEdge {
+    /// Create a new edge between two nodes with the given relationship type.
     pub fn new(source_id: String, target_id: String, edge_type: String) -> Self {
         Self {
             edge_id: String::new(),
@@ -77,9 +93,13 @@ impl GraphEdge {
 /// Container for multi-hop graph traversal results.
 #[derive(Debug, Clone, Default)]
 pub struct TraversalResult {
+    /// Ordered paths discovered during traversal, each a sequence of nodes and edges.
     pub paths: Vec<Vec<TraversalItem>>,
+    /// All distinct nodes visited during traversal.
     pub nodes: Vec<GraphNode>,
+    /// All distinct edges traversed.
     pub edges: Vec<GraphEdge>,
+    /// Whether the traversal crossed federated graph boundaries.
     pub crossed_boundaries: bool,
 }
 

--- a/rust/amplihack-memory/src/hierarchical_memory/experience_ops.rs
+++ b/rust/amplihack-memory/src/hierarchical_memory/experience_ops.rs
@@ -20,7 +20,7 @@ impl HierarchicalMemory {
     /// Store a knowledge node in the graph.
     ///
     /// Auto-classifies if `category` is `None`. Computes similarity against
-    /// existing nodes and creates `SIMILAR_TO` edges for scores > `DEFAULT_SIMILARITY_THRESHOLD`.
+    /// existing nodes and creates `SIMILAR_TO` edges for scores above the default similarity threshold.
     /// Detects contradictions and creates `SUPERSEDES` edges when found.
     ///
     /// Returns the `node_id` of the stored knowledge node.

--- a/rust/amplihack-memory/src/lib.rs
+++ b/rust/amplihack-memory/src/lib.rs
@@ -51,69 +51,105 @@ compile_error!(
      Use one graph backend at a time."
 );
 
+/// Storage backend abstraction layer (SQLite, Kùzu, Ladybug).
 pub mod backends;
+/// Six-category cognitive memory system modeled after human cognition.
 pub mod cognitive_memory;
+/// High-level memory connector that selects and initializes a backend.
 pub mod connector;
+/// Contradiction detection between memory facts.
 pub mod contradiction;
+/// Named-entity extraction from free-text content.
 pub mod entity_extraction;
+/// Error types and the crate-wide `Result` alias.
 pub mod errors;
+/// Core experience data model and serialization.
 pub mod experience;
+/// Graph abstraction layer with in-memory, Hive, and federated stores.
 pub mod graph;
+/// Hierarchical knowledge graph with classification and similarity linking.
 pub mod hierarchical_memory;
+/// Cognitive memory type definitions (sensory, working, episodic, etc.).
 pub mod memory_types;
+/// Pattern recognition engine for extracting recurring patterns from experiences.
 pub mod pattern_recognition;
+/// Python bindings via PyO3.
 #[cfg(feature = "python")]
 pub mod python;
+/// Security layer with capability-based access control and credential scrubbing.
 pub mod security;
+/// TF-IDF-based semantic search and relevance scoring.
 pub mod semantic_search;
+/// Deterministic text similarity functions (Jaccard, word-level, tag-level).
 pub mod similarity;
+/// Managed experience store with auto-compression and retention policies.
 pub mod store;
+/// Internal utility functions shared across modules.
 pub(crate) mod utils;
 
 // Re-exports for convenience
+
+/// Crate-wide error type and result alias.
 pub use errors::{MemoryError, Result};
 
+/// Core experience data types.
 pub use experience::{Experience, ExperienceType};
 
+/// Cognitive memory structs for each of the six memory categories.
 pub use memory_types::{
     ConsolidatedEpisode, EpisodicMemory, MemoryCategory, ProceduralMemory, ProspectiveMemory,
     SemanticFact, SensoryItem, WorkingMemorySlot,
 };
 
+/// Deterministic text-similarity scoring functions.
 pub use similarity::{
     compute_similarity, compute_tag_similarity, compute_word_similarity, rerank_facts_by_query,
 };
 
+/// Contradiction detection result types.
 pub use contradiction::{detect_contradiction, ContradictionResult};
+/// Entity-name extraction from free-text.
 pub use entity_extraction::extract_entity_name;
 
+/// Kùzu-backed graph store (requires the `kuzu` feature).
 #[cfg(feature = "kuzu")]
 pub use graph::KuzuGraphStore;
+/// Graph abstraction types, stores, and traversal primitives.
 pub use graph::{
     AnnotatedResult, Direction, FederatedGraphStore, FederatedQueryResult, GraphEdge, GraphNode,
     GraphStore, HiveGraphStore, InMemoryGraphStore, TraversalItem, TraversalResult,
 };
 
+/// Security primitives: capabilities, credential scrubbing, query validation.
 pub use security::{
     AgentCapabilities, CredentialScrubber, QueryValidator, ScopeLevel, SecureMemoryBackend,
 };
 
+/// Semantic search engine and TF-IDF similarity scorer.
 pub use semantic_search::{
     calculate_relevance, retrieve_relevant_experiences, SemanticSearchEngine, TfIdfSimilarity,
 };
 
+/// Pattern recognition utilities for discovering recurring experience patterns.
 pub use pattern_recognition::{
     calculate_pattern_confidence, extract_pattern_key, recognize_patterns, PatternDetector,
 };
 
+/// Kùzu storage backend (requires the `kuzu` feature).
 #[cfg(feature = "kuzu")]
 pub use backends::KuzuBackend;
+/// Ladybug graph storage backend (requires the `ladybug` feature).
 #[cfg(feature = "ladybug")]
 pub use backends::LadybugBackend;
+/// Core backend traits and SQLite implementation.
 pub use backends::{ExperienceBackend, MemoryBackend, SqliteBackend};
+/// Unified cognitive memory interface over the graph layer.
 pub use cognitive_memory::CognitiveMemory;
+/// Backend selector and memory connector entry point.
 pub use connector::{BackendType, MemoryConnector};
+/// Hierarchical knowledge graph with classification, subgraph queries, and edge types.
 pub use hierarchical_memory::{
     HierarchicalMemory, KnowledgeEdge, KnowledgeNode, KnowledgeSubgraph, MemoryClassifier,
 };
+/// Managed experience store with auto-compression and retention policies.
 pub use store::ExperienceStore;

--- a/rust/amplihack-memory/src/python/converters.rs
+++ b/rust/amplihack-memory/src/python/converters.rs
@@ -11,6 +11,7 @@ use crate::memory_types::{
 
 use super::helpers::hashmap_to_pydict;
 
+/// Convert a [`SensoryItem`] to a Python dictionary.
 pub(crate) fn sensory_to_dict(py: Python<'_>, s: &SensoryItem) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("node_id", &s.node_id)?;
@@ -22,6 +23,7 @@ pub(crate) fn sensory_to_dict(py: Python<'_>, s: &SensoryItem) -> PyResult<PyObj
     Ok(d.to_object(py))
 }
 
+/// Convert a [`WorkingMemorySlot`] to a Python dictionary.
 pub(crate) fn working_to_dict(py: Python<'_>, w: &WorkingMemorySlot) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("node_id", &w.node_id)?;
@@ -33,6 +35,7 @@ pub(crate) fn working_to_dict(py: Python<'_>, w: &WorkingMemorySlot) -> PyResult
     Ok(d.to_object(py))
 }
 
+/// Convert an [`EpisodicMemory`] to a Python dictionary.
 pub(crate) fn episode_to_dict(py: Python<'_>, e: &EpisodicMemory) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("node_id", &e.node_id)?;
@@ -45,6 +48,7 @@ pub(crate) fn episode_to_dict(py: Python<'_>, e: &EpisodicMemory) -> PyResult<Py
     Ok(d.to_object(py))
 }
 
+/// Convert a [`SemanticFact`] to a Python dictionary.
 pub(crate) fn fact_to_dict(py: Python<'_>, f: &SemanticFact) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("node_id", &f.node_id)?;
@@ -58,6 +62,7 @@ pub(crate) fn fact_to_dict(py: Python<'_>, f: &SemanticFact) -> PyResult<PyObjec
     Ok(d.to_object(py))
 }
 
+/// Convert a [`ProceduralMemory`] to a Python dictionary.
 pub(crate) fn procedure_to_dict(py: Python<'_>, p: &ProceduralMemory) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("node_id", &p.node_id)?;
@@ -69,6 +74,7 @@ pub(crate) fn procedure_to_dict(py: Python<'_>, p: &ProceduralMemory) -> PyResul
     Ok(d.to_object(py))
 }
 
+/// Convert a [`ProspectiveMemory`] to a Python dictionary.
 pub(crate) fn prospective_to_dict(py: Python<'_>, p: &ProspectiveMemory) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("node_id", &p.node_id)?;
@@ -81,6 +87,7 @@ pub(crate) fn prospective_to_dict(py: Python<'_>, p: &ProspectiveMemory) -> PyRe
     Ok(d.to_object(py))
 }
 
+/// Convert a [`KnowledgeNode`] to a Python dictionary.
 pub(crate) fn knowledge_node_to_dict(py: Python<'_>, n: &KnowledgeNode) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("node_id", &n.node_id)?;
@@ -95,6 +102,7 @@ pub(crate) fn knowledge_node_to_dict(py: Python<'_>, n: &KnowledgeNode) -> PyRes
     Ok(d.to_object(py))
 }
 
+/// Convert a [`KnowledgeEdge`] to a Python dictionary.
 pub(crate) fn knowledge_edge_to_dict(py: Python<'_>, e: &KnowledgeEdge) -> PyResult<PyObject> {
     let d = PyDict::new_bound(py);
     d.set_item("source_id", &e.source_id)?;

--- a/rust/amplihack-memory/src/python/helpers.rs
+++ b/rust/amplihack-memory/src/python/helpers.rs
@@ -10,14 +10,17 @@ use crate::backends::base::StorageStatistics;
 use crate::experience::ExperienceType;
 use crate::memory_types::MemoryCategory;
 
+/// Convert a [`crate::MemoryError`] into a Python `RuntimeError`.
 pub(crate) fn mem_err(e: crate::MemoryError) -> PyErr {
     PyRuntimeError::new_err(e.to_string())
 }
 
+/// Parse a string into an [`ExperienceType`], raising `ValueError` on failure.
 pub(crate) fn parse_experience_type(s: &str) -> PyResult<ExperienceType> {
     s.parse::<ExperienceType>().map_err(PyValueError::new_err)
 }
 
+/// Convert a `serde_json::Value` to a Python object recursively.
 pub(crate) fn json_to_py(py: Python<'_>, val: &serde_json::Value) -> PyResult<PyObject> {
     match val {
         serde_json::Value::Null => Ok(py.None()),
@@ -47,6 +50,7 @@ pub(crate) fn json_to_py(py: Python<'_>, val: &serde_json::Value) -> PyResult<Py
     }
 }
 
+/// Convert a Python object to a `serde_json::Value` recursively.
 pub(crate) fn py_to_json(obj: &Bound<'_, pyo3::PyAny>) -> PyResult<serde_json::Value> {
     if obj.is_none() {
         Ok(serde_json::Value::Null)
@@ -74,6 +78,7 @@ pub(crate) fn py_to_json(obj: &Bound<'_, pyo3::PyAny>) -> PyResult<serde_json::V
     }
 }
 
+/// Convert an optional Python dict to a Rust `HashMap<String, serde_json::Value>`.
 pub(crate) fn pydict_to_hashmap(
     dict: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<HashMap<String, serde_json::Value>> {
@@ -90,6 +95,7 @@ pub(crate) fn pydict_to_hashmap(
     }
 }
 
+/// Convert a Rust `HashMap<String, serde_json::Value>` to a Python dict.
 pub(crate) fn hashmap_to_pydict(
     py: Python<'_>,
     map: &HashMap<String, serde_json::Value>,
@@ -101,6 +107,7 @@ pub(crate) fn hashmap_to_pydict(
     Ok(d.to_object(py))
 }
 
+/// Convert a [`StorageStatistics`] struct to a Python dictionary.
 pub(crate) fn storage_stats_to_dict(
     py: Python<'_>,
     stats: &StorageStatistics,
@@ -118,6 +125,7 @@ pub(crate) fn storage_stats_to_dict(
     Ok(d.to_object(py))
 }
 
+/// Parse a string into a [`MemoryCategory`], raising `ValueError` on failure.
 pub(crate) fn parse_category(s: &str) -> PyResult<MemoryCategory> {
     s.parse::<MemoryCategory>().map_err(PyValueError::new_err)
 }

--- a/rust/amplihack-memory/src/security/scope_enforcer.rs
+++ b/rust/amplihack-memory/src/security/scope_enforcer.rs
@@ -24,7 +24,7 @@ impl ScopeLevel {
 /// Security capabilities governing what a memory-enabled agent can do.
 ///
 /// Capabilities are checked before every store/retrieve/query operation
-/// by `SecureMemoryBackend`.
+/// by [`crate::security::SecureMemoryBackend`].
 pub struct AgentCapabilities {
     /// The maximum scope this agent is allowed to access.
     pub scope: ScopeLevel,


### PR DESCRIPTION
## Summary

Add `///` doc comments to all undocumented public items across 10 files (116 lines added).

### Changes by file

| File | Items documented |
|------|-----------------|
| `src/lib.rs` | 35 doc comments on `pub mod` and `pub use` declarations |
| `src/graph/types.rs` | Field docs on GraphNode, GraphEdge, TraversalResult; Direction variants; constructors |
| `src/graph/mod.rs` | 13 doc comments on module and re-export declarations |
| `src/backends/mod.rs` | 8 doc comments on feature-gated module exports |
| `src/backends/base.rs` | Field docs on StorageStatistics; method docs on ExperienceBackend |
| `src/cognitive_memory/types.rs` | 11 doc comments on node/edge type constants |
| `src/python/converters.rs` | 8 doc comments on converter functions |
| `src/python/helpers.rs` | 8 doc comments on helper functions |

### Bug fixes

- Fixed broken intra-doc link to `SecureMemoryBackend` in `scope_enforcer.rs` (→ fully-qualified path)
- Fixed private item reference to `DEFAULT_SIMILARITY_THRESHOLD` in `experience_ops.rs` (→ prose)

### Verification

- `cargo doc --no-deps` → **ZERO warnings** ✅
- `cargo test` → **375 tests pass** ✅
- `cargo clippy -- -D warnings` → **clean** ✅