### PR TITLE
fix: QA audit - kuzu validate() and federated doc comments

### DIFF
--- a/rust/amplihack-memory/src/backends/kuzu_backend/storage.rs
+++ b/rust/amplihack-memory/src/backends/kuzu_backend/storage.rs
@@ -91,21 +91,7 @@ impl MemoryBackend for KuzuBackend {
     }
 
     fn store_experience(&mut self, experience: &Experience) -> crate::Result<String> {
-        if experience.context.trim().is_empty() {
-            return Err(MemoryError::InvalidExperience(
-                "context cannot be empty".into(),
-            ));
-        }
-        if experience.outcome.trim().is_empty() {
-            return Err(MemoryError::InvalidExperience(
-                "outcome cannot be empty".into(),
-            ));
-        }
-        if !(0.0..=1.0).contains(&experience.confidence) {
-            return Err(MemoryError::InvalidExperience(
-                "confidence must be between 0.0 and 1.0".into(),
-            ));
-        }
+        experience.validate()?;
         let metadata_json =
             serde_json::to_string(&experience.metadata).unwrap_or_else(|_| "{}".to_string());
         let tags_json =

--- a/rust/amplihack-memory/src/graph/federated_store.rs
+++ b/rust/amplihack-memory/src/graph/federated_store.rs
@@ -22,9 +22,9 @@ pub struct AnnotatedResult {
 #[derive(Debug, Clone, Default)]
 pub struct FederatedQueryResult {
     pub results: Vec<AnnotatedResult>,
-    /// Number of results sourced from the local agent graph.
+    /// Number of raw results returned by the local agent graph (before deduplication).
     pub local_count: usize,
-    /// Number of results sourced from the shared hive graph.
+    /// Number of results from the shared hive graph added after deduplication against local results.
     pub hive_count: usize,
     pub expert_agents: Vec<String>,
 }

--- a/rust/amplihack-memory/src/hierarchical_memory/helpers.rs
+++ b/rust/amplihack-memory/src/hierarchical_memory/helpers.rs
@@ -186,7 +186,12 @@ mod tests {
         props.insert("confidence".into(), "0.95".into());
         props.insert("tags".into(), r#"["lang"]"#.into());
         props.insert("metadata".into(), r#"{"category":"procedural"}"#.into());
-        let gn = GraphNode { node_id: "n2".into(), node_type: "F".into(), properties: props, graph_origin: String::new() };
+        let gn = GraphNode {
+            node_id: "n2".into(),
+            node_type: "F".into(),
+            properties: props,
+            graph_origin: String::new(),
+        };
         let kn = graph_node_to_knowledge_node(&gn);
         assert!((kn.confidence - 0.95).abs() < 0.01);
         assert_eq!(kn.category, MemoryCategory::Procedural);
@@ -196,7 +201,14 @@ mod tests {
     fn test_parse_edge_metadata_valid() {
         let mut props = HashMap::new();
         props.insert("metadata".into(), r#"{"w":0.5}"#.into());
-        let edge = GraphEdge { edge_id: String::new(), source_id: "a".into(), target_id: "b".into(), edge_type: "L".into(), properties: props, graph_origin: String::new() };
+        let edge = GraphEdge {
+            edge_id: String::new(),
+            source_id: "a".into(),
+            target_id: "b".into(),
+            edge_type: "L".into(),
+            properties: props,
+            graph_origin: String::new(),
+        };
         let meta = parse_edge_metadata(&edge);
         assert!((meta.get("w").unwrap().as_f64().unwrap() - 0.5).abs() < 0.01);
     }
@@ -211,13 +223,23 @@ mod tests {
     fn test_parse_edge_metadata_invalid() {
         let mut props = HashMap::new();
         props.insert("metadata".into(), "not json".into());
-        let edge = GraphEdge { edge_id: String::new(), source_id: "a".into(), target_id: "b".into(), edge_type: "L".into(), properties: props, graph_origin: String::new() };
+        let edge = GraphEdge {
+            edge_id: String::new(),
+            source_id: "a".into(),
+            target_id: "b".into(),
+            edge_type: "L".into(),
+            properties: props,
+            graph_origin: String::new(),
+        };
         assert!(parse_edge_metadata(&edge).is_empty());
     }
 
     #[test]
     fn test_rank_and_truncate_basic() {
-        let nodes = vec![make_knode("a", "rust programming", 0.5), make_knode("b", "rust compiler", 0.9)];
+        let nodes = vec![
+            make_knode("a", "rust programming", 0.5),
+            make_knode("b", "rust compiler", 0.9),
+        ];
         let result = rank_and_truncate(nodes, &["rust".into()], 1);
         assert_eq!(result.len(), 1);
     }


### PR DESCRIPTION
## QA Audit Error Handling and API Quality Fixes

### Changes

**Fix 12: kuzu_backend store_experience validation** (backends/kuzu_backend/storage.rs)
- Replace inline validation (3 if-blocks checking empty context/outcome and confidence range) with `experience.validate()?`
- Matches SQLite and Ladybug backend patterns for consistency

**Fix 14: federated_store count field documentation** (graph/federated_store.rs)
- Clarify `local_count` doc: raw results from local store (before deduplication)
- Clarify `hive_count` doc: results from hive store added after deduplication against local

### Note
The other 12 fixes from the original QA audit were already merged in PR #57. This PR completes the remaining 2 items.

### Testing
- All 391 tests pass
- Clippy clean (`-D warnings`)
- `cargo fmt --check` passes