### PR TITLE
fix: strip uppercase Kuzu internal keys from node/edge properties

### DIFF
--- a/src/amplihack_memory/graph/ladybug_store.py
+++ b/src/amplihack_memory/graph/ladybug_store.py
@@ -660,7 +660,8 @@ class LadybugGraphStore:
         graph_origin = str(row_data.get("graph_origin", ""))
 
         # Everything except internal fields goes into properties.
-        skip = {"node_id", "graph_origin", "_id", "_label"}
+        # Kuzu returns internal keys as _ID/_LABEL (uppercase).
+        skip = {"node_id", "graph_origin", "_id", "_label", "_ID", "_LABEL"}
         props = {k: v for k, v in row_data.items() if k not in skip}
 
         self._id_table_cache[node_id] = table
@@ -693,7 +694,8 @@ class LadybugGraphStore:
         eid = str(rel_data.get("edge_id", ""))
         graph_origin = str(rel_data.get("graph_origin", ""))
 
-        skip = {"edge_id", "graph_origin", "_id", "_label", "_src", "_dst"}
+        skip = {"edge_id", "graph_origin", "_id", "_label", "_src", "_dst",
+                "_ID", "_LABEL", "_SRC", "_DST"}
         props = {k: v for k, v in rel_data.items() if k not in skip}
 
         # Kuzu _src/_dst are internal IDs, not our node_ids.


### PR DESCRIPTION
## Problem

`_row_to_node` and `_rel_to_edge` in `LadybugGraphStore` only stripped lowercase internal Kuzu keys (`_id`, `_label`, `_src`, `_dst`) from the properties dict. Kuzu actually returns these as uppercase (`_ID`, `_LABEL`, `_SRC`, `_DST`).

The leaked `_ID` field — containing a Kuzu-internal table offset that differs per node — caused `_content_hash()` to produce different hashes for nodes with identical user-defined content. This broke content-based deduplication in `FederatedGraphStore.search_nodes()`.

## Fix

Add uppercase variants to the skip sets in both `_row_to_node` and `_rel_to_edge`.

## Verification

- `test_search_deduplicates` now passes
- Full suite: 420 passed, 33 skipped, 0 failed