### PR TITLE
fix: QA audit security and correctness fixes (19 findings)

### DIFF
--- a/rust/amplihack-memory/src/backends/kuzu_backend/mod.rs
+++ b/rust/amplihack-memory/src/backends/kuzu_backend/mod.rs
@@ -176,8 +176,8 @@ impl KuzuBackend {
             serde_json::from_str(&metadata_str).unwrap_or_default();
         let tags: Vec<String> = serde_json::from_str(&tags_str).unwrap_or_default();
 
-        Ok(Experience {
-            experience_id: exp_id,
+        Experience::from_parts(
+            exp_id,
             experience_type,
             context,
             outcome,
@@ -185,7 +185,7 @@ impl KuzuBackend {
             timestamp,
             metadata,
             tags,
-        })
+        )
     }
 }
 

--- a/rust/amplihack-memory/src/backends/ladybug_backend/search.rs
+++ b/rust/amplihack-memory/src/backends/ladybug_backend/search.rs
@@ -4,6 +4,7 @@ use ladybug_graph_rs::Property;
 
 use super::LadybugBackend;
 use crate::experience::{Experience, ExperienceType};
+use crate::security::QueryValidator;
 
 /// Execute a text search against experiences in the Ladybug graph.
 ///
@@ -44,6 +45,12 @@ pub(crate) fn search_experiences(
          LIMIT {limit}",
         LadybugBackend::RETURN_COLS
     );
+
+    if !QueryValidator::is_safe_cypher(&cypher) {
+        return Err(crate::errors::MemoryError::SecurityViolation(
+            "constructed Cypher query failed safety check".into(),
+        ));
+    }
 
     let rows = backend.exec(&cypher, &params)?;
     rows.iter()

--- a/rust/amplihack-memory/src/backends/sqlite_backend/search.rs
+++ b/rust/amplihack-memory/src/backends/sqlite_backend/search.rs
@@ -7,6 +7,7 @@ use crate::errors::MemoryError;
 use crate::experience::{Experience, ExperienceType};
 
 use super::escape_fts5_query;
+use tracing::warn;
 
 /// Execute an FTS5 search against the experiences table.
 ///
@@ -53,5 +54,13 @@ pub(crate) fn fts5_search(
         .query_map(params_refs.as_slice(), SqliteBackend::row_to_experience)
         .map_err(|e| MemoryError::Storage(format!("Failed to execute search: {e}")))?;
 
-    Ok(rows.filter_map(|r| r.ok()).collect())
+    Ok(rows
+        .filter_map(|r| match r {
+            Ok(exp) => Some(exp),
+            Err(e) => {
+                warn!("fts5_search: skipping row: {e}");
+                None
+            }
+        })
+        .collect())
 }

--- a/rust/amplihack-memory/src/backends/sqlite_backend/storage.rs
+++ b/rust/amplihack-memory/src/backends/sqlite_backend/storage.rs
@@ -11,6 +11,7 @@ use crate::errors::MemoryError;
 use crate::experience::{Experience, ExperienceType};
 
 use super::search::fts5_search;
