### PR TITLE
docs: add CHANGELOG.md, CONTRIBUTING.md, and SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] - 2026-03-13
+
+### Added
+- Quality audit cycle with 83 findings fixed (PRs #57–#60)
+- 31 outside-in behavioral tests (`tests/outside_in.rs`)
+- Property-based and concurrent tests (`tests/concurrent.rs`)
+- Supply chain security with `cargo-deny` (`deny.toml`)
+- Python integration tests for PyO3 bindings
+- Extended `.gitignore` for Rust, editor, and Python entries
+
+### Changed
+- Split 6 oversized modules into submodules — all modules now < 400 LOC (#47, #56)
+- Improved CI: kuzu tests, `cargo audit`, MSRV 1.80 verification, dependency caching (#49, #50)
+- Doc comments added to all public items (#55)
+
+### Fixed
+- 21 HIGH severity issues covering security, correctness, and error handling (#57, #60)
+- Credential scrubber now covers metadata and tags (#48)
+- SQL/Cypher injection hardening (#48)
+- Path traversal validation on Python bindings (#48)
+- Kuzu `validate()` and federated doc comments (#58)
+
+## [0.3.0] - 2026-03-12
+
+### Added
+- Complete Rust port of amplihack-memory-lib from Python
+- Native LadybugDB backend replacing PyO3 Kuzu bridge
+- Kuzu graph database support via PyO3 bridge
+- Comprehensive security hardening (#48)
+- Multi-threaded concurrent access tests (#43)
+- Graph, hierarchical, concurrent, and pattern benchmarks (Criterion) (#54)
+- PyO3 Python bindings with graph operations (#53)
+- HiveStore: 5 public functions with 30 tests (#52)
+- GitHub Actions CI pipeline for Rust and Python tests
+- Reverse-edge index for O(1) incoming-edge lookup (#42)
+
+### Changed
+- Code quality improvements: DRY patterns, dead code removal, constants (#45)
+- Removed 17 unnecessary `.clone()` calls across 5 files
+- Module split, dead code removal, parity tests (Phase 2)
+- Expanded amplihack-memory README (#51)
+
+### Fixed
+- Python–Rust behavioral parity alignment (#46)
+- Replaced swallowed errors with `tracing` warnings (#44)
+- String slicing panic prevention and extended experience ID hash (#41)
+- 12 quality audit findings (2 HIGH, 4 MEDIUM, 6 LOW)
+- All audit findings in Python bindings resolved
+
+## [0.2.0] - 2026-02-27
+
+### Added
+- 6-type cognitive memory system backed by Kuzu (episodic, semantic, procedural, prospective, sensory, working) (#1)
+- Dual-backend architecture: Kuzu (default) + SQLite
+- CognitiveMemory exported from package (#7)
+- Comprehensive documentation and GitHub Pages with MkDocs (#5)
+- Release notes for v0.1.0
+
+## [0.1.0] - 2026-02-15
+
+### Added
+- Initial release of amplihack-memory-lib
+- 166 unit tests
+- SQLite backend and InMemoryGraphStore
+- Cognitive memory with 6 experience types
+- Hierarchical memory with experience consolidation
+- Pattern recognition and semantic search
+- Security layer with credential scrubbing
+
+[0.4.0]: https://github.com/rysweet/amplihack-memory-lib/compare/v0.2.0...HEAD
+[0.3.0]: https://github.com/rysweet/amplihack-memory-lib/compare/v0.2.0...v0.2.0
+[0.2.0]: https://github.com/rysweet/amplihack-memory-lib/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/rysweet/amplihack-memory-lib/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing to amplihack-memory
+
+Thank you for your interest in contributing! This guide covers everything you need to get started.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Rust | 1.80+ (MSRV) | Core development |
+| Python | 3.10+ | PyO3 bindings and integration tests |
+| pre-commit | latest | Git hooks for formatting, linting, testing |
+
+## Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/rysweet/amplihack-memory-lib.git
+cd amplihack-memory-lib
+
+# Build the crate
+cargo build --manifest-path rust/amplihack-memory/Cargo.toml
+
+# Run all tests
+cargo test --manifest-path rust/amplihack-memory/Cargo.toml
+
+# Install pre-commit hooks
+pip install pre-commit
+pre-commit install
+```
+
+### Feature flags
+
+The crate has optional features that can be tested individually:
+
+```bash
+# Default (no optional features)
+cargo test --manifest-path rust/amplihack-memory/Cargo.toml
+
+# With LadybugDB backend
+cargo test --manifest-path rust/amplihack-memory/Cargo.toml --features ladybug
+
+# With PyO3 Python bindings
+cargo test --manifest-path rust/amplihack-memory/Cargo.toml --features python
+```
+
+## Pre-commit hooks
+
+The project uses [pre-commit](https://pre-commit.com/) to enforce quality on every commit. After `pre-commit install`, each commit automatically runs:
+
+- **`cargo fmt`** — formatting check
+- **`cargo clippy -- -D warnings`** — lint with zero warnings
+- **`cargo test --quiet`** — full test suite
+- **trailing-whitespace**, **end-of-file-fixer**, **check-yaml**, **check-toml**, **check-merge-conflict**
+
+## Pull request process
+
+1. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+2. **Write tests first** — new functionality must include tests.
+3. **Run the full check suite locally**:
+   ```bash
+   cd rust/amplihack-memory
+   cargo fmt --check
+   cargo clippy -- -D warnings
+   cargo test
+   ```
+4. **Push and open a draft PR** for early feedback.
+5. **CI must pass** — the pipeline runs tests, clippy, formatting, `cargo audit`, and MSRV verification on Rust 1.80.
+6. **Request review** when ready. At least one approval is required before merging.
+
+## Coding standards
+
+### Module size
+Every module must stay **under 400 lines of code**. If a module grows beyond this limit, split it into submodules with a `mod.rs` barrel file.
+
+### Documentation
+All `pub` items must have doc comments (`///`). Run `cargo doc --no-deps` to verify documentation builds without warnings.
+
+### Error handling
+- Use `thiserror` for error types. All error variants live in `src/errors.rs`.
+- Annotate `Result`-returning public functions with `#[must_use]` where the caller should not silently ignore the return value.
+- Never swallow errors — use `tracing::warn!` at minimum when an error cannot be propagated.
+
+### Security
+- All experience data passes through `CredentialScrubber` before storage.
+- Custom queries are validated by `QueryValidator` (SQL and Cypher).
+- See [SECURITY.md](SECURITY.md) for the full security model.
+
+## Testing
+
+The project maintains four layers of tests:
+
+| Layer | Location | Purpose |
+|-------|----------|---------|
+| **Unit tests** | `src/**/tests.rs` | Per-module logic verification (~250 tests) |
+| **Integration tests** | `tests/parity_test.rs` | Python–Rust behavioral parity |
+| **Outside-in tests** | `tests/outside_in.rs` | 31 end-to-end behavioral tests |
+| **Concurrent tests** | `tests/concurrent.rs` | Multi-threaded correctness (8+ threads) |
+
+### Running benchmarks
+
+```bash
+cd rust/amplihack-memory
+cargo bench
+```
+
+Benchmarks use the [Criterion](https://github.com/bheisler/criterion.rs) framework and produce HTML reports in `target/criterion/`.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,106 @@
+# Security Policy
+
+## Security model overview
+
+amplihack-memory implements defense-in-depth across four layers:
+
+1. **Credential scrubbing** — detects and redacts secrets before they reach storage.
+2. **Query validation** — blocks SQL/Cypher injection and limits query cost.
+3. **Path traversal protection** — validates file paths in Python bindings.
+4. **Scope enforcement** — per-agent capability restrictions (documented stub, enforced at API boundary).
+
+All layers are composed in `SecureMemoryBackend<S>`, which wraps any experience backend and applies checks on every operation. Violations return `MemoryError::SecurityViolation`.
+
+## Credential scrubbing
+
+`CredentialScrubber` scans experience content, metadata, and tags using compiled regex patterns. Matched values are replaced with `[REDACTED]`.
+
+### Detected patterns
+
+| Pattern | What it matches |
+|---------|----------------|
+| AWS Access Key | `AKIA` followed by 16 alphanumeric characters |
+| AWS Secret Key | `aws_secret_access_key` followed by a 40-character base64 value |
+| OpenAI API Key | `sk-` prefix with 20+ alphanumeric characters |
+| GitHub Token | `gh[pousr]_` prefix with 36+ alphanumeric characters |
+| Azure Key | Context-aware — requires `azure`, `subscription`, or `account` label before a 32+ hex value (avoids false positives on UUIDs and commit hashes) |
+| Password | `password=` or `password:` followed by a value |
+| Generic Token | `token=` or `token:` followed by 8+ characters |
+| API Key | `api_key=` / `api-key=` followed by 8+ characters |
+| Secret | `secret=` or `secret:` followed by 8+ characters |
+| SSH Private Key | `-----BEGIN (RSA\|DSA\|EC\|OPENSSH) PRIVATE KEY-----` header |
+| Database URL | `postgres://`, `mysql://`, `mongodb://` with embedded credentials |
+| GCP Service Account | JSON containing `"type": "service_account"` |
+
+Scrubbing is applied to all three fields of every experience: **content**, **metadata**, and **tags**.
+
+## Query validation
+
+`QueryValidator` enforces read-only access and query cost limits.
+
+### SQL safety
+
+- Only `SELECT` statements are allowed.
+- Semicolons are rejected (prevents statement chaining).
+- Blocked keywords: `INSERT`, `UPDATE`, `DELETE`, `DROP`, `CREATE`, `ALTER`, `TRUNCATE`, `EXEC`, `EXECUTE`, `GRANT`, `REVOKE`.
+- SQL comments (`--` and `/* */`) are stripped before validation.
+
+### Cypher safety
+
+- Only `MATCH` queries are allowed (read-only).
+- Blocked operations: `DELETE`, `DETACH`, `SET`, `REMOVE`, `MERGE`, `CREATE`, `CALL`, `LOAD`, `FOREACH`.
+
+### Query cost estimation
+
+Each query is scored against heuristic cost rules:
+
+| Pattern | Cost |
+|---------|------|
+| Base cost | +1 |
+| `SELECT * FROM` (full scan) | +10 |
+| Each `JOIN` | +5 |
+| Each subquery | +3 |
+| `ORDER BY` | +2 |
+| Missing `LIMIT` clause | +20 |
+
+Queries exceeding an agent's `max_query_cost` are rejected with a descriptive error.
+
+## Path traversal protection
+
+Python bindings validate file paths to prevent directory traversal attacks. Paths containing `..` sequences or absolute paths outside the expected working directory are rejected before reaching the Rust backend.
+
+## Scope enforcement
+
+`ScopeEnforcer` restricts per-agent capabilities through the `AgentCapabilities` struct:
+
+| Capability | Description |
+|------------|-------------|
+| `scope` | Access level — `SessionOnly`, `CrossSessionRead`, `CrossSessionWrite`, `GlobalRead`, `GlobalWrite` |
+| `allowed_experience_types` | Allowlist of experience types the agent may store or retrieve |
+| `max_query_cost` | Maximum query cost budget (1–100+) |
+| `can_access_patterns` | Whether the agent may read pattern-type memories |
+| `memory_quota_mb` | Per-agent memory quota in megabytes |
+
+Scope enforcement is currently documented as a structured stub. The `AgentCapabilities` struct is defined and validated at the `SecureMemoryBackend` API boundary, but dynamic policy loading is not yet implemented.
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.4.x | ✅ Current |
+| 0.3.x | ⚠️ Best-effort |
+| < 0.3 | ❌ No |
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do not open a public issue.**
+2. Email **[security@amplihack.dev](mailto:security@amplihack.dev)** with:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+3. You will receive an acknowledgment within **48 hours**.
+4. A fix will be developed privately and released as a patch version.
+
+For non-security bugs, please [open an issue](https://github.com/rysweet/amplihack-memory-lib/issues).


### PR DESCRIPTION
## Summary

Adds three project documentation files at the repository root:

- **CHANGELOG.md** — Version history (v0.1.0 through v0.4.0) derived from git log, following Keep a Changelog format
- **CONTRIBUTING.md** — Prerequisites, setup, pre-commit hooks, PR process, coding standards (<400 LOC modules, doc comments, #[must_use]), and testing layers
- **SECURITY.md** — Security model: credential scrubbing (12 patterns), SQL/Cypher injection validation, path traversal protection, scope enforcement, and vulnerability reporting