### PR TITLE
feat(cognitive-memory): complete persistent CognitiveMemory for de-fork (#86)

### DIFF
--- a/rust/amplihack-memory/src/cognitive_memory/converters.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/converters.rs
@@ -74,6 +74,7 @@ pub(crate) fn node_to_episodic(props: &HashMap<String, String>) -> EpisodicMemor
         source_label: prop_str(props, "source_label"),
         temporal_index: prop_i64(props, "temporal_index"),
         compressed: prop_str(props, "compressed") == "true",
+        distilled: prop_str(props, "distilled") == "true",
         created_at: prop_datetime(props, "created_at"),
         metadata,
     }

--- a/rust/amplihack-memory/src/cognitive_memory/episodic.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/episodic.rs
@@ -54,6 +54,7 @@ impl CognitiveMemory {
         props.insert("source_label".to_string(), source_label.to_string());
         props.insert("temporal_index".to_string(), tidx.to_string());
         props.insert("compressed".to_string(), "false".to_string());
+        props.insert("distilled".to_string(), "false".to_string());
         props.insert("metadata".to_string(), meta_json);
         props.insert("created_at".to_string(), now.to_string());
 
@@ -94,6 +95,80 @@ impl CognitiveMemory {
     /// Search episodes, excluding compressed ones.
     pub fn search_episodes(&self, limit: usize) -> Vec<EpisodicMemory> {
         self.get_episodes(limit, false)
+    }
+
+    /// Search episodes by case-insensitive substring over content.
+    ///
+    /// Returns un-compressed episodes whose lowercased `content` contains the
+    /// lowercased `query`, newest-first (temporal_index descending), capped at
+    /// `limit`. This is a whole-query substring match — distinct from semantic
+    /// fact search, which OR-matches individual tokens.
+    pub fn search_episodes_by_keyword(&self, query: &str, limit: usize) -> Vec<EpisodicMemory> {
+        let query_lc = query.to_lowercase();
+        let filter = agent_filter(&self.agent_name);
+        let nodes = self
+            .graph
+            .query_nodes(NT_EPISODIC, Some(&filter), usize::MAX);
+
+        let mut episodes: Vec<EpisodicMemory> = nodes
+            .into_iter()
+            .filter(|n| n.properties.get("compressed").is_none_or(|v| v != "true"))
+            .filter(|n| {
+                n.properties
+                    .get("content")
+                    .map(|c| c.to_lowercase().contains(&query_lc))
+                    .unwrap_or(false)
+            })
+            .map(|n| node_to_episodic(&n.properties))
+            .collect();
+
+        episodes.sort_by_key(|e| std::cmp::Reverse(e.temporal_index));
+        episodes.truncate(limit);
+        episodes
+    }
+
+    /// Mark an episode as distilled — a one-way latch that persists across reopen.
+    ///
+    /// Returns `true` when the episode exists, is an episodic node owned by this
+    /// agent, and the flag was persisted. Returns `false` for unknown ids,
+    /// non-episode nodes, or episodes owned by a different agent. Idempotent:
+    /// re-marking an already-distilled episode still returns `true`.
+    pub fn mark_episode_distilled(&mut self, episode_id: &str) -> bool {
+        let Some(node) = self.graph.get_node(episode_id) else {
+            return false;
+        };
+        if node.node_type != NT_EPISODIC {
+            return false;
+        }
+        if node.properties.get("agent_id").map(String::as_str) != Some(self.agent_name.as_str()) {
+            return false;
+        }
+        let mut update = HashMap::new();
+        update.insert("distilled".to_string(), "true".to_string());
+        self.graph.update_node(episode_id, update)
+    }
+
+    /// List this agent's episodes that have not yet been distilled.
+    ///
+    /// Excludes episodes whose `distilled` flag is set, ordered newest-first
+    /// (temporal_index descending) and capped at `limit`. Compressed episodes
+    /// are intentionally NOT excluded: distillation may consume any
+    /// not-yet-distilled episode regardless of its consolidation state.
+    pub fn list_undistilled_episodes(&self, limit: usize) -> Vec<EpisodicMemory> {
+        let filter = agent_filter(&self.agent_name);
+        let nodes = self
+            .graph
+            .query_nodes(NT_EPISODIC, Some(&filter), usize::MAX);
+
+        let mut episodes: Vec<EpisodicMemory> = nodes
+            .into_iter()
+            .filter(|n| n.properties.get("distilled").is_none_or(|v| v != "true"))
+            .map(|n| node_to_episodic(&n.properties))
+            .collect();
+
+        episodes.sort_by_key(|e| std::cmp::Reverse(e.temporal_index));
+        episodes.truncate(limit);
+        episodes
     }
 
     /// Deprecated: renamed to [`search_episodes`](Self::search_episodes).

--- a/rust/amplihack-memory/src/cognitive_memory/procedural.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/procedural.rs
@@ -139,6 +139,17 @@ impl CognitiveMemory {
         procs
     }
 
+    /// Recall procedures matching `query`, reinforcing each match.
+    ///
+    /// On every recall the matched procedures' persisted `usage_count` is
+    /// incremented (reinforcement), and results are returned ordered by
+    /// `usage_count` descending so frequently-used procedures rank first. The
+    /// returned structs carry the pre-increment counts; the reinforced values
+    /// are what persist and drive subsequent orderings.
+    pub fn recall_procedure(&mut self, query: &str, limit: usize) -> Vec<ProceduralMemory> {
+        self.search_procedures_mut(query, limit)
+    }
+
     /// Deprecated: renamed to [`search_procedures`](Self::search_procedures).
     #[deprecated(since = "0.2.0", note = "renamed to search_procedures")]
     pub fn recall_procedures(&self, query: &str, limit: usize) -> Vec<ProceduralMemory> {

--- a/rust/amplihack-memory/src/cognitive_memory/tests/conformance_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/conformance_tests.rs
@@ -1,0 +1,148 @@
+//! End-to-end conformance suite for the persistent `CognitiveMemory` backend.
+//!
+//! Every one of the six cognitive memory types is exercised against a
+//! LadybugDB-backed `CognitiveMemory::open_persistent` instance, after which the
+//! store is DROPPED and RE-OPENED at the same path to prove the system is durable
+//! across runs (issue #86 — Simard's sole memory backend).
+//!
+//! Gated behind the `persistent` feature.
+
+use std::collections::HashMap;
+
+use crate::cognitive_memory::CognitiveMemory;
+
+fn steps(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn all_six_memory_types_persist_across_drop_and_reopen() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("conformance.ladybug");
+
+    let episode_id;
+
+    // --- Phase 1: populate every memory type, then drop the store. ---
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "conformance-agent").unwrap();
+
+        // sensory: one durable, one already-expired (deterministic TTL, no sleeps).
+        cm.store_sensory("text", "durable observation", 3600)
+            .unwrap();
+        cm.store_sensory("text", "expired observation", 0).unwrap();
+
+        // working
+        cm.store_working("goal", "finish the migration", "task-1", 0.95)
+            .unwrap();
+
+        // episodic: with metadata and an auto-assigned temporal index.
+        let mut meta = HashMap::new();
+        meta.insert("severity".to_string(), serde_json::json!("high"));
+        episode_id = cm
+            .store_episode("migrated the database", "ops", None, Some(&meta))
+            .unwrap();
+
+        // semantic
+        cm.store_fact(
+            "rust",
+            "Rust has no garbage collector",
+            0.9,
+            "book",
+            Some(&steps(&["rust", "memory"])),
+            None,
+        )
+        .unwrap();
+
+        // procedural
+        cm.store_procedure("deploy", &steps(&["build", "ship"]), None)
+            .unwrap();
+
+        // prospective
+        cm.store_prospective(
+            "watch for outage",
+            "service outage detected",
+            "page on-call",
+            5,
+        )
+        .unwrap();
+
+        cm.close();
+    } // CognitiveMemory dropped -> LadybugDB flushed to disk.
+
+    // --- Phase 2: reopen and assert everything survived with fields intact. ---
+    let mut cm = CognitiveMemory::open_persistent(&path, "conformance-agent").unwrap();
+
+    // sensory: the durable item is recalled; the expired item prunes.
+    let sensory = cm.get_sensory(10);
+    assert_eq!(
+        sensory.len(),
+        1,
+        "only the non-expired sensory item survives recall"
+    );
+    assert_eq!(sensory[0].raw_data, "durable observation");
+    assert_eq!(
+        cm.prune_expired_sensory(),
+        1,
+        "the persisted-but-expired sensory item is pruned after reopen"
+    );
+
+    // working: the slot is recalled with its fields intact.
+    let working = cm.get_working("task-1");
+    assert_eq!(working.len(), 1);
+    assert_eq!(working[0].content, "finish the migration");
+    assert!((working[0].relevance - 0.95).abs() < 1e-9);
+
+    // episodic: content + metadata + temporal index intact; keyword-searchable; undistilled.
+    let episodes = cm.search_episodes(10);
+    assert_eq!(episodes.len(), 1);
+    assert_eq!(episodes[0].content, "migrated the database");
+    assert_eq!(episodes[0].node_id, episode_id);
+    assert!(episodes[0].temporal_index > 0);
+    assert!(!episodes[0].distilled);
+    assert_eq!(
+        episodes[0]
+            .metadata
+            .get("severity")
+            .and_then(|v| v.as_str()),
+        Some("high")
+    );
+    assert_eq!(cm.search_episodes_by_keyword("database", 10).len(), 1);
+    assert_eq!(cm.list_undistilled_episodes(10).len(), 1);
+
+    // distillation latch works within the reopened store.
+    assert!(cm.mark_episode_distilled(&episode_id));
+    assert!(cm.list_undistilled_episodes(10).is_empty());
+
+    // semantic: tokenized OR recall matches the persisted fact.
+    let facts = cm.search_facts("rust nonexistent", 10, 0.0);
+    assert_eq!(facts.len(), 1, "OR-token recall matches the persisted fact");
+    assert_eq!(facts[0].concept, "rust");
+
+    // procedural: recall reinforces usage (persisted increment).
+    let procs = cm.recall_procedure("deploy", 10);
+    assert_eq!(procs.len(), 1);
+    assert_eq!(
+        cm.search_procedures("deploy", 10)[0].usage_count,
+        1,
+        "recall must reinforce the procedure's usage_count"
+    );
+
+    // prospective: trigger fires on keyword overlap, is one-shot, then resolves.
+    let fired = cm.check_triggers("we have a service outage right now");
+    assert_eq!(fired.len(), 1);
+    assert_eq!(fired[0].status, "triggered");
+    assert!(
+        cm.check_triggers("another service outage").is_empty(),
+        "a triggered prospective is one-shot and must not re-fire"
+    );
+    cm.resolve_prospective(&fired[0].node_id);
+
+    // Every type is counted in the stats after the round-trip.
+    let stats = cm.get_memory_stats();
+    assert_eq!(stats.get("sensory"), Some(&1));
+    assert_eq!(stats.get("working"), Some(&1));
+    assert_eq!(stats.get("episodic"), Some(&1));
+    assert_eq!(stats.get("semantic"), Some(&1));
+    assert_eq!(stats.get("procedural"), Some(&1));
+    assert_eq!(stats.get("prospective"), Some(&1));
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/episodic_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/episodic_tests.rs
@@ -169,3 +169,67 @@ fn test_consolidate_episodes_creates_summary() {
     let uncompressed = cm.get_episodes(10, false);
     assert_eq!(uncompressed.len(), 2);
 }
+
+// -- distilled-episode flag (in-memory mirror of the persistent contract) --
+
+#[test]
+fn test_episode_distilled_defaults_false_and_marks() {
+    let mut cm = make_cm();
+    let ep = cm.store_episode("to distill", "src", None, None).unwrap();
+
+    let undistilled = cm.list_undistilled_episodes(10);
+    assert_eq!(undistilled.len(), 1);
+    assert!(!undistilled[0].distilled, "fresh episodes are undistilled");
+
+    assert!(cm.mark_episode_distilled(&ep));
+    // Idempotent latch.
+    assert!(cm.mark_episode_distilled(&ep));
+
+    assert!(cm.search_episodes(10)[0].distilled);
+    assert!(cm.list_undistilled_episodes(10).is_empty());
+}
+
+#[test]
+fn test_mark_episode_distilled_rejects_unknown_id() {
+    let mut cm = make_cm();
+    assert!(!cm.mark_episode_distilled("epi_missing"));
+}
+
+#[test]
+fn test_list_undistilled_excludes_distilled_newest_first_limit() {
+    let mut cm = make_cm();
+    let e1 = cm.store_episode("first", "src", None, None).unwrap();
+    cm.store_episode("second", "src", None, None).unwrap();
+    cm.store_episode("third", "src", None, None).unwrap();
+
+    assert!(cm.mark_episode_distilled(&e1));
+
+    let undistilled = cm.list_undistilled_episodes(10);
+    assert_eq!(undistilled.len(), 2);
+    assert_eq!(undistilled[0].content, "third");
+    assert_eq!(undistilled[1].content, "second");
+
+    let limited = cm.list_undistilled_episodes(1);
+    assert_eq!(limited.len(), 1);
+    assert_eq!(limited[0].content, "third");
+}
+
+#[test]
+fn test_search_episodes_by_keyword_case_insensitive_substring() {
+    let mut cm = make_cm();
+    cm.store_episode("Deployed the Payment service to PROD", "ops", None, None)
+        .unwrap();
+    cm.store_episode("rolled back the cache layer", "ops", None, None)
+        .unwrap();
+    cm.store_episode("Deployed the Payment service again", "ops", None, None)
+        .unwrap();
+
+    let hits = cm.search_episodes_by_keyword("payment", 10);
+    assert_eq!(hits.len(), 2);
+    assert_eq!(hits[0].content, "Deployed the Payment service again");
+    assert_eq!(hits[1].content, "Deployed the Payment service to PROD");
+
+    assert_eq!(cm.search_episodes_by_keyword("prod", 10).len(), 1);
+    assert!(cm.search_episodes_by_keyword("kubernetes", 10).is_empty());
+    assert_eq!(cm.search_episodes_by_keyword("payment", 1).len(), 1);
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "persistent")]
+mod conformance_tests;
 mod episodic_tests;
 mod integration_tests;
 #[cfg(feature = "persistent")]

--- a/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 
 use crate::cognitive_memory::CognitiveMemory;
+use crate::cognitive_memory::WORKING_MEMORY_CAPACITY;
 
 fn temp_db() -> (tempfile::TempDir, std::path::PathBuf) {
     let tmp = tempfile::tempdir().unwrap();
@@ -266,4 +267,354 @@ fn metadata_round_trips_through_persistence() {
             .unwrap(),
         "high"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Gap 1: distilled-episode flag (mark_episode_distilled / list_undistilled_episodes)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distilled_flag_persists_across_reopen() {
+    let (_tmp, path) = temp_db();
+    let ep;
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        ep = cm
+            .store_episode("episode to distill", "src", Some(1), None)
+            .unwrap();
+
+        // A freshly stored episode is undistilled.
+        let undistilled = cm.list_undistilled_episodes(10);
+        assert_eq!(undistilled.len(), 1);
+        assert!(!undistilled[0].distilled);
+
+        // Mark it distilled (one-way latch).
+        assert!(cm.mark_episode_distilled(&ep));
+        cm.close();
+    } // dropped -> flushed to disk
+
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    // The distilled flag survived the reopen.
+    let all = cm.search_episodes(10);
+    assert_eq!(all.len(), 1);
+    assert!(
+        all[0].distilled,
+        "distilled flag must persist across close + reopen"
+    );
+    // And the distilled episode is excluded from the undistilled list.
+    assert!(
+        cm.list_undistilled_episodes(10).is_empty(),
+        "distilled episodes must not appear in list_undistilled_episodes"
+    );
+}
+
+#[test]
+fn list_undistilled_episodes_orders_newest_first_and_honors_limit() {
+    let (_tmp, path) = temp_db();
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+
+    let e1 = cm.store_episode("first", "src", None, None).unwrap(); // temporal_index 1
+    cm.store_episode("second", "src", None, None).unwrap(); // 2
+    cm.store_episode("third", "src", None, None).unwrap(); // 3
+
+    // Distill the oldest episode.
+    assert!(cm.mark_episode_distilled(&e1));
+
+    let undistilled = cm.list_undistilled_episodes(10);
+    assert_eq!(undistilled.len(), 2, "distilled episode must be excluded");
+    // Newest-first ordering by temporal_index.
+    assert_eq!(undistilled[0].content, "third");
+    assert_eq!(undistilled[1].content, "second");
+    assert!(undistilled.iter().all(|e| !e.distilled));
+
+    // The limit argument is honored.
+    let limited = cm.list_undistilled_episodes(1);
+    assert_eq!(limited.len(), 1);
+    assert_eq!(limited[0].content, "third");
+}
+
+#[test]
+fn mark_episode_distilled_latch_and_ownership() {
+    let (_tmp, path) = temp_db();
+    let mut alice = CognitiveMemory::open_persistent(&path, "alice").unwrap();
+    let ep = alice
+        .store_episode("alice event", "src", Some(1), None)
+        .unwrap();
+
+    // Unknown id is rejected.
+    assert!(!alice.mark_episode_distilled("epi_does_not_exist"));
+
+    // Owned episode is marked, and the latch is idempotent (stays true).
+    assert!(alice.mark_episode_distilled(&ep));
+    assert!(alice.mark_episode_distilled(&ep));
+
+    // A different agent sharing the DB cannot distill alice's episode.
+    let mut bob = CognitiveMemory::open_persistent(&path, "bob").unwrap();
+    assert!(
+        !bob.mark_episode_distilled(&ep),
+        "cross-agent distill must be rejected (ownership check)"
+    );
+
+    // Alice's episode is still distilled; bob owns nothing undistilled.
+    assert!(alice.list_undistilled_episodes(10).is_empty());
+    assert!(bob.list_undistilled_episodes(10).is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Gap 2: procedure reinforcement on recall (usage_count increments + ordering)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn recall_procedure_increments_usage_and_persists() {
+    let (_tmp, path) = temp_db();
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        cm.store_procedure("deploy", &steps(&["build", "ship"]), None)
+            .unwrap();
+
+        // First recall reinforces the matched procedure (stored count -> 1).
+        let r1 = cm.recall_procedure("deploy", 10);
+        assert_eq!(r1.len(), 1);
+        assert_eq!(cm.search_procedures("deploy", 10)[0].usage_count, 1);
+
+        // Second recall bumps it again (stored count -> 2).
+        cm.recall_procedure("deploy", 10);
+        assert_eq!(cm.search_procedures("deploy", 10)[0].usage_count, 2);
+        cm.close();
+    }
+
+    // The reinforced usage_count persisted across the reopen.
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    assert_eq!(
+        cm.search_procedures("deploy", 10)[0].usage_count,
+        2,
+        "reinforced usage_count must persist across reopen"
+    );
+}
+
+#[test]
+fn recall_procedure_orders_by_usage_desc_and_persists() {
+    let (_tmp, path) = temp_db();
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        // Both procedures share the keyword "shared" via their steps.
+        cm.store_procedure("alpha task", &steps(&["shared work"]), None)
+            .unwrap();
+        cm.store_procedure("beta task", &steps(&["shared work"]), None)
+            .unwrap();
+
+        // Reinforce alpha three times via a query that matches only alpha.
+        for _ in 0..3 {
+            let only_alpha = cm.recall_procedure("alpha", 10);
+            assert_eq!(only_alpha.len(), 1, "'alpha' matches only the alpha task");
+            assert_eq!(only_alpha[0].name, "alpha task");
+        }
+
+        // A query matching both returns them ordered by usage_count descending.
+        let both = cm.recall_procedure("shared", 10);
+        assert_eq!(both.len(), 2);
+        assert_eq!(
+            both[0].name, "alpha task",
+            "more-used procedure ranks first"
+        );
+        assert_eq!(both[1].name, "beta task");
+        assert_eq!(both[0].usage_count, 3);
+        assert_eq!(both[1].usage_count, 0);
+        cm.close();
+    }
+
+    // After reopen the persisted usage drives the same ordering.
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    let ranked = cm.search_procedures("shared", 10);
+    assert_eq!(ranked.len(), 2);
+    assert_eq!(ranked[0].name, "alpha task");
+    assert_eq!(ranked[1].name, "beta task");
+    // alpha: 3 (alpha-only recalls) + 1 (the shared recall) = 4; beta: 1 (shared recall).
+    assert_eq!(ranked[0].usage_count, 4);
+    assert_eq!(ranked[1].usage_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Gap 3: episodic content keyword search (case-insensitive substring)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_episodes_by_keyword_is_case_insensitive_substring() {
+    let (_tmp, path) = temp_db();
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+
+    cm.store_episode("Deployed the Payment service to PROD", "ops", None, None)
+        .unwrap();
+    cm.store_episode("rolled back the cache layer", "ops", None, None)
+        .unwrap();
+    cm.store_episode("Deployed the Payment service again", "ops", None, None)
+        .unwrap();
+
+    // Case-insensitive substring match over content, newest-first.
+    let hits = cm.search_episodes_by_keyword("payment", 10);
+    assert_eq!(hits.len(), 2);
+    assert_eq!(hits[0].content, "Deployed the Payment service again");
+    assert_eq!(hits[1].content, "Deployed the Payment service to PROD");
+
+    // Substring (not whole-token) match, case-insensitive.
+    let prod = cm.search_episodes_by_keyword("prod", 10);
+    assert_eq!(prod.len(), 1);
+    assert_eq!(prod[0].content, "Deployed the Payment service to PROD");
+
+    // A non-matching query returns nothing.
+    assert!(cm.search_episodes_by_keyword("kubernetes", 10).is_empty());
+
+    // The limit argument is honored.
+    assert_eq!(cm.search_episodes_by_keyword("payment", 1).len(), 1);
+
+    // Compressed episodes are excluded from keyword search.
+    cm.consolidate_episodes::<fn(&[String]) -> String>(3, None)
+        .unwrap();
+    assert!(
+        cm.search_episodes_by_keyword("payment", 10).is_empty(),
+        "compressed episodes must be excluded from keyword search"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sensory + working durability (round-trip across reopen)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sensory_round_trip_and_ttl_prune_across_reopen() {
+    let (_tmp, path) = temp_db();
+    let valid_id;
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        // Long TTL survives; non-positive TTL is already expired (deterministic, no sleep).
+        valid_id = cm.store_sensory("text", "keep me", 3600).unwrap();
+        cm.store_sensory("text", "drop me", 0).unwrap();
+
+        // The expired item is never returned by get_sensory, even before prune.
+        let live = cm.get_sensory(10);
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].raw_data, "keep me");
+        cm.close();
+    }
+
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    // The valid item survived the reopen.
+    let recalled = cm.get_sensory(10);
+    assert_eq!(recalled.len(), 1);
+    assert_eq!(recalled[0].node_id, valid_id);
+    assert_eq!(recalled[0].raw_data, "keep me");
+
+    // Pruning removes the persisted-but-expired item and keeps the valid one.
+    let pruned = cm.prune_expired_sensory();
+    assert_eq!(pruned, 1, "exactly the expired sensory item is pruned");
+    assert_eq!(cm.get_sensory(10).len(), 1);
+}
+
+#[test]
+fn working_round_trip_and_capacity_eviction_across_reopen() {
+    let (_tmp, path) = temp_db();
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        cm.store_working("goal", "primary goal", "task-1", 0.9)
+            .unwrap();
+        cm.store_working("context", "some context", "task-1", 0.4)
+            .unwrap();
+        // A different task is isolated.
+        cm.store_working("goal", "other-task goal", "task-2", 0.5)
+            .unwrap();
+        cm.close();
+    }
+
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    // Slots persisted and are returned ordered by relevance descending.
+    let slots = cm.get_working("task-1");
+    assert_eq!(slots.len(), 2);
+    assert_eq!(slots[0].content, "primary goal");
+    assert_eq!(slots[1].content, "some context");
+    assert_eq!(cm.get_working("task-2").len(), 1);
+
+    // Capacity eviction: filling beyond capacity drops the least-relevant slot.
+    cm.clear_working("task-1");
+    for i in 0..WORKING_MEMORY_CAPACITY {
+        // Relevance increases with i, so "slot-0" is the least relevant.
+        let rel = (i as f64 + 1.0) / (WORKING_MEMORY_CAPACITY as f64 + 1.0);
+        cm.store_working("context", &format!("slot-{i}"), "task-cap", rel)
+            .unwrap();
+    }
+    assert_eq!(cm.get_working("task-cap").len(), WORKING_MEMORY_CAPACITY);
+
+    // One more high-relevance slot evicts the least-relevant existing slot ("slot-0").
+    cm.store_working("context", "newcomer", "task-cap", 1.0)
+        .unwrap();
+    let capped = cm.get_working("task-cap");
+    assert_eq!(
+        capped.len(),
+        WORKING_MEMORY_CAPACITY,
+        "working capacity must be enforced"
+    );
+    assert!(
+        !capped.iter().any(|s| s.content == "slot-0"),
+        "least-relevant slot must be evicted at capacity"
+    );
+    assert!(capped.iter().any(|s| s.content == "newcomer"));
+}
+
+// ---------------------------------------------------------------------------
+// Gap 4: episode temporal ordering is monotonic and persists
+// ---------------------------------------------------------------------------
+
+#[test]
+fn episode_temporal_index_is_monotonic_and_persists() {
+    let (_tmp, path) = temp_db();
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        cm.store_episode("e1", "src", None, None).unwrap();
+        cm.store_episode("e2", "src", None, None).unwrap();
+        cm.store_episode("e3", "src", None, None).unwrap();
+
+        let eps = cm.get_episodes(10, false);
+        // Newest-first, with strictly increasing temporal indices.
+        assert_eq!(eps[0].content, "e3");
+        assert_eq!(eps[1].content, "e2");
+        assert_eq!(eps[2].content, "e1");
+        assert!(eps[0].temporal_index > eps[1].temporal_index);
+        assert!(eps[1].temporal_index > eps[2].temporal_index);
+        // Auto-index must be a real monotonic counter, never the always-zero default.
+        assert!(eps.iter().all(|e| e.temporal_index > 0));
+        cm.close();
+    }
+
+    // Counter recovers after reopen: a new auto-index exceeds all persisted ones.
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    let prev_max = cm
+        .get_episodes(10, false)
+        .iter()
+        .map(|e| e.temporal_index)
+        .max()
+        .unwrap();
+    cm.store_episode("e4", "src", None, None).unwrap();
+    let e4 = cm
+        .get_episodes(10, false)
+        .into_iter()
+        .find(|e| e.content == "e4")
+        .unwrap();
+    assert!(
+        e4.temporal_index > prev_max,
+        "auto temporal_index must keep increasing across reopen"
+    );
+
+    // Consolidation is deterministic oldest-first: the two oldest are compressed.
+    let cons = cm
+        .consolidate_episodes(2, Some(|c: &[String]| c.join(",")))
+        .unwrap()
+        .unwrap();
+    assert!(cons.starts_with("con_"));
+    let remaining = cm.get_episodes(10, false);
+    assert!(remaining.iter().any(|e| e.content == "e3"));
+    assert!(remaining.iter().any(|e| e.content == "e4"));
+    assert!(
+        !remaining.iter().any(|e| e.content == "e1"),
+        "oldest episode (e1) must be consolidated first"
+    );
+    assert!(!remaining.iter().any(|e| e.content == "e2"));
 }

--- a/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
@@ -618,3 +618,58 @@ fn episode_temporal_index_is_monotonic_and_persists() {
     );
     assert!(!remaining.iter().any(|e| e.content == "e2"));
 }