+use tracing::warn;
 
 impl MemoryBackend for SqliteBackend {
     fn initialize_schema(&mut self) -> crate::Result<()> {
@@ -92,7 +93,15 @@ impl MemoryBackend for SqliteBackend {
             .query_map(params_refs.as_slice(), Self::row_to_experience)
             .map_err(|e| MemoryError::Storage(format!("Failed to execute query: {e}")))?;
 
-        Ok(rows.filter_map(|r| r.ok()).collect())
+        Ok(rows
+            .filter_map(|r| match r {
+                Ok(exp) => Some(exp),
+                Err(e) => {
+                    warn!("retrieve: skipping row: {e}");
+                    None
+                }
+            })
+            .collect())
     }
 
     fn search(
@@ -133,7 +142,7 @@ impl MemoryBackend for SqliteBackend {
                 params![self.agent_name],
                 |row| row.get(0),
             )
-            .unwrap_or(0);
+            .map_err(|e| MemoryError::Storage(format!("count failed: {e}")))?;
 
         let mut by_type = HashMap::new();
         let mut stmt = conn
@@ -171,7 +180,7 @@ impl MemoryBackend for SqliteBackend {
                 params![self.agent_name],
                 |row| row.get(0),
             )
-            .unwrap_or(0);
+            .map_err(|e| MemoryError::Storage(format!("compressed count failed: {e}")))?;
 
         // No actual compression implemented; ratio is always 1:1
         let compression_ratio = 1.0;
@@ -239,7 +248,7 @@ impl MemoryBackend for SqliteBackend {
                     params![self.agent_name],
                     |row| row.get(0),
                 )
-                .unwrap_or(0);
+                .map_err(|e| MemoryError::Storage(format!("cleanup count failed: {e}")))?;
 
             if count > max_exp {
                 conn.execute(

--- a/rust/amplihack-memory/src/backends/sqlite_backend/tests.rs
+++ b/rust/amplihack-memory/src/backends/sqlite_backend/tests.rs
@@ -229,4 +229,33 @@ mod tests {
         let results = MemoryBackend::search(&backend, "AND", None, 0.0, 10).unwrap();
         assert_eq!(results.len(), 1);
     }
+
+    #[test]
+    fn test_qa_retrieve_with_logging() {
+        let (mut backend, _tmp) = test_backend();
+        let exp = test_experience();
+        backend.store_experience(&exp).unwrap();
+        let results = backend.retrieve_experiences(Some(10), None, 0.0).unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn test_qa_statistics_propagation() {
+        let (mut backend, _tmp) = test_backend();
+        let exp = test_experience();
+        backend.store_experience(&exp).unwrap();
+        let stats = backend.get_statistics().unwrap();
+        assert_eq!(stats.total_experiences, 1);
+        assert_eq!(stats.compressed_experiences, 0);
+    }
+
+    #[test]
+    fn test_qa_cleanup_propagation() {
+        let (mut backend, _tmp) = test_backend();
+        for _ in 0..5 {
+            backend.store_experience(&test_experience()).unwrap();
+        }
+        let result = backend.cleanup(false, None, Some(3));
+        assert!(result.is_ok());
+    }
 }

--- a/rust/amplihack-memory/src/contradiction.rs
+++ b/rust/amplihack-memory/src/contradiction.rs
@@ -51,7 +51,7 @@ pub fn detect_contradiction(
 
     let common: HashSet<&String> = concept_words_a
         .intersection(&concept_words_b)
-        .filter(|w| w.len() > 2)
+        .filter(|w| w.chars().count() > 2)
         .collect();
 
     if common.is_empty() {
@@ -128,6 +128,24 @@ mod tests {
             "team size",
             "team size",
         );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_qa_unicode_chars_count() {
+        let result = detect_contradiction(
+            "The café has 5 tables",
+            "The café has 8 tables",
+            "café layout",
+            "café layout",
+        );
+        assert!(result.is_some());
+        assert!(result.unwrap().contradiction);
+    }
+
+    #[test]
+    fn test_qa_short_word_excluded() {
+        let result = detect_contradiction("The ab has 5 items", "The ab has 8 items", "ab", "ab");
         assert!(result.is_none());
     }
 }

--- a/rust/amplihack-memory/src/graph/kuzu_store/schema.rs
+++ b/rust/amplihack-memory/src/graph/kuzu_store/schema.rs
@@ -58,6 +58,7 @@ impl KuzuGraphStore {
                 .collect();
 
             if !new_cols.is_empty() {
+                let mut added_cols = Vec::new();
                 Python::with_gil(|py| -> crate::Result<()> {
                     for (col_name, col_type) in &new_cols {
                         let ddl = format!(
@@ -65,6 +66,8 @@ impl KuzuGraphStore {
                         );
                         if let Err(e) = self.execute_no_params(py, &ddl) {
                             warn!("ensure_node_table: failed to add column {col_name} to {table_name}: {e}");
+                        } else {
+                            added_cols.push(col_name.clone());
                         }
                     }
                     Ok(())
@@ -74,7 +77,7 @@ impl KuzuGraphStore {
                     .node_table_columns
                     .entry(table_name.to_string())
                     .or_default();
-                for (col_name, _) in new_cols {
+                for col_name in added_cols {
                     known.insert(col_name);
                 }
             }

--- a/rust/amplihack-memory/src/hierarchical_memory/consolidation.rs
+++ b/rust/amplihack-memory/src/hierarchical_memory/consolidation.rs
@@ -116,9 +116,9 @@ impl HierarchicalMemory {
                 sorted.sort_by(|a, b| b.1.cmp(&a.1));
                 sorted.truncate(limit);
 
-                let items: HashMap<String, usize> = sorted.into_iter().collect();
-                result.insert("items".into(), serde_json::json!(items));
-                result.insert("count".into(), serde_json::json!(items.len()));
+                let count = sorted.len();
+                result.insert("items".into(), serde_json::json!(sorted));
+                result.insert("count".into(), serde_json::json!(count));
             }
             "by_category" => {
                 let mut cat_counts: HashMap<String, usize> = HashMap::new();

--- a/rust/amplihack-memory/src/hierarchical_memory/tests.rs
+++ b/rust/amplihack-memory/src/hierarchical_memory/tests.rs
@@ -336,9 +336,16 @@ fn test_aggregation_top_concepts() {
         .unwrap();
 
     let result = mem.execute_aggregation("top_concepts", "", 10);
-    let items = result.get("items").unwrap().as_object().unwrap();
-    assert!(items.contains_key("alpha"));
-    assert_eq!(items.get("alpha").and_then(|v| v.as_u64()), Some(2));
+    let items = result.get("items").unwrap().as_array().unwrap();
+    let item_map: std::collections::HashMap<String, u64> = items
+        .iter()
+        .filter_map(|v| {
+            let pair = v.as_array()?;
+            Some((pair[0].as_str()?.to_string(), pair[1].as_u64()?))
+        })
+        .collect();
+    assert!(item_map.contains_key("alpha"));
+    assert_eq!(item_map.get("alpha"), Some(&2));
 }
 
 #[test]
@@ -1035,7 +1042,7 @@ fn test_aggregation_top_concepts_with_limit() {
     }
 
     let result = mem.execute_aggregation("top_concepts", "", 2);
-    let items = result.get("items").unwrap().as_object().unwrap();
+    let items = result.get("items").unwrap().as_array().unwrap();
     assert!(items.len() <= 2);
 }
 
@@ -1081,4 +1088,20 @@ fn test_classifier_case_insensitive() {
 fn test_classifier_default_returns() {
     let c = MemoryClassifier;
     assert_eq!(c.classify("plain fact", ""), MemoryCategory::Semantic);
+}
+
+#[test]
+fn test_qa_top_concepts_is_array() {
+    let mut mem = make_mem();
+    for _ in 0..5 {
+        mem.store_knowledge("Plants grow", "plants", 0.9, None, "", &[], None)
+            .unwrap();
+    }
+    for _ in 0..3 {
+        mem.store_knowledge("Animals eat", "animals", 0.8, None, "", &[], None)
+            .unwrap();
+    }
+    let result = mem.execute_aggregation("top_concepts", "", 10);
+    let items = result.get("items").unwrap();
+    assert!(items.is_array());
 }

--- a/rust/amplihack-memory/src/python/connectors.rs
+++ b/rust/amplihack-memory/src/python/connectors.rs
@@ -11,6 +11,20 @@ use crate::store::ExperienceStore;
 use super::experience::PyExperience;
 use super::helpers::{mem_err, parse_experience_type, storage_stats_to_dict};
 
+fn validate_db_path(db_path: &str) -> PyResult<()> {
+    if db_path.contains("..") {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "db_path must not contain '..' path traversal",
+        ));
+    }
+    if std::path::Path::new(db_path).is_absolute() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "db_path must be a relative path, not absolute",
+        ));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // PyMemoryConnector
 // ---------------------------------------------------------------------------
@@ -31,6 +45,9 @@ impl PyMemoryConnector {
     #[new]
     #[pyo3(signature = (agent_name, db_path=None))]
     fn new(agent_name: &str, db_path: Option<&str>) -> PyResult<Self> {
+        if let Some(p) = db_path {
+            validate_db_path(p)?;
+        }
         let path = db_path.map(Path::new);
         let conn = MemoryConnector::new(agent_name, path, 100, false).map_err(mem_err)?;
         Ok(Self { inner: conn })
@@ -106,6 +123,9 @@ impl PyExperienceStore {
     #[new]
     #[pyo3(signature = (agent_name, db_path=None))]
     fn new(agent_name: &str, db_path: Option<&str>) -> PyResult<Self> {
+        if let Some(p) = db_path {
+            validate_db_path(p)?;
+        }
         let path = db_path.map(Path::new);
         let store =
             ExperienceStore::new(agent_name, false, None, None, 100, path).map_err(mem_err)?;

--- a/rust/amplihack-memory/src/python/security.rs
+++ b/rust/amplihack-memory/src/python/security.rs
@@ -13,6 +13,20 @@ use crate::security::{AgentCapabilities, ScopeLevel, SecureMemoryBackend};
 use super::experience::PyExperience;
 use super::helpers::{mem_err, parse_experience_type, storage_stats_to_dict};
 
+fn validate_db_path(db_path: &str) -> PyResult<()> {
+    if db_path.contains("..") {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "db_path must not contain '..' path traversal",
+        ));
+    }
+    if std::path::Path::new(db_path).is_absolute() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "db_path must be a relative path, not absolute",
+        ));
+    }
+    Ok(())
+}
+
 /// Parse a scope level string into a ScopeLevel enum.
 fn parse_scope(s: &str) -> PyResult<ScopeLevel> {
     match s {
@@ -67,6 +81,7 @@ impl PySecureMemoryBackend {
         memory_quota_mb: i32,
     ) -> PyResult<Self> {
         let scope_level = parse_scope(scope)?;
+        validate_db_path(db_path)?;
         let types: Vec<ExperienceType> = allowed_types
             .unwrap_or_default()
             .iter()

--- a/rust/amplihack-memory/src/security/credential_scrubber.rs
+++ b/rust/amplihack-memory/src/security/credential_scrubber.rs
@@ -98,11 +98,33 @@ impl CredentialScrubber {
     pub fn scrub_experience(&self, experience: &Experience) -> crate::Result<(Experience, bool)> {
         let (scrubbed_context, ctx_modified) = self.scrub_text(&experience.context);
         let (scrubbed_outcome, out_modified) = self.scrub_text(&experience.outcome);
-        let was_scrubbed = ctx_modified || out_modified;
+        let mut was_scrubbed = ctx_modified || out_modified;
 
-        let mut tags = experience.tags.clone();
-        if was_scrubbed && !tags.contains(&"credential_scrubbed".to_string()) {
-            tags.push("credential_scrubbed".to_string());
+        let mut scrubbed_metadata = experience.metadata.clone();
+        for value in scrubbed_metadata.values_mut() {
+            if let Some(s) = value.as_str() {
+                let (sv, m) = self.scrub_text(s);
+                if m {
+                    *value = serde_json::Value::String(sv);
+                    was_scrubbed = true;
+                }
+            }
+        }
+
+        let mut scrubbed_tags: Vec<String> = experience
+            .tags
+            .iter()
+            .map(|t| {
+                let (st, m) = self.scrub_text(t);
+                if m {
+                    was_scrubbed = true;
+                }
+                st
+            })
+            .collect();
+
+        if was_scrubbed && !scrubbed_tags.contains(&"credential_scrubbed".to_string()) {
+            scrubbed_tags.push("credential_scrubbed".to_string());
         }
 
         let scrubbed = Experience::from_parts(
@@ -112,8 +134,8 @@ impl CredentialScrubber {
             scrubbed_outcome,
             experience.confidence,
             experience.timestamp,
-            experience.metadata.clone(),
-            tags,
+            scrubbed_metadata,
+            scrubbed_tags,
         )
         .map_err(|e| {
             MemoryError::Internal(format!("failed to reconstruct scrubbed experience: {e}"))
@@ -133,7 +155,8 @@ impl CredentialScrubber {
                     "db_url" => {
                         format!("${{1}}{REDACTION_TEXT}${{3}}")
                     }
-                    "bearer_token" => {
+                    "bearer_token" | "aws_secret" | "azure_key" | "password" | "token"
+                    | "api_key" | "secret" => {
                         format!("${{1}}{REDACTION_TEXT}")
                     }
                     _ => REDACTION_TEXT.to_string(),

--- a/rust/amplihack-memory/src/security/mod.rs
+++ b/rust/amplihack-memory/src/security/mod.rs
@@ -70,8 +70,9 @@ impl<S: crate::backends::ExperienceBackend> SecureMemoryBackend<S> {
             }
         }
 
+        let sanitized = query.replace('\'', "''").replace('"', "\"\"");
         self.store
-            .search(query, experience_type, min_confidence, limit)
+            .search(&sanitized, experience_type, min_confidence, limit)
     }
 
     /// Validate custom SQL query.

--- a/rust/amplihack-memory/src/security/query_validator.rs
+++ b/rust/amplihack-memory/src/security/query_validator.rs
@@ -73,10 +73,17 @@ impl QueryValidator {
         Ok(())
     }
 
+    /// Strip SQL comments.
+    fn strip_sql_comments(sql: &str) -> String {
+        static LINE_COMMENT_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"--[^\n]*").unwrap());
+        static BLOCK_COMMENT_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"(?s)/\*.*?\*/").unwrap());
+        let no_block = BLOCK_COMMENT_RE.replace_all(sql, " ");
+        LINE_COMMENT_RE.replace_all(&no_block, " ").to_string()
+    }
+
     /// Check if a Cypher query is non-destructive (read-only).
-    ///
-    /// Allows `MATCH ... RETURN` queries and rejects destructive operations
-    /// like `DELETE`, `SET`, `REMOVE`, `MERGE`, and non-schema `CREATE`.
     pub fn is_safe_cypher(cypher: &str) -> bool {
         let trimmed = cypher.trim();
         if !trimmed
@@ -89,20 +96,25 @@ impl QueryValidator {
         }
 
         static DESTRUCTIVE_CYPHER: LazyLock<Vec<Regex>> = LazyLock::new(|| {
-            ["DELETE", "DETACH", "SET", "REMOVE", "MERGE", "CREATE"]
-                .iter()
-                .map(|kw| Regex::new(&format!(r"(?i)\b{kw}\b")).unwrap())
-                .collect()
+            [
+                "DELETE", "DETACH", "SET", "REMOVE", "MERGE", "CREATE", "CALL", "LOAD", "FOREACH",
+            ]
+            .iter()
+            .map(|kw| Regex::new(&format!(r"(?i)\b{kw}\b")).unwrap())
+            .collect()
         });
 
         !DESTRUCTIVE_CYPHER.iter().any(|p| p.is_match(trimmed))
     }
 
     /// Check if a SQL query is non-destructive (read-only SELECT).
-    ///
-    /// Returns `false` for DELETE, UPDATE, INSERT, DROP, and other DDL/DML.
     pub fn is_safe_query(sql: &str) -> bool {
-        let sql_trimmed = sql.trim();
+        let stripped = Self::strip_sql_comments(sql);
+        let sql_trimmed = stripped.trim();
+
+        if sql_trimmed.contains(';') {
+            return false;
+        }
 
         if !sql_trimmed
             .chars()
@@ -115,8 +127,25 @@ impl QueryValidator {
 
         static DESTRUCTIVE_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
             [
-                "DELETE", "UPDATE", "INSERT", "DROP", "TRUNCATE", "ALTER", "CREATE", "REPLACE",
-                "GRANT", "REVOKE", "UNION", "ATTACH", "PRAGMA",
+                "DELETE",
+                "UPDATE",
+                "INSERT",
+                "DROP",
+                "TRUNCATE",
+                "ALTER",
+                "CREATE",
+                "REPLACE",
+                "GRANT",
+                "REVOKE",
+                "UNION",
+                "ATTACH",
+                "PRAGMA",
+                "VACUUM",
+                "REINDEX",
+                "SAVEPOINT",
+                "BEGIN",
+                "COMMIT",
+                "ROLLBACK",
             ]
             .iter()
             .map(|kw| Regex::new(&format!(r"(?i)\b{kw}\b")).unwrap())

--- a/rust/amplihack-memory/src/security/tests.rs
+++ b/rust/amplihack-memory/src/security/tests.rs
@@ -514,9 +514,11 @@ fn test_redaction_full_replacement_no_prefix() {
 fn test_redaction_password_full_replacement() {
     let scrubber = CredentialScrubber::new();
     let (scrubbed, _) = scrubber.scrub_text(r#"password="SuperSecret123!""#);
+    assert!(scrubbed.contains("password="), "label: {scrubbed}");
+    assert!(scrubbed.contains("[REDACTED]"), "redacted: {scrubbed}");
     assert!(
-        scrubbed.starts_with("[REDACTED]"),
-        "should be fully redacted: {scrubbed}"
+        !scrubbed.contains("SuperSecret123!"),
+        "secret gone: {scrubbed}"
     );
 }
 
@@ -673,4 +675,150 @@ fn test_scrub_experience_credential_in_metadata() {
         .insert("api_key".into(), serde_json::json!("abc123def456ghi789"));
     let (scrubbed, _) = scrubber.scrub_experience(&exp).unwrap();
     assert!(scrubbed.metadata.contains_key("api_key"));
+}
+
+// ====================================================================
+// QA Audit Fix Tests
+// ====================================================================
+
+#[test]
+fn test_qa_rejects_semicolons() {
+    assert!(!QueryValidator::is_safe_query("SELECT 1; DROP TABLE t"));
+    assert!(!QueryValidator::is_safe_query("SELECT 1;"));
+}
+
+#[test]
+fn test_qa_strips_line_comments() {
+    assert!(QueryValidator::is_safe_query(
+        "SELECT 1 -- comment\nFROM t LIMIT 1"
+    ));
+}
+
+#[test]
+fn test_qa_strips_block_comments() {
+    assert!(!QueryValidator::is_safe_query(
+        "SELECT /* x */ 1; DROP TABLE t"
+    ));
+}
+
+#[test]
+fn test_qa_rejects_vacuum() {
+    assert!(!QueryValidator::is_safe_query("SELECT 1 FROM VACUUM"));
+}
+
+#[test]
+fn test_qa_rejects_savepoint() {
+    assert!(!QueryValidator::is_safe_query("SELECT 1 SAVEPOINT sp"));
+}
+
+#[test]
+fn test_qa_rejects_begin_commit_rollback() {
+    assert!(!QueryValidator::is_safe_query("SELECT 1 BEGIN"));
+    assert!(!QueryValidator::is_safe_query("SELECT 1 COMMIT"));
+    assert!(!QueryValidator::is_safe_query("SELECT 1 ROLLBACK"));
+}
+
+#[test]
+fn test_qa_cypher_rejects_call() {
+    assert!(!QueryValidator::is_safe_cypher(
+        "MATCH (e:Experience) CALL db.info()"
+    ));
+}
+
+#[test]
+fn test_qa_cypher_rejects_load() {
+    assert!(!QueryValidator::is_safe_cypher(
+        "MATCH (e:Experience) LOAD CSV FROM '/etc/passwd'"
+    ));
+}
+
+#[test]
+fn test_qa_cypher_rejects_foreach() {
+    assert!(!QueryValidator::is_safe_cypher(
+        "MATCH (e:Experience) FOREACH (x IN [1] | SET e.v = x)"
+    ));
+}
+
+#[test]
+fn test_qa_scrub_metadata() {
+    let scrubber = CredentialScrubber::new();
+    let mut metadata = std::collections::HashMap::new();
+    metadata.insert(
+        "notes".to_string(),
+        serde_json::Value::String("key is sk-abcdefghijklmnopqrst12345".to_string()),
+    );
+    let exp = Experience::from_parts(
+        "m1".into(),
+        ExperienceType::Success,
+        "ctx".into(),
+        "out".into(),
+        0.8,
+        chrono::Utc::now(),
+        metadata,
+        vec![],
+    )
+    .unwrap();
+    let (s, w) = scrubber.scrub_experience(&exp).unwrap();
+    assert!(w);
+    assert!(s
+        .metadata
+        .get("notes")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .contains("[REDACTED]"));
+}
+
+#[test]
+fn test_qa_scrub_tags() {
+    let scrubber = CredentialScrubber::new();
+    let exp = Experience::from_parts(
+        "t1".into(),
+        ExperienceType::Success,
+        "ctx".into(),
+        "out".into(),
+        0.8,
+        chrono::Utc::now(),
+        std::collections::HashMap::new(),
+        vec!["sk-abcdefghijklmnopqrst12345".into()],
+    )
+    .unwrap();
+    let (s, w) = scrubber.scrub_experience(&exp).unwrap();
+    assert!(w);
+    assert!(s.tags.iter().any(|t| t.contains("[REDACTED]")));
+}
+
+#[test]
+fn test_qa_preserves_password_label() {
+    let scrubber = CredentialScrubber::new();
+    let (s, m) = scrubber.scrub_text(r#"password="mysecret""#);
+    assert!(m);
+    assert!(s.contains("password="));
+    assert!(s.contains("[REDACTED]"));
+}
+
+#[test]
+fn test_qa_preserves_api_key_label() {
+    let scrubber = CredentialScrubber::new();
+    let (s, _) = scrubber.scrub_text(r#"api_key="abcdef1234567890""#);
+    assert!(s.contains("api_key="));
+    assert!(s.contains("[REDACTED]"));
+}
+
+#[test]
+fn test_qa_preserves_secret_label() {
+    let scrubber = CredentialScrubber::new();
+    let (s, _) = scrubber.scrub_text(r#"secret="TopSecretValue123""#);
+    assert!(s.contains("secret="));
+    assert!(s.contains("[REDACTED]"));
+}
+
+#[test]
+fn test_qa_search_sanitizes_quotes() {
+    let caps = AgentCapabilities::new(ScopeLevel::SessionOnly, vec![], 50, false, 10).unwrap();
+    let mut backend = SecureMemoryBackend::new(MockBackend::new(), caps);
+    let exp = make_experience(ExperienceType::Success, "test ctx", "test out");
+    backend.add_experience(&exp).unwrap();
+    let result = backend.search("test' OR '1'='1", None, 0.0, 10);
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
## Security fixes
- **query_validator**: Strip SQL comments, reject semicolons, add VACUUM/REINDEX/SAVEPOINT/BEGIN/COMMIT/ROLLBACK to blocklist, add CALL/LOAD/FOREACH to Cypher blocklist
- **credential_scrubber**: Scrub metadata values and tags, preserve label prefix in pattern replacements
- **SecureMemoryBackend.search**: Sanitize quotes before forwarding
- **python connectors/security**: validate_db_path rejects .. traversal and absolute paths
- **ladybug_backend search**: Add QueryValidator::is_safe_cypher check

## Correctness fixes
- **hive_store**: Check update_node return, increment_fact_count returns Result, validate confidence
- **kuzu_backend**: Propagate schema errors, use Experience::from_parts
- **sqlite_backend**: Log deserialization warnings, replace unwrap_or(0) with proper error propagation
- **consolidation**: Use Vec of tuples to preserve sort order in top_concepts
- **episodic**: consolidate_episodes returns Result with proper rollback
- **contradiction**: Use chars().count() for Unicode correctness
- **kuzu/ladybug**: Set compression_ratio to 1.0 always
- **kuzu_store schema**: Only track successfully added columns

## Tests
30+ new tests covering all 19 fixes. All 414 tests pass, clippy clean, fmt clean.