### PR TITLE
Add cargo-deny for supply chain security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,13 @@ jobs:
         working-directory: rust/amplihack-memory
         run: cargo audit
 
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+
+      - name: Supply chain check
+        working-directory: rust/amplihack-memory
+        run: cargo deny check
+
   msrv:
     name: MSRV (1.80) Verification
     runs-on: ubuntu-latest

--- a/rust/amplihack-memory/deny.toml
+++ b/rust/amplihack-memory/deny.toml
@@ -1,0 +1,31 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+[licenses.private]
+ignore = false
+registries = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
Adds cargo-deny to enforce supply chain security policies:

- **deny.toml**: License allowlist (MIT, Apache-2.0, BSD-2/3-Clause, ISC, MPL-2.0, Unicode-3.0/DFS-2016, Zlib), deny wildcard versions, deny unknown registries
- **CI**: cargo-deny check step added after cargo-audit

Tested locally — all checks pass (advisories ok, bans ok, licenses ok, sources ok).