+
+// ---------------------------------------------------------------------------
+// Cypher-injection safety: special characters round-trip through persistence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn special_characters_round_trip_safely() {
+    let (_tmp, path) = temp_db();
+
+    // Content and a procedure name laced with Cypher-significant characters:
+    // single quotes, double quotes, backslashes, and a newline. If inputs were
+    // not escaped these would corrupt the generated Cypher (or inject).
+    let nasty_content = "O'Brien said: \"DROP\" \\ all // tables\nline2";
+    let nasty_name = "deploy '; MATCH (n) DETACH DELETE n; //";
+    let nasty_step = "rm -rf / && echo \"don't\"";
+    let ep;
+
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        ep = cm
+            .store_episode(nasty_content, "src", Some(1), None)
+            .unwrap();
+        cm.store_procedure(nasty_name, &steps(&[nasty_step]), None)
+            .unwrap();
+        cm.store_fact("c", nasty_content, 0.9, "s", None, None)
+            .unwrap();
+        cm.close();
+    }
+
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+
+    // The episode survived intact (no truncation, no corruption, no deletion).
+    let episodes = cm.search_episodes(10);
+    assert_eq!(episodes.len(), 1, "no injection deleted the data");
+    assert_eq!(episodes[0].node_id, ep);
+    assert_eq!(episodes[0].content, nasty_content);
+
+    // Keyword search over the escaped content still matches a literal substring.
+    assert_eq!(cm.search_episodes_by_keyword("O'Brien", 10).len(), 1);
+
+    // The procedure name and step round-tripped verbatim.
+    let procs = cm.search_procedures("deploy", 10);
+    assert_eq!(procs.len(), 1);
+    assert_eq!(procs[0].name, nasty_name);
+    assert_eq!(procs[0].steps, steps(&[nasty_step]));
+
+    // Distillation still works on the special-character episode.
+    assert!(cm.mark_episode_distilled(&ep));
+    assert!(cm.list_undistilled_episodes(10).is_empty());
+
+    // The fact persisted with its special-character content intact.
+    let facts = cm.get_all_facts(10);
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].content, nasty_content);
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/procedural_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/procedural_tests.rs
@@ -133,3 +133,35 @@ fn test_store_procedure_is_idempotent_by_name() {
         vec!["step-a".to_string(), "step-b".to_string()]
     );
 }
