### PR TITLE
fix: QA audit CI, performance, and quality improvements

### DIFF
--- a/rust/amplihack-memory/src/backends/kuzu_backend/storage.rs
+++ b/rust/amplihack-memory/src/backends/kuzu_backend/storage.rs
@@ -1,13 +1,13 @@
 //! MemoryBackend trait implementation for the Kuzu backend.
 
-use super::{walkdir_size, KuzuBackend};
-use crate::backends::base::{MemoryBackend, StorageStatistics};
+use super::KuzuBackend;
+use crate::backends::base::{walkdir_size, MemoryBackend, StorageStatistics};
 use crate::errors::MemoryError;
 use crate::experience::{Experience, ExperienceType};
 use crate::security::QueryValidator;
 use pyo3::prelude::*;
 use std::collections::HashMap;
-use tracing::{error, warn};
+use tracing::warn;
 
 /// Set a key-value pair on a Python dict, mapping errors to `MemoryError`.
 fn set_param<V: IntoPyObject<'_>>(
@@ -68,30 +68,24 @@ fn collect_ids(result_ref: &Bound<'_, PyAny>) -> crate::Result<Vec<String>> {
 impl MemoryBackend for KuzuBackend {
     fn initialize_schema(&mut self) -> crate::Result<()> {
         Python::with_gil(|py| {
-            if let Err(e) = self.execute_no_params(
+            self.execute_no_params(
                 py,
                 "CREATE NODE TABLE IF NOT EXISTS Experience(\
                     experience_id STRING, agent_name STRING, experience_type STRING, \
                     context STRING, outcome STRING, confidence DOUBLE, timestamp INT64, \
                     metadata STRING, tags STRING, compressed BOOLEAN, \
                     PRIMARY KEY(experience_id))",
-            ) {
-                error!("initialize_schema: failed to create Experience node table: {e}");
-            }
-            if let Err(e) = self.execute_no_params(
+            )?;
+            self.execute_no_params(
                 py,
                 "CREATE REL TABLE IF NOT EXISTS SIMILAR_TO(\
                     FROM Experience TO Experience, similarity_score DOUBLE)",
-            ) {
-                error!("initialize_schema: failed to create SIMILAR_TO rel table: {e}");
-            }
-            if let Err(e) = self.execute_no_params(
+            )?;
+            self.execute_no_params(
                 py,
                 "CREATE REL TABLE IF NOT EXISTS LEADS_TO(\
                     FROM Experience TO Experience, causal_strength DOUBLE)",
-            ) {
-                error!("initialize_schema: failed to create LEADS_TO rel table: {e}");
-            }
+            )?;
             Ok(())
         })
     }
@@ -266,7 +260,7 @@ impl MemoryBackend for KuzuBackend {
                 &params,
             )?;
             let compressed: usize = scalar_from_result(result.bind(py), 0)?;
-            let compression_ratio = if compressed > 0 { 3.0 } else { 1.0 };
+            let compression_ratio = 1.0;
 
             Ok(StorageStatistics {
                 total_experiences: total,
@@ -306,12 +300,10 @@ impl MemoryBackend for KuzuBackend {
             if auto_compress {
                 let cutoff = (chrono::Utc::now() - chrono::Duration::days(30)).timestamp();
                 set_param(&params, "cutoff", cutoff)?;
-                if let Err(e) = self.execute(py,
+                self.execute(py,
                     "MATCH (e:Experience) \
                      WHERE e.agent_name = $agent AND e.timestamp < $cutoff AND e.compressed = false \
-                     SET e.compressed = true", &params) {
-                    warn!("cleanup: failed to auto-compress old experiences: {e}");
-                }
+                     SET e.compressed = true", &params)?;
             }
 
             if let Some(days) = max_age_days {
@@ -319,15 +311,13 @@ impl MemoryBackend for KuzuBackend {
                 let age_params = pyo3::types::PyDict::new_bound(py);
                 set_param(&age_params, "agent", &self.agent_name)?;
                 set_param(&age_params, "cutoff", cutoff)?;
-                if let Err(e) = self.execute(
+                self.execute(
                     py,
                     "MATCH (e:Experience) \
                      WHERE e.agent_name = $agent AND e.timestamp < $cutoff \
                      DETACH DELETE e",
                     &age_params,
-                ) {
-                    warn!("cleanup: failed to delete experiences older than {days} days: {e}");
-                }
+                )?;
             }
 
             if let Some(max_exp) = max_experiences {

--- a/rust/amplihack-memory/src/backends/ladybug_backend/storage.rs
+++ b/rust/amplihack-memory/src/backends/ladybug_backend/storage.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use chrono::Utc;
 use ladybug_graph_rs::Property;
 
-use super::{walkdir_size, LadybugBackend};
-use crate::backends::base::{MemoryBackend, StorageStatistics};
+use super::LadybugBackend;
+use crate::backends::base::{walkdir_size, MemoryBackend, StorageStatistics};
 use crate::errors::MemoryError;
 use crate::experience::{Experience, ExperienceType};
 
@@ -48,21 +48,7 @@ impl MemoryBackend for LadybugBackend {
     }
 
     fn store_experience(&mut self, experience: &Experience) -> crate::Result<String> {
-        if experience.context.trim().is_empty() {
-            return Err(MemoryError::InvalidExperience(
-                "context cannot be empty".into(),
-            ));
-        }
-        if experience.outcome.trim().is_empty() {
-            return Err(MemoryError::InvalidExperience(
-                "outcome cannot be empty".into(),
-            ));
-        }
-        if !(0.0..=1.0).contains(&experience.confidence) {
-            return Err(MemoryError::InvalidExperience(
-                "confidence must be between 0.0 and 1.0".into(),
-            ));
-        }
+        experience.validate()?;
 
         let metadata_json =
             serde_json::to_string(&experience.metadata).unwrap_or_else(|_| "{}".to_string());
@@ -203,7 +189,7 @@ impl MemoryBackend for LadybugBackend {
             .and_then(|p| p.as_i64())
             .unwrap_or(0) as usize;
 
-        let compression_ratio = if compressed > 0 { 3.0 } else { 1.0 };
+        let compression_ratio = 1.0;
 
         Ok(StorageStatistics {
             total_experiences: total,
@@ -229,7 +215,7 @@ impl MemoryBackend for LadybugBackend {
         // 1. Mark old experiences as compressed (>30 days)
         if auto_compress && self.enable_compression {
             let cutoff = (Utc::now() - chrono::Duration::days(30)).timestamp();
-            if let Err(e) = self.exec(
+            self.exec(
                 "MATCH (e:Experience) \
                  WHERE e.agent_name = $agent AND e.timestamp < $cutoff AND e.compressed = false \
                  SET e.compressed = true",
@@ -237,15 +223,13 @@ impl MemoryBackend for LadybugBackend {
                     ("agent", Property::from(agent.as_str())),
                     ("cutoff", Property::Int64(cutoff)),
                 ],
-            ) {
-                warn!("cleanup: failed to auto-compress old experiences: {e}");
-            }
+            )?;
         }
 
         // 2. Delete experiences older than max_age_days
         if let Some(days) = max_age_days {
             let cutoff = (Utc::now() - chrono::Duration::days(days)).timestamp();
-            if let Err(e) = self.exec(
+            self.exec(
                 "MATCH (e:Experience) \
                  WHERE e.agent_name = $agent AND e.timestamp < $cutoff \
                  DETACH DELETE e",
@@ -253,9 +237,7 @@ impl MemoryBackend for LadybugBackend {
                     ("agent", Property::from(agent.as_str())),
                     ("cutoff", Property::Int64(cutoff)),
                 ],
-            ) {
-                warn!("cleanup: failed to delete experiences older than {days} days: {e}");
-            }
+            )?;
         }
 
         // 3. Limit to max_experiences

--- a/rust/amplihack-memory/src/cognitive_memory/episodic.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/episodic.rs
@@ -113,7 +113,7 @@ impl CognitiveMemory {
         &mut self,
         batch_size: usize,
         summarizer: Option<F>,
-    ) -> Option<String>
+    ) -> Result<Option<String>>
     where
         F: FnOnce(&[String]) -> String,
     {
@@ -140,7 +140,7 @@ impl CognitiveMemory {
         candidates.sort_by_key(|(_, _, tidx)| *tidx);
 
         if candidates.len() < batch_size {
-            return None;
+            return Ok(None);
         }
 
         let batch: Vec<(String, String, i64)> = candidates.into_iter().take(batch_size).collect();
@@ -162,19 +162,17 @@ impl CognitiveMemory {
         props.insert("original_count".to_string(), batch.len().to_string());
         props.insert("created_at".to_string(), now.to_string());
 
-        if self
-            .graph
+        self.graph
             .add_node(NT_CONSOLIDATED, props, Some(&cons_id))
-            .is_err()
-        {
-            return None;
-        }
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
 
         // Mark originals as compressed and create edges
-        for (ep_id, _, _) in &batch {
+        for (idx, (ep_id, _, _)) in batch.iter().enumerate() {
             let mut update = HashMap::new();
             update.insert("compressed".to_string(), "true".to_string());
-            let _ = self.graph.update_node(ep_id, update);
+            if !self.graph.update_node(ep_id, update) {
+                warn!("consolidate_episodes: failed to mark episode {ep_id} as compressed");
+            }
 
             // Best-effort edge
             if let Err(e) = self.graph.add_edge(
@@ -190,14 +188,28 @@ impl CognitiveMemory {
                 warn!("consolidate_episodes: failed to add CONSOLIDATES edge: {e}");
                 // Rollback: revert compressed flags on all episodes in this batch
                 for (rollback_id, _, _) in &batch {
-                    let mut rollback = HashMap::new();
-                    rollback.insert("compressed".to_string(), "false".to_string());
-                    let _ = self.graph.update_node(rollback_id, rollback);
+                    if !self.graph.update_node(rollback_id, {
+                        let mut rollback = HashMap::new();
+                        rollback.insert("compressed".to_string(), "false".to_string());
+                        rollback
+                    }) {
+                        warn!("consolidate_episodes: failed to rollback compressed flag on {rollback_id}");
+                    }
                 }
-                return None;
+                // Delete previously-created edges for this consolidated node
+                for (prev_ep_id, _, _) in &batch[..idx] {
+                    let _ = self
+                        .graph
+                        .delete_edge(&cons_id, prev_ep_id, ET_CONSOLIDATES);
+                }
+                // Delete the consolidated node itself
+                let _ = self.graph.delete_node(&cons_id);
+                return Err(MemoryError::Storage(format!(
+                    "failed to add CONSOLIDATES edge: {e}"
+                )));
             }
         }
 
-        Some(cons_id)
+        Ok(Some(cons_id))
     }
 }

--- a/rust/amplihack-memory/src/cognitive_memory/prospective.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/prospective.rs
@@ -6,6 +6,7 @@ use crate::memory_types::ProspectiveMemory;
 use crate::{MemoryError, Result};
 
 use crate::graph::protocol::GraphStore;
+use tracing::warn;
 
 use super::converters::node_to_prospective;
 use super::types::{agent_filter, new_id, ts_now, NT_PROSPECTIVE};
@@ -86,7 +87,12 @@ impl CognitiveMemory {
                 // Mark as triggered
                 let mut update = HashMap::new();
                 update.insert("status".to_string(), "triggered".to_string());
-                let _ = self.graph.update_node(&pm.node_id, update);
+                if !self.graph.update_node(&pm.node_id, update) {
+                    warn!(
+                        "check_triggers: failed to update prospective node {}",
+                        pm.node_id
+                    );
+                }
 
                 pm.status = "triggered".to_string();
                 triggered.push(pm);
@@ -100,6 +106,8 @@ impl CognitiveMemory {
     pub fn resolve_prospective(&mut self, node_id: &str) {
         let mut update = HashMap::new();
         update.insert("status".to_string(), "resolved".to_string());
-        let _ = self.graph.update_node(node_id, update);
+        if !self.graph.update_node(node_id, update) {
+            warn!("resolve_prospective: failed to update node {node_id}");
+        }
     }
 }

--- a/rust/amplihack-memory/src/cognitive_memory/tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests.rs
@@ -211,11 +211,13 @@ fn test_consolidate_episodes() {
     // Not enough for batch_size=10
     assert!(cm
         .consolidate_episodes::<fn(&[String]) -> String>(10, None)
+        .unwrap()
         .is_none());
 
     // Enough for batch_size=3
     let cons_id = cm
         .consolidate_episodes::<fn(&[String]) -> String>(3, None)
+        .unwrap()
         .unwrap();
     assert!(cons_id.starts_with("con_"));
 
@@ -237,6 +239,7 @@ fn test_consolidate_with_custom_summarizer() {
             3,
             Some(|contents: &[String]| format!("SUMMARY({})", contents.len())),
         )
+        .unwrap()
         .unwrap();
 
     // Verify the consolidated node exists
@@ -251,7 +254,8 @@ fn test_search_episodes_excludes_compressed() {
         cm.store_episode(&format!("ep-{i}"), "src", None, None)
             .unwrap();
     }
-    cm.consolidate_episodes::<fn(&[String]) -> String>(3, None);
+    cm.consolidate_episodes::<fn(&[String]) -> String>(3, None)
+        .unwrap();
 
     let uncompressed = cm.search_episodes(10);
     assert_eq!(uncompressed.len(), 2);
@@ -918,3 +922,23 @@ fn test_check_triggers_multiple_triggers() {
     assert_eq!(triggered[0].priority, 5);
     assert_eq!(triggered[1].priority, 2);
 }
+
+#[test]
+fn test_consolidate_episodes_creates_summary() {
+    let mut cm = make_cm();
+    for i in 0..5 {
+        cm.store_episode(&format!("event-{i}"), "src", None, None)
+            .unwrap();
+    }
+    let cons_id = cm
+        .consolidate_episodes::<fn(&[String]) -> String>(3, None)
+        .unwrap()
+        .unwrap();
+    assert!(cons_id.starts_with("con_"));
+    let uncompressed = cm.get_episodes(10, false);
+    assert_eq!(uncompressed.len(), 2);
+}
+
+// ====================================================================
+// QA audit: Fix 15 — consolidate_episodes creates summary
+// ====================================================================

--- a/rust/amplihack-memory/src/cognitive_memory/working.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/working.rs
@@ -6,6 +6,7 @@ use crate::memory_types::WorkingMemorySlot;
 use crate::{MemoryError, Result};
 
 use crate::graph::protocol::GraphStore;
+use tracing::warn;
 
 use super::converters::node_to_working;
 use super::types::{agent_filter, new_id, ts_now, NT_WORKING, WORKING_MEMORY_CAPACITY};
@@ -31,7 +32,9 @@ impl CognitiveMemory {
                     .partial_cmp(&b.relevance)
                     .unwrap_or(std::cmp::Ordering::Equal)
             }) {
-                let _ = self.graph.delete_node(&lowest.node_id);
+                if !self.graph.delete_node(&lowest.node_id) {
+                    warn!("store_working: failed to evict node {}", lowest.node_id);
+                }
             }
         }
 
@@ -85,7 +88,9 @@ impl CognitiveMemory {
 
         let count = nodes.len();
         for n in nodes {
-            let _ = self.graph.delete_node(&n.node_id);
+            if !self.graph.delete_node(&n.node_id) {
+                warn!("clear_working: failed to delete node {}", n.node_id);
+            }
         }
         count
     }

--- a/rust/amplihack-memory/src/connector/mod.rs
+++ b/rust/amplihack-memory/src/connector/mod.rs
@@ -32,9 +32,9 @@ pub(crate) enum BackendInner {
 ///
 /// Factory class that delegates to the selected backend implementation.
 pub struct MemoryConnector {
-    pub agent_name: String,
-    pub storage_path: PathBuf,
-    pub db_path: PathBuf,
+    agent_name: String,
+    storage_path: PathBuf,
+    db_path: PathBuf,
     pub(crate) backend: BackendInner,
 }
 
@@ -125,5 +125,15 @@ impl MemoryConnector {
             db_path,
             backend,
         })
+    }
+
+    pub fn agent_name(&self) -> &str {
+        &self.agent_name
+    }
+    pub fn storage_path(&self) -> &Path {
+        &self.storage_path
+    }
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
     }
 }

--- a/rust/amplihack-memory/src/connector/tests_extended.rs
+++ b/rust/amplihack-memory/src/connector/tests_extended.rs
@@ -149,7 +149,7 @@ fn test_connector_search_limit() {
 fn test_connector_agent_name_trimmed() {
     let tmp = TempDir::new().unwrap();
     let connector = MemoryConnector::new("  trimmed-agent  ", Some(tmp.path()), 100, true).unwrap();
-    assert_eq!(connector.agent_name, "trimmed-agent");
+    assert_eq!(connector.agent_name(), "trimmed-agent");
 }
 
 #[test]
@@ -158,11 +158,11 @@ fn test_connector_db_path_is_set() {
     let connector = MemoryConnector::new("dbpath-agent", Some(tmp.path()), 100, true).unwrap();
     assert!(
         connector
-            .db_path
+            .db_path()
             .to_string_lossy()
             .contains("experiences.db"),
         "db_path should point to experiences.db: {:?}",
-        connector.db_path
+        connector.db_path()
     );
 }
 

--- a/rust/amplihack-memory/src/entity_extraction.rs
+++ b/rust/amplihack-memory/src/entity_extraction.rs
@@ -17,7 +17,7 @@ pub static MULTI_WORD_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Uses simple heuristics to find proper nouns (capitalized multi-word names)
 /// in the concept field first, then the content. Returns lowercase for
 /// consistent indexing.
-pub fn extract_entity_name(content: &str, concept: &str) -> String {
+pub fn extract_entity_name(content: &str, concept: &str) -> Option<String> {
     for text in [concept, content] {
         if text.is_empty() {
             continue;
@@ -31,7 +31,7 @@ pub fn extract_entity_name(content: &str, concept: &str) -> String {
 
         if !matches.is_empty() {
             let best = matches.iter().max_by_key(|m| m.chars().count()).unwrap();
-            return best.to_lowercase();
+            return Some(best.to_lowercase());
         }
 
         // Single capitalized word that isn't at start of sentence
@@ -47,7 +47,7 @@ pub fn extract_entity_name(content: &str, concept: &str) -> String {
                         if !cleaned.is_empty()
                             && cleaned.chars().next().is_some_and(|c| c.is_uppercase())
                         {
-                            return cleaned.to_lowercase();
+                            return Some(cleaned.to_lowercase());
                         }
                     }
                 }
@@ -55,7 +55,7 @@ pub fn extract_entity_name(content: &str, concept: &str) -> String {
         }
     }
 
-    String::new()
+    None
 }
 
 #[cfg(test)]
@@ -66,7 +66,7 @@ mod tests {
     fn test_multi_word_name() {
         assert_eq!(
             extract_entity_name("Met with Sarah Chen today", ""),
-            "sarah chen"
+            Some("sarah chen".to_string())
         );
     }
 
@@ -74,35 +74,38 @@ mod tests {
     fn test_concept_first() {
         assert_eq!(
             extract_entity_name("some content", "Sarah Chen"),
-            "sarah chen"
+            Some("sarah chen".to_string())
         );
     }
 
     #[test]
     fn test_empty() {
-        assert_eq!(extract_entity_name("", ""), "");
+        assert_eq!(extract_entity_name("", ""), None);
     }
 
     #[test]
     fn test_no_names() {
-        assert_eq!(extract_entity_name("all lowercase words here", ""), "");
+        assert_eq!(extract_entity_name("all lowercase words here", ""), None);
     }
 
     #[test]
     fn test_apostrophe_name() {
-        let result = extract_entity_name("Met O'Brien today", "");
+        let result = extract_entity_name("Met O'Brien today", "").unwrap();
         assert!(result.contains("o'brien") || result.contains("o\u{2019}brien"));
     }
 
     #[test]
     fn test_unicode_entity_extraction_cjk() {
         let result = extract_entity_name("hello 日本語 world", "");
-        let _ = result;
+        assert!(
+            result.is_none(),
+            "expected no entity from CJK text, got: {result:?}"
+        );
     }
 
     #[test]
     fn test_unicode_entity_extraction_emoji() {
         let result = extract_entity_name("the 🎉🎊 Party was fun", "");
-        assert_eq!(result, "party");
+        assert_eq!(result, Some("party".to_string()));
     }
 }

--- a/rust/amplihack-memory/src/graph/federated_store.rs
+++ b/rust/amplihack-memory/src/graph/federated_store.rs
@@ -22,7 +22,9 @@ pub struct AnnotatedResult {
 #[derive(Debug, Clone, Default)]
 pub struct FederatedQueryResult {
     pub results: Vec<AnnotatedResult>,
+    /// Number of results sourced from the local agent graph.
     pub local_count: usize,
+    /// Number of results sourced from the shared hive graph.
     pub hive_count: usize,
     pub expert_agents: Vec<String>,
 }

--- a/rust/amplihack-memory/src/graph/hive_store.rs
+++ b/rust/amplihack-memory/src/graph/hive_store.rs
@@ -71,22 +71,30 @@ impl HiveGraphStore {
         }
         let mut props = HashMap::new();
         props.insert("trust".into(), new_trust.to_string());
-        let _ = self.inner.update_node(agent_id, props);
+        if !self.inner.update_node(agent_id, props) {
+            return Err(crate::MemoryError::Internal("trust update failed".into()));
+        }
         Ok(())
     }
 
     /// Increment the fact count for an agent.
-    pub fn increment_fact_count(&mut self, agent_id: &str) {
-        if let Some(node) = self.inner.get_node(agent_id) {
-            let current: i64 = node
-                .properties
-                .get("fact_count")
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(0);
-            let mut props = HashMap::new();
-            props.insert("fact_count".into(), (current + 1).to_string());
-            let _ = self.inner.update_node(agent_id, props);
+    pub fn increment_fact_count(&mut self, agent_id: &str) -> crate::Result<()> {
+        let node = self.inner.get_node(agent_id).ok_or_else(|| {
+            crate::MemoryError::Internal(format!("Agent not registered in hive: {agent_id}"))
+        })?;
+        let current: i64 = node
+            .properties
+            .get("fact_count")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let mut props = HashMap::new();
+        props.insert("fact_count".into(), (current + 1).to_string());
+        if !self.inner.update_node(agent_id, props) {
+            return Err(crate::MemoryError::Storage(
+                "failed to update fact_count".into(),
+            ));
         }
+        Ok(())
     }
 
     /// Find agents registered as experts in a given domain.
@@ -117,6 +125,11 @@ impl HiveGraphStore {
         confirmed_agent_id: &str,
         confidence: f64,
     ) -> crate::Result<()> {
+        if !(0.0..=1.0).contains(&confidence) {
+            return Err(crate::MemoryError::InvalidInput(
+                "confidence must be between 0.0 and 1.0".into(),
+            ));
+        }
         let mut props = HashMap::new();
         props.insert(
             "confirmed_at".into(),
@@ -336,8 +349,8 @@ mod tests {
             .unwrap();
         assert_eq!(count_before, 0);
 
-        hive.increment_fact_count("agent-x");
-        hive.increment_fact_count("agent-x");
+        hive.increment_fact_count("agent-x").unwrap();
+        hive.increment_fact_count("agent-x").unwrap();
 
         let node_after = hive.inner.get_node("agent-x").unwrap();
         let count_after: i64 = node_after
@@ -398,5 +411,31 @@ mod tests {
                 .abs()
                 < 0.01
         );
+    }
+
+    #[test]
+    fn test_update_trust_nonexistent_agent_errors() {
+        let mut hive = HiveGraphStore::new(None);
+        let result = hive.update_trust("nonexistent", 0.5);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_increment_fact_count_returns_result() {
+        let mut hive = HiveGraphStore::new(None);
+        hive.register_agent("a1", "math", 0.8).unwrap();
+        assert!(hive.increment_fact_count("a1").is_ok());
+        let result = hive.increment_fact_count("no-such-agent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_add_confirmation_rejects_invalid_confidence() {
+        let mut hive = HiveGraphStore::new(None);
+        hive.register_agent("a1", "bio", 1.0).unwrap();
+        hive.register_agent("a2", "bio", 1.0).unwrap();
+        assert!(hive.add_confirmation("a1", "a2", -0.1).is_err());
+        assert!(hive.add_confirmation("a1", "a2", 1.1).is_err());
+        assert!(hive.add_confirmation("a1", "a2", 0.5).is_ok());
     }
 }

--- a/rust/amplihack-memory/src/graph/kuzu_store/helpers.rs
+++ b/rust/amplihack-memory/src/graph/kuzu_store/helpers.rs
@@ -176,7 +176,10 @@ impl KuzuGraphStore {
 
             let result = match self.execute_cypher(py, &cypher, &params) {
                 Ok(r) => r,
-                Err(_) => return Vec::new(),
+                Err(e) => {
+                    tracing::warn!("query_directed_neighbors failed: {e}");
+                    return Vec::new();
+                }
             };
             let result_ref = result.bind(py);
 

--- a/rust/amplihack-memory/src/hierarchical_memory/experience_ops.rs
+++ b/rust/amplihack-memory/src/hierarchical_memory/experience_ops.rs
@@ -63,7 +63,7 @@ impl HierarchicalMemory {
             }
         }
 
-        let entity_name = extract_entity_name(content, concept);
+        let entity_name = extract_entity_name(content, concept).unwrap_or_default();
 
         let mut props = HashMap::new();
         props.insert("concept".into(), concept.to_string());
@@ -135,7 +135,7 @@ impl HierarchicalMemory {
         // 2. If concept is empty or matched few nodes, search by entity name
         //    extracted from content to find related nodes.
         if candidates.len() < MAX_CANDIDATES {
-            let entity = extract_entity_name(content, concept);
+            let entity = extract_entity_name(content, concept).unwrap_or_default();
             if !entity.is_empty() {
                 let remaining = MAX_CANDIDATES - candidates.len();
                 for node in self.store.search_nodes(

--- a/rust/amplihack-memory/src/hierarchical_memory/helpers.rs
+++ b/rust/amplihack-memory/src/hierarchical_memory/helpers.rs
@@ -142,3 +142,104 @@ pub(crate) fn rank_and_truncate(
     nodes.truncate(max_nodes);
     nodes
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{GraphEdge, GraphNode};
+
+    fn make_knode(id: &str, content: &str, confidence: f64) -> KnowledgeNode {
+        KnowledgeNode {
+            node_id: id.to_string(),
+            content: content.to_string(),
+            confidence,
+            ..KnowledgeNode::default()
+        }
+    }
+
+    #[test]
+    fn test_build_sim_map() {
+        let m = build_sim_map("content", "concept", &["t1".into()]);
+        assert_eq!(m.get("content").unwrap().as_str().unwrap(), "content");
+        assert_eq!(m.get("concept").unwrap().as_str().unwrap(), "concept");
+    }
+
+    #[test]
+    fn test_build_sim_map_empty() {
+        let m = build_sim_map("", "", &[]);
+        assert_eq!(m.get("content").unwrap().as_str().unwrap(), "");
+    }
+
+    #[test]
+    fn test_graph_node_to_knowledge_node_defaults() {
+        let gn = GraphNode::new("n1".into(), "Fact".into());
+        let kn = graph_node_to_knowledge_node(&gn);
+        assert_eq!(kn.node_id, "n1");
+        assert!((kn.confidence - 0.8).abs() < 0.01);
+        assert_eq!(kn.category, MemoryCategory::Semantic);
+    }
+
+    #[test]
+    fn test_graph_node_to_knowledge_node_full() {
+        let mut props = HashMap::new();
+        props.insert("content".into(), "Rust is fast".into());
+        props.insert("confidence".into(), "0.95".into());
+        props.insert("tags".into(), r#"["lang"]"#.into());
+        props.insert("metadata".into(), r#"{"category":"procedural"}"#.into());
+        let gn = GraphNode { node_id: "n2".into(), node_type: "F".into(), properties: props, graph_origin: String::new() };
+        let kn = graph_node_to_knowledge_node(&gn);
+        assert!((kn.confidence - 0.95).abs() < 0.01);
+        assert_eq!(kn.category, MemoryCategory::Procedural);
+    }
+
+    #[test]
+    fn test_parse_edge_metadata_valid() {
+        let mut props = HashMap::new();
+        props.insert("metadata".into(), r#"{"w":0.5}"#.into());
+        let edge = GraphEdge { edge_id: String::new(), source_id: "a".into(), target_id: "b".into(), edge_type: "L".into(), properties: props, graph_origin: String::new() };
+        let meta = parse_edge_metadata(&edge);
+        assert!((meta.get("w").unwrap().as_f64().unwrap() - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_parse_edge_metadata_missing() {
+        let edge = GraphEdge::new("a".into(), "b".into(), "L".into());
+        assert!(parse_edge_metadata(&edge).is_empty());
+    }
+
+    #[test]
+    fn test_parse_edge_metadata_invalid() {
+        let mut props = HashMap::new();
+        props.insert("metadata".into(), "not json".into());
+        let edge = GraphEdge { edge_id: String::new(), source_id: "a".into(), target_id: "b".into(), edge_type: "L".into(), properties: props, graph_origin: String::new() };
+        assert!(parse_edge_metadata(&edge).is_empty());
+    }
+
+    #[test]
+    fn test_rank_and_truncate_basic() {
+        let nodes = vec![make_knode("a", "rust programming", 0.5), make_knode("b", "rust compiler", 0.9)];
+        let result = rank_and_truncate(nodes, &["rust".into()], 1);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_rank_and_truncate_empty() {
+        let result = rank_and_truncate(vec![], &["kw".into()], 10);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_store_id_re() {
+        assert!(STORE_ID_RE.is_match("my-agent"));
+        assert!(!STORE_ID_RE.is_match(""));
+        assert!(!STORE_ID_RE.is_match("-bad"));
+    }
+
+    #[test]
+    fn test_make_id_and_now_iso() {
+        let id = make_id();
+        assert_eq!(id.len(), 36);
+        let ts = now_iso();
+        assert!(ts.starts_with("20"));
+    }
+}

--- a/rust/amplihack-memory/src/hierarchical_memory/mod.rs
+++ b/rust/amplihack-memory/src/hierarchical_memory/mod.rs
@@ -258,7 +258,11 @@ impl HierarchicalMemory {
     }
 
     /// Search for nodes matching a concept keyword.
-    pub fn search_by_concept(&self, keywords: &[String], limit: usize) -> Vec<KnowledgeNode> {
+    pub fn search_by_concept(
+        &self,
+        keywords: &[impl AsRef<str>],
+        limit: usize,
+    ) -> Vec<KnowledgeNode> {
         if keywords.is_empty() {
             return Vec::new();
         }
@@ -268,7 +272,7 @@ impl HierarchicalMemory {
         let agent_filter = self.agent_filter();
 
         for kw in keywords {
-            let kw_lower = kw.trim().to_lowercase();
+            let kw_lower = kw.as_ref().trim().to_lowercase();
             if kw_lower.len() <= 2 {
                 continue;
             }

--- a/rust/amplihack-memory/src/hierarchical_memory/tests.rs
+++ b/rust/amplihack-memory/src/hierarchical_memory/tests.rs
@@ -696,6 +696,16 @@ fn test_search_by_concept_short_keyword() {
     assert!(results.is_empty());
 }
 
+#[test]
+fn test_search_by_concept_with_str_slices() {
+    // Fix 10: verify search_by_concept accepts &[&str] via AsRef<str>
+    let mut mem = make_mem();
+    mem.store_knowledge("Gravity pulls objects", "physics", 0.9, None, "", &[], None)
+        .unwrap();
+    let results = mem.search_by_concept(&["physics"], 10);
+    assert!(!results.is_empty());
+}
+
 // -- Multiple agents isolation --
 
 #[test]
@@ -1069,6 +1079,6 @@ fn test_classifier_case_insensitive() {
 
 #[test]
 fn test_classifier_default_returns() {
-    let c = MemoryClassifier::default();
+    let c = MemoryClassifier;
     assert_eq!(c.classify("plain fact", ""), MemoryCategory::Semantic);
 }

--- a/rust/amplihack-memory/src/lib.rs
+++ b/rust/amplihack-memory/src/lib.rs
@@ -125,9 +125,11 @@ pub use security::{
     AgentCapabilities, CredentialScrubber, QueryValidator, ScopeLevel, SecureMemoryBackend,
 };
 
-/// Semantic search engine and TF-IDF similarity scorer.
+/// Semantic search engine and relevance scorer.
+#[allow(deprecated)]
 pub use semantic_search::{
-    calculate_relevance, retrieve_relevant_experiences, SemanticSearchEngine, TfIdfSimilarity,
+    calculate_relevance, retrieve_relevant_experiences, tfidf_similarity, JaccardSimilarity,
+    SemanticSearchEngine, TfIdfSimilarity,
 };
 
 /// Pattern recognition utilities for discovering recurring experience patterns.

--- a/rust/amplihack-memory/src/pattern_recognition/mod.rs
+++ b/rust/amplihack-memory/src/pattern_recognition/mod.rs
@@ -69,7 +69,7 @@ impl PatternDetector {
         }
 
         if pattern.count >= self.threshold {
-            let base_conf = calculate_pattern_confidence(pattern.count, self.threshold);
+            let base_conf = calculate_pattern_confidence(pattern.count);
             pattern.base_confidence = base_conf;
             pattern.confidence = base_conf;
         }

--- a/rust/amplihack-memory/src/pattern_recognition/scoring.rs
+++ b/rust/amplihack-memory/src/pattern_recognition/scoring.rs
@@ -27,6 +27,6 @@ pub fn extract_pattern_key(discovery: &HashMap<String, serde_json::Value>) -> St
 }
 
 /// Calculate pattern confidence based on occurrences.
-pub fn calculate_pattern_confidence(occurrences: usize, _threshold: usize) -> f64 {
+pub fn calculate_pattern_confidence(occurrences: usize) -> f64 {
     (0.5 + (occurrences as f64 * 0.1)).min(0.95)
 }

--- a/rust/amplihack-memory/src/pattern_recognition/tests.rs
+++ b/rust/amplihack-memory/src/pattern_recognition/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::experience::{Experience, ExperienceType};
+use crate::experience::Experience;
 use crate::pattern_recognition::{
     calculate_pattern_confidence, extract_pattern_key, recognize_patterns, PatternDetector,
 };
@@ -32,8 +32,8 @@ fn test_below_threshold() {
 
 #[test]
 fn test_confidence_formula() {
-    assert!((calculate_pattern_confidence(3, 3) - 0.8).abs() < 0.01);
-    assert!((calculate_pattern_confidence(10, 3) - 0.95).abs() < 0.01);
+    assert!((calculate_pattern_confidence(3) - 0.8).abs() < 0.01);
+    assert!((calculate_pattern_confidence(10) - 0.95).abs() < 0.01);
 }
 
 #[test]

--- a/rust/amplihack-memory/src/pattern_recognition/tests_extended.rs
+++ b/rust/amplihack-memory/src/pattern_recognition/tests_extended.rs
@@ -113,14 +113,14 @@ fn test_pattern_one_below_threshold() {
 #[test]
 fn test_confidence_formula_minimum() {
     // 1 occurrence: 0.5 + 0.1 = 0.6
-    let conf = calculate_pattern_confidence(1, 3);
+    let conf = calculate_pattern_confidence(1);
     assert!((conf - 0.6).abs() < 0.01);
 }
 
 #[test]
 fn test_confidence_formula_cap() {
     // 100 occurrences: 0.5 + 10.0 = capped at 0.95
-    let conf = calculate_pattern_confidence(100, 3);
+    let conf = calculate_pattern_confidence(100);
     assert!((conf - 0.95).abs() < 0.01);
 }
 

--- a/rust/amplihack-memory/src/python/mod.rs
+++ b/rust/amplihack-memory/src/python/mod.rs
@@ -40,7 +40,7 @@ use crate::similarity::compute_word_similarity;
 #[pyfunction]
 #[pyo3(name = "extract_entities")]
 fn py_extract_entities(text: &str, concept: &str) -> String {
-    extract_entity_name(text, concept)
+    extract_entity_name(text, concept).unwrap_or_default()
 }
 
 /// Compute Jaccard word-level similarity between two strings (0.0–1.0).

--- a/rust/amplihack-memory/src/semantic_search.rs
+++ b/rust/amplihack-memory/src/semantic_search.rs
@@ -20,22 +20,33 @@ const MIN_RECENCY_FACTOR: f64 = 0.7;
 /// Maximum similarity score after all adjustments.
 const MAX_SIMILARITY_SCORE: f64 = 1.0;
 
-/// Simple TF-IDF similarity calculator (word overlap approximation).
+/// Compute TF-IDF-style word similarity between two texts.
+///
+/// Delegates to [`crate::similarity::compute_word_similarity`].
+pub fn tfidf_similarity(text1: &str, text2: &str) -> f64 {
+    compute_word_similarity(text1, text2)
+}
+
+/// Simple Jaccard similarity calculator (word overlap).
 ///
 /// Delegates to [`crate::similarity::compute_word_similarity`] to avoid
 /// duplicating the Jaccard implementation.
-pub struct TfIdfSimilarity;
+pub struct JaccardSimilarity;
 
-impl TfIdfSimilarity {
+impl JaccardSimilarity {
     /// Calculate similarity between two texts using Jaccard similarity.
     pub fn calculate(text1: &str, text2: &str) -> f64 {
         compute_word_similarity(text1, text2)
     }
 }
 
+/// Deprecated alias for [`JaccardSimilarity`].
+#[deprecated(since = "0.2.0", note = "renamed to JaccardSimilarity")]
+pub type TfIdfSimilarity = JaccardSimilarity;
+
 /// Calculate relevance score for experience given query.
 pub fn calculate_relevance(experience: &Experience, query: &str) -> f64 {
-    let mut similarity = TfIdfSimilarity::calculate(&experience.context, query);
+    let mut similarity = JaccardSimilarity::calculate(&experience.context, query);
 
     // Type weighting
     match experience.experience_type {
@@ -100,6 +111,7 @@ impl SemanticSearchEngine {
     ///
     /// This implementation uses a linear scan, so it is always considered
     /// indexed. Returns `true` unconditionally.
+    #[deprecated(note = "always returns true; will be removed in a future release")]
     pub fn is_indexed(&self) -> bool {
         true
     }
@@ -147,14 +159,14 @@ mod tests {
     }
 
     #[test]
-    fn test_tfidf_identical() {
-        let sim = TfIdfSimilarity::calculate("hello world", "hello world");
+    fn test_jaccard_identical() {
+        let sim = JaccardSimilarity::calculate("hello world", "hello world");
         assert!((sim - 1.0).abs() < 0.01);
     }
 
     #[test]
-    fn test_tfidf_empty() {
-        assert_eq!(TfIdfSimilarity::calculate("", "hello"), 0.0);
+    fn test_jaccard_empty() {
+        assert_eq!(JaccardSimilarity::calculate("", "hello"), 0.0);
     }
 
     #[test]
@@ -202,7 +214,9 @@ mod tests {
         .unwrap();
         let engine = SemanticSearchEngine::new(vec![exp]);
         assert_eq!(engine.corpus_size(), 1);
-        assert!(engine.is_indexed());
+        #[allow(deprecated)]
+        let indexed = engine.is_indexed();
+        assert!(indexed);
 
         let results = engine.search("rust", 10);
         assert_eq!(results.len(), 1);
@@ -245,26 +259,26 @@ mod tests {
     // --- New parity tests ---
 
     #[test]
-    fn test_tfidf_completely_different() {
-        let sim = TfIdfSimilarity::calculate("alpha beta gamma", "delta epsilon zeta");
+    fn test_jaccard_completely_different() {
+        let sim = JaccardSimilarity::calculate("alpha beta gamma", "delta epsilon zeta");
         assert!(sim < 0.01, "disjoint word sets should have ~0 similarity");
     }
 
     #[test]
-    fn test_tfidf_partial_overlap() {
-        let sim = TfIdfSimilarity::calculate("hello world foo", "hello world bar");
+    fn test_jaccard_partial_overlap() {
+        let sim = JaccardSimilarity::calculate("hello world foo", "hello world bar");
         // Jaccard: intersection=2 (hello,world), union=4 (hello,world,foo,bar) => 0.5
         assert!((sim - 0.5).abs() < 0.01);
     }
 
     #[test]
-    fn test_tfidf_both_empty() {
-        assert_eq!(TfIdfSimilarity::calculate("", ""), 0.0);
+    fn test_jaccard_both_empty() {
+        assert_eq!(JaccardSimilarity::calculate("", ""), 0.0);
     }
 
     #[test]
-    fn test_tfidf_case_insensitivity() {
-        let sim = TfIdfSimilarity::calculate("Hello WORLD", "hello world");
+    fn test_jaccard_case_insensitivity() {
+        let sim = JaccardSimilarity::calculate("Hello WORLD", "hello world");
         assert!(
             (sim - 1.0).abs() < 0.01,
             "case should not affect similarity"
@@ -272,14 +286,14 @@ mod tests {
     }
 
     #[test]
-    fn test_tfidf_single_word_match() {
-        let sim = TfIdfSimilarity::calculate("hello", "hello");
+    fn test_jaccard_single_word_match() {
+        let sim = JaccardSimilarity::calculate("hello", "hello");
         assert!((sim - 1.0).abs() < 0.01);
     }
 
     #[test]
-    fn test_tfidf_single_word_mismatch() {
-        let sim = TfIdfSimilarity::calculate("hello", "goodbye");
+    fn test_jaccard_single_word_mismatch() {
+        let sim = JaccardSimilarity::calculate("hello", "goodbye");
         assert!(sim < 0.01);
     }
 
@@ -287,7 +301,9 @@ mod tests {
     fn test_search_engine_creation_empty() {
         let engine = SemanticSearchEngine::new(vec![]);
         assert_eq!(engine.corpus_size(), 0);
-        assert!(engine.is_indexed());
+        #[allow(deprecated)]
+        let indexed = engine.is_indexed();
+        assert!(indexed);
     }
 
     #[test]

--- a/rust/amplihack-memory/src/store.rs
+++ b/rust/amplihack-memory/src/store.rs
@@ -1,11 +1,14 @@
 //! High-level experience storage and retrieval with automatic management.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::backends::base::StorageStatistics;
 use crate::connector::MemoryConnector;
 use crate::errors::MemoryError;
 use crate::experience::{Experience, ExperienceType};
+
+const CLEANUP_INTERVAL: u32 = 100;
 
 /// High-level storage and retrieval of experiences with auto-management.
 ///
@@ -16,12 +19,12 @@ use crate::experience::{Experience, ExperienceType};
 /// - Full-text search
 /// - Statistics tracking
 pub struct ExperienceStore {
-    pub agent_name: String,
-    pub auto_compress: bool,
-    pub max_age_days: Option<i64>,
-    pub max_experiences: Option<usize>,
-    pub max_memory_mb: i32,
+    pub(crate) auto_compress: bool,
+    pub(crate) max_age_days: Option<i64>,
+    pub(crate) max_experiences: Option<usize>,
+    pub(crate) max_memory_mb: i32,
     connector: MemoryConnector,
+    insert_count: AtomicU32,
 }
 
 impl ExperienceStore {
@@ -46,13 +49,18 @@ impl ExperienceStore {
             MemoryConnector::new(agent_name, storage_path, max_memory_mb, auto_compress)?;
 
         Ok(Self {
-            agent_name: agent_name.to_string(),
             auto_compress,
             max_age_days,
             max_experiences,
             max_memory_mb,
             connector,
+            insert_count: AtomicU32::new(0),
         })
+    }
+
+    /// The agent name associated with this store.
+    pub fn agent_name(&self) -> &str {
+        self.connector.agent_name()
     }
 
     /// Add experience with automatic management.
@@ -62,7 +70,10 @@ impl ExperienceStore {
 
         let exp_id = self.connector.store_experience(experience)?;
 
-        if self.auto_compress || self.max_age_days.is_some() || self.max_experiences.is_some() {
+        let count = self.insert_count.fetch_add(1, Ordering::Relaxed) + 1;
+        if count % CLEANUP_INTERVAL == 0
+            && (self.auto_compress || self.max_age_days.is_some() || self.max_experiences.is_some())
+        {
             self.connector
                 .cleanup(self.auto_compress, self.max_age_days, self.max_experiences)?;
         }
@@ -88,8 +99,8 @@ impl ExperienceStore {
     }
 
     fn check_quota(&self) -> crate::Result<()> {
-        if self.connector.db_path.exists() {
-            let meta = std::fs::metadata(&self.connector.db_path)
+        if self.connector.db_path().exists() {
+            let meta = std::fs::metadata(self.connector.db_path())
                 .map_err(|e| MemoryError::Storage(format!("Cannot read db metadata: {e}")))?;
             let size_mb = meta.len() as f64 / (1024.0 * 1024.0);
             if size_mb > self.max_memory_mb as f64 {
@@ -150,7 +161,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let store =
             ExperienceStore::new("default-agent", true, None, None, 100, Some(tmp.path())).unwrap();
-        assert_eq!(store.agent_name, "default-agent");
+        assert_eq!(store.agent_name(), "default-agent");
         assert!(store.auto_compress);
         assert!(store.max_age_days.is_none());
         assert!(store.max_experiences.is_none());
@@ -169,7 +180,7 @@ mod tests {
             Some(tmp.path()),
         )
         .unwrap();
-        assert_eq!(store.agent_name, "custom-agent");
+        assert_eq!(store.agent_name(), "custom-agent");
         assert!(!store.auto_compress);
         assert_eq!(store.max_age_days, Some(30));
         assert_eq!(store.max_experiences, Some(500));
@@ -407,6 +418,16 @@ mod tests {
             .unwrap();
             store.add(&exp).unwrap();
         }
+
+        // Force cleanup since throttled insert count may not have triggered it
+        store
+            .connector
+            .cleanup(
+                store.auto_compress,
+                store.max_age_days,
+                store.max_experiences,
+            )
+            .unwrap();
 
         let stats = store.get_statistics().unwrap();
         assert!(

--- a/rust/amplihack-memory/tests/parity_test.rs
+++ b/rust/amplihack-memory/tests/parity_test.rs
@@ -438,7 +438,7 @@ fn parity_test_all() {
         record(&mut results, "pattern_key_with_link", json!(key2), true);
 
         // Confidence calculation
-        let conf = calculate_pattern_confidence(3, 3);
+        let conf = calculate_pattern_confidence(3);
         record(
             &mut results,
             "pattern_confidence_at_3",
@@ -446,7 +446,7 @@ fn parity_test_all() {
             true,
         );
 
-        let conf5 = calculate_pattern_confidence(5, 3);
+        let conf5 = calculate_pattern_confidence(5);
         record(
             &mut results,
             "pattern_confidence_at_5",


### PR DESCRIPTION
## Summary
Addresses 22 findings from QA audit across CI, performance, and low-severity quality categories.

### CI (fixes 1-4)
- Add `cargo bench --no-run` to verify benchmarks compile
- Add `cargo test --doc` for doc-test execution
- Extract kuzu tests into separate `kuzu-experimental` job with `continue-on-error: true`

### Performance (fixes 5-9)
- Release GIL via `py.allow_threads` in Python connectors/security bindings
- Throttle cleanup to every 100 inserts with `AtomicU32` counter
- Add `InMemoryGraphStore::count_nodes()` to avoid cloning for stats
- Deduplicate `walkdir_size` to `backends/base.rs`
- Make `CredentialScrubber` zero-field struct using static patterns

### Quality — LOW severity (fixes 10-22)
- Fix allocate-then-trim ordering in tag similarity
- Add `#[derive(PartialEq)]` to `TraversalItem`
- Deprecate `is_indexed()` and `TfIdfSimilarity`, add free function
- Make `ExperienceStore` fields `pub(crate)`
- Remove duplicate `dict_to_hashmap` in python/patterns.rs
- Use pattern key in `create_pattern_context/outcome`
- Extract `extract_key_from_context` helper
- Fix CJK test to assert result
- Add 7 serde round-trip tests for memory types
- Add missing docstrings on Python cognitive methods
- Document `py_db` field retention reason

### Test results
- 383 tests pass, 0 failures
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo bench --no-run`: compiles