+
+// -- procedure reinforcement on recall (in-memory mirror) --
+
+#[test]
+fn test_recall_procedure_increments_and_orders_by_usage() {
+    let mut cm = make_cm();
+    cm.store_procedure("alpha task", &["shared work".into()], None)
+        .unwrap();
+    cm.store_procedure("beta task", &["shared work".into()], None)
+        .unwrap();
+
+    // Reinforce alpha via a query that matches only alpha.
+    for _ in 0..3 {
+        let only_alpha = cm.recall_procedure("alpha", 10);
+        assert_eq!(only_alpha.len(), 1);
+        assert_eq!(only_alpha[0].name, "alpha task");
+    }
+
+    // A query matching both returns them ordered by usage_count descending,
+    // carrying pre-increment counts.
+    let both = cm.recall_procedure("shared", 10);
+    assert_eq!(both.len(), 2);
+    assert_eq!(both[0].name, "alpha task");
+    assert_eq!(both[0].usage_count, 3);
+    assert_eq!(both[1].name, "beta task");
+    assert_eq!(both[1].usage_count, 0);
+
+    // The reinforced (post-increment) counts now drive ordering.
+    let ranked = cm.search_procedures("shared", 10);
+    assert_eq!(ranked[0].usage_count, 4);
+    assert_eq!(ranked[1].usage_count, 1);
+}

--- a/rust/amplihack-memory/src/memory_types.rs
+++ b/rust/amplihack-memory/src/memory_types.rs
@@ -138,6 +138,14 @@ pub struct EpisodicMemory {
     pub temporal_index: i64,
     /// Whether this episode has been compressed during consolidation.
     pub compressed: bool,
+    /// Whether this episode has been distilled into procedural knowledge.
+    ///
+    /// One-way latch: set by `mark_episode_distilled` and never cleared. Used by
+    /// the episode→procedure distillation pipeline to skip already-processed
+    /// episodes. Defaults to `false` for episodes stored before this field
+    /// existed.
+    #[serde(default)]
+    pub distilled: bool,
     /// When this episode was recorded.
     pub created_at: DateTime<Utc>,
     /// Arbitrary key-value metadata attached to the episode.

--- a/rust/amplihack-memory/src/python/cognitive.rs
+++ b/rust/amplihack-memory/src/python/cognitive.rs
@@ -117,6 +117,36 @@ impl PyCognitiveMemory {
             .collect()
     }
 
+    /// Search episodes by case-insensitive substring over content.
+    #[pyo3(signature = (query, limit=10))]
+    fn search_episodes_by_keyword(
+        &self,
+        py: Python<'_>,
+        query: &str,
+        limit: usize,
+    ) -> PyResult<Vec<PyObject>> {
+        self.inner
+            .search_episodes_by_keyword(query, limit)
+            .iter()
+            .map(|e| episode_to_dict(py, e))
+            .collect()
+    }
+
+    /// Mark an episode as distilled (one-way latch). Returns whether it was set.
+    fn mark_episode_distilled(&mut self, episode_id: &str) -> bool {
+        self.inner.mark_episode_distilled(episode_id)
+    }
+
+    /// List episodes that have not yet been distilled (newest-first).
+    #[pyo3(signature = (limit=10))]
+    fn list_undistilled_episodes(&self, py: Python<'_>, limit: usize) -> PyResult<Vec<PyObject>> {
+        self.inner
+            .list_undistilled_episodes(limit)
+            .iter()
+            .map(|e| episode_to_dict(py, e))
+            .collect()
+    }
+
     // -- Semantic --
 
     /// Store a semantic fact.
@@ -189,6 +219,21 @@ impl PyCognitiveMemory {
     ) -> PyResult<Vec<PyObject>> {
         self.inner
             .search_procedures_mut(query, limit)
+            .iter()
+            .map(|p| procedure_to_dict(py, p))
+            .collect()
+    }
+
+    /// Recall procedures matching a query, reinforcing the matches' usage_count.
+    #[pyo3(signature = (query, limit=5))]
+    fn recall_procedure(
+        &mut self,
+        py: Python<'_>,
+        query: &str,
+        limit: usize,
+    ) -> PyResult<Vec<PyObject>> {
+        self.inner
+            .recall_procedure(query, limit)
             .iter()
             .map(|p| procedure_to_dict(py, p))
             .collect()

--- a/rust/amplihack-memory/src/python/converters.rs
+++ b/rust/amplihack-memory/src/python/converters.rs
@@ -43,6 +43,7 @@ pub(crate) fn episode_to_dict(py: Python<'_>, e: &EpisodicMemory) -> PyResult<Py
     d.set_item("source_label", &e.source_label)?;
     d.set_item("temporal_index", e.temporal_index)?;
     d.set_item("compressed", e.compressed)?;
+    d.set_item("distilled", e.distilled)?;
     d.set_item("created_at", e.created_at.to_rfc3339())?;
     d.set_item("metadata", hashmap_to_pydict(py, &e.metadata)?)?;
     Ok(d.to_object(py))


### PR DESCRIPTION
## Summary

Closes the remaining functional gaps in the persistent Rust `CognitiveMemory` (LadybugDB/`lbug`-backed `GraphStore`) so **all six memory types store, recall, evolve, and PERSIST across runs**. This is the final functional step toward amplihack-memory-lib becoming Simard's **sole** memory backend (replacing its private fork).

Builds on the persistent `GraphStore` + pluggable `CognitiveMemory` from #86 (constructors: `new` = in-memory, `with_store`, `open_persistent` behind feature `persistent`). **Additive and backward compatible** — the in-memory default path is unchanged.

## Strict TDD (red → green)

- **Red:** `ae706e8` — failing tests against `CognitiveMemory::open_persistent(tmpdir)`, gated on `persistent`. Verified red: `cargo test --features persistent --no-run` produced 28 compile errors mapping to the missing symbols.
- **Green:** `1c69eae` — implementation in this PR. All suites now pass.

## Gaps closed

| # | Gap | What landed |
|---|-----|-------------|
| 1 | **Distilled-episode flag** (highest priority) | New persisted `EpisodicMemory.distilled` (`#[serde(default)]`, old nodes read as `false`). `store_episode` writes `distilled=false`; `mark_episode_distilled(&mut)` is a one-way latch with an **agent-ownership check** (cross-agent distill rejected); `list_undistilled_episodes(&self)` excludes distilled, newest-first, honors `limit`. Unblocks episode→procedure distillation (Simard's adapter currently no-ops these). |
| 2 | **Procedure reinforcement** | `recall_procedure(&mut, query, limit)` increments matched procedures' **persisted** `usage_count` and returns them ordered by `usage_count` descending. |
| 3 | **Episodic content keyword search** | `search_episodes_by_keyword(&self)` — case-insensitive **whole-query substring** over content (distinct from facts' tokenized-OR), excludes compressed, newest-first, honors `limit`. |
| 4 | **Episode temporal ordering** | `store_episode` assigns a **monotonic, non-zero** `temporal_index` that recovers across reopen; consolidation is deterministic oldest-first, recall newest-first. Now covered by tests. |
| 5 | **Cypher-injection safety** | Inputs are escaped (`escape_cypher`); added a special-character (`'`, `"`, `\`, newline) round-trip test proving safe persist/reopen with content intact and no injection. |
| 6 | **Full per-type persistence + recall** | Verified each type via per-type round-trip tests + an end-to-end conformance suite that **drops and re-opens** the store at the same path. |

## API coherence (PyO3)

Exposed `mark_episode_distilled`, `list_undistilled_episodes`, `recall_procedure`, and `search_episodes_by_keyword`; `episode_to_dict` now includes `distilled` — so a consumer (Simard) can drive every memory type from Python.

## Test evidence

- `tests/conformance_tests.rs` (gated on `persistent`): all six types stored, then **dropped + re-opened**, proving durability across runs — including sensory TTL prune, working capacity eviction, episodic metadata/temporal/distilled, semantic OR-recall, procedural reinforcement, and one-shot prospective triggers.
- `cargo test --lib` → **454 passed** (449 baseline + 5 new in-memory mirrors; zero regressions)
- `cargo test --features persistent` → **484 passed**
- `cargo test --features python` → **456 passed**
- `cargo fmt --check`, `cargo clippy` (default + python, `-D warnings`), `cargo doc --no-deps` → clean

## Files

- `src/memory_types.rs` — `EpisodicMemory.distilled`
- `src/cognitive_memory/converters.rs` — read `distilled`
- `src/cognitive_memory/episodic.rs` — persist `distilled`; `mark_episode_distilled`, `list_undistilled_episodes`, `search_episodes_by_keyword`
- `src/cognitive_memory/procedural.rs` — `recall_procedure`
- `src/python/{cognitive,converters}.rs` — bindings + `distilled` in episode dict
- `src/cognitive_memory/tests/{persistent,conformance,episodic,procedural}_tests.rs` — tests

Refs #86.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>