### PR TITLE
fix(persistent): recover from corrupt WAL + checkpoint API (durability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Critical durability bug (#88):** the persistent `CognitiveMemory`
+  (`LbugGraphStore`) could no longer be opened after an unclean shutdown left
+  the LadybugDB write-ahead log (WAL) partially written — `open_persistent`
+  crashed on a C++ WAL-replay assertion and the only "recovery" was deleting the
+  WAL, losing every uncheckpointed record. `open_persistent` now transparently
+  recovers: the unreplayable WAL is quarantined to `<wal>.corrupt-<timestamp>`
+  (moved aside, never deleted), the recoverable prefix is replayed, and a
+  checkpoint folds the survivors into the main database file.
+
+### Added
+- `CognitiveMemory::open_persistent_with_recovery` and
+  `LbugGraphStore::open_with_recovery` — explicit corrupt-WAL recovery entry
+  points returning a structured `WalRecovery` report (`WalRecoveryOutcome`,
+  recovered record count, quarantine path). `open_persistent` delegates to the
+  recovery path so existing callers gain crash-resilience with no code change.
+- `CognitiveMemory::checkpoint()` / `GraphStore::checkpoint()` — force-flush the
+  WAL into the durable store so a clean reopen needs no replay (no-op for the
+  in-memory backend).
+- Automatic checkpointing every `AUTO_CHECKPOINT_WRITES` (128) writes and on
+  `close` / `Drop`, bounding how much data an unclean shutdown can strand in the
+  WAL.
+
 ## [0.4.0] - 2026-03-13
 
 ### Added

--- a/rust/amplihack-memory/README.md
+++ b/rust/amplihack-memory/README.md
@@ -274,7 +274,8 @@ killed mid-write and the write-ahead log (WAL) is left partially written:
   no-op for the in-memory backend.
 - **Bounded loss / auto-checkpoint.** The store auto-checkpoints after every
   `AUTO_CHECKPOINT_WRITES` (128) mutating operations and always on `close` /
-  `Drop`, and lets LadybugDB checkpoint by size as a safety net. An unclean
+  `Drop`, and leaves LadybugDB's own `auto_checkpoint` enabled to bound the WAL
+  as a safety net. An unclean
   shutdown therefore strands at most a small, bounded number of writes in the
   WAL rather than every uncheckpointed record.
 

--- a/rust/amplihack-memory/README.md
+++ b/rust/amplihack-memory/README.md
@@ -261,10 +261,10 @@ procedure storage). See `src/graph/lbug_store/` for details.
 The persistent backend is hardened against the failure mode where a process is
 killed mid-write and the write-ahead log (WAL) is left partially written:
 
-- **Corrupt-WAL recovery.** `open_persistent` first attempts a strict open; if
-  the WAL cannot be replayed (the failure that previously made the store
-  permanently unopenable and crashed with a C++ assertion), it transparently
-  falls back to `open_persistent_with_recovery`. The unreplayable WAL is **moved
+- **Corrupt-WAL recovery.** `open_persistent` delegates to
+  `open_persistent_with_recovery`, which first attempts a strict open; if the WAL
+  cannot be replayed (the failure that previously made the store permanently
+  unopenable and crashed with a C++ assertion), the unreplayable WAL is **moved
   aside** to `<wal>.corrupt-<timestamp>` (never deleted), the recoverable prefix
   is replayed, and a checkpoint folds it into the main database file. A
   structured `warn!` reports how many records survived. A clean open is
@@ -275,9 +275,8 @@ killed mid-write and the write-ahead log (WAL) is left partially written:
 - **Bounded loss / auto-checkpoint.** The store auto-checkpoints after every
   `AUTO_CHECKPOINT_WRITES` (128) mutating operations and always on `close` /
   `Drop`, and leaves LadybugDB's own `auto_checkpoint` enabled to bound the WAL
-  as a safety net. An unclean
-  shutdown therefore strands at most a small, bounded number of writes in the
-  WAL rather than every uncheckpointed record.
+  as a safety net. An unclean shutdown therefore strands at most a small,
+  bounded number of writes in the WAL rather than every uncheckpointed record.
 
 ### Pattern detection
 

--- a/rust/amplihack-memory/README.md
+++ b/rust/amplihack-memory/README.md
@@ -234,9 +234,11 @@ let mut mem = CognitiveMemory::new("agent-1")?;
 let mut mem = CognitiveMemory::open_persistent("/var/lib/agent/cognitive.ladybug", "agent-1")?;
 mem.store_fact("rust", "memory safety without a GC", 0.9, "book", None, None)?;
 mem.store_procedure("deploy", &["build".into(), "rollout".into()], None)?;
-drop(mem); // flushes to disk
+mem.checkpoint()?; // force-flush the WAL into the main DB file (bounded crash loss)
+drop(mem);         // also checkpoints on drop
 
 // Reopen later — facts, procedures, episodes and triggers are all still there.
+// This transparently recovers from a WAL left corrupt by an unclean shutdown.
 let mem = CognitiveMemory::open_persistent("/var/lib/agent/cognitive.ladybug", "agent-1")?;
 assert_eq!(mem.search_facts("safety", 10, 0.0).len(), 1);
 ```
@@ -253,6 +255,28 @@ barriers, crash-atomic multi-statement transactions, reopen-safe schema
 introspection, agent isolation, and the corrected retrieval semantics
 (tokenized multi-word recall, keyword-overlap trigger matching, idempotent
 procedure storage). See `src/graph/lbug_store/` for details.
+
+#### Durability & crash recovery
+
+The persistent backend is hardened against the failure mode where a process is
+killed mid-write and the write-ahead log (WAL) is left partially written:
+
+- **Corrupt-WAL recovery.** `open_persistent` first attempts a strict open; if
+  the WAL cannot be replayed (the failure that previously made the store
+  permanently unopenable and crashed with a C++ assertion), it transparently
+  falls back to `open_persistent_with_recovery`. The unreplayable WAL is **moved
+  aside** to `<wal>.corrupt-<timestamp>` (never deleted), the recoverable prefix
+  is replayed, and a checkpoint folds it into the main database file. A
+  structured `warn!` reports how many records survived. A clean open is
+  unaffected: no artifact is written and no warning emitted.
+- **Checkpoint API.** `CognitiveMemory::checkpoint()` forces the WAL into the
+  main database file, so a subsequent clean reopen needs no replay. It is a
+  no-op for the in-memory backend.
+- **Bounded loss / auto-checkpoint.** The store auto-checkpoints after every
+  `AUTO_CHECKPOINT_WRITES` (128) mutating operations and always on `close` /
+  `Drop`, and lets LadybugDB checkpoint by size as a safety net. An unclean
+  shutdown therefore strands at most a small, bounded number of writes in the
+  WAL rather than every uncheckpointed record.
 
 ### Pattern detection
 

--- a/rust/amplihack-memory/src/cognitive_memory/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/mod.rs
@@ -103,18 +103,83 @@ impl CognitiveMemory {
     /// so all cognitive-memory methods behave identically — only durability and
     /// crash-safety differ.
     ///
+    /// This is resilient to an unclean shutdown: if the on-disk write-ahead log
+    /// was left partially written (the failure that previously made the store
+    /// permanently unopenable), it transparently delegates to
+    /// [`open_persistent_with_recovery`](Self::open_persistent_with_recovery),
+    /// which quarantines the corrupt WAL and recovers the last good checkpoint
+    /// plus any replayable prefix rather than returning an error.
+    ///
     /// Requires the `persistent` cargo feature.
     ///
     /// # Errors
     ///
     /// Returns `MemoryError::InvalidInput` if `agent_name` is empty, or
-    /// `MemoryError::Storage` if the database cannot be opened.
+    /// `MemoryError::Storage` if the database cannot be opened even after WAL
+    /// recovery.
     #[cfg(feature = "persistent")]
     pub fn open_persistent(path: impl AsRef<std::path::Path>, agent_name: &str) -> Result<Self> {
+        Self::open_persistent_with_recovery(path, agent_name)
+    }
+
+    /// Open a LadybugDB-backed persistent `CognitiveMemory`, recovering from a
+    /// corrupt / partially-written WAL instead of failing.
+    ///
+    /// A strict open is attempted first. If it fails because the WAL cannot be
+    /// replayed (e.g. after a process was killed mid-write), the unreplayable WAL
+    /// is moved aside to `<wal>.corrupt-<timestamp>`, the recoverable prefix is
+    /// replayed, and a checkpoint folds it into the main database file. A
+    /// structured `warn!` reports how many records survived. The clean case is
+    /// identical to a strict open: no artifact is written and no warning emitted.
+    ///
+    /// [`open_persistent`](Self::open_persistent) delegates to this method, so
+    /// existing callers gain recovery automatically.
+    ///
+    /// Requires the `persistent` cargo feature.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::InvalidInput` if `agent_name` is empty, or
+    /// `MemoryError::Storage` if the database cannot be opened even after
+    /// quarantining the WAL.
+    #[cfg(feature = "persistent")]
+    pub fn open_persistent_with_recovery(
+        path: impl AsRef<std::path::Path>,
+        agent_name: &str,
+    ) -> Result<Self> {
         let trimmed = Self::validate_agent_name(agent_name)?;
         let store_id = format!("cognitive-{trimmed}");
-        let store = crate::graph::lbug_store::LbugGraphStore::open(path.as_ref(), Some(&store_id))?;
+        let (store, recovery) = crate::graph::lbug_store::LbugGraphStore::open_with_recovery(
+            path.as_ref(),
+            Some(&store_id),
+        )?;
+        if recovery.recovered() {
+            tracing::warn!(
+                agent = %trimmed,
+                outcome = ?recovery.outcome,
+                recovered_records = recovery.recovered_records,
+                quarantined_wal = ?recovery.quarantined_wal,
+                "CognitiveMemory::open_persistent recovered from a corrupt WAL"
+            );
+        }
         Self::with_store(agent_name, Box::new(store))
+    }
+
+    /// Flush durable state: force the backend to checkpoint its write-ahead log
+    /// into the main store so a subsequent reopen needs no replay.
+    ///
+    /// For the in-memory backend this is a no-op. For the LadybugDB persistent
+    /// backend it issues a `CHECKPOINT`, bounding how much data an unclean
+    /// shutdown could strand in the WAL. The persistent backend also
+    /// auto-checkpoints periodically and on close/drop; call this explicitly at
+    /// known-safe points (e.g. after a batch of writes) for a stronger guarantee.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Storage` if the backend supports checkpointing but
+    /// the flush fails.
+    pub fn checkpoint(&self) -> Result<()> {
+        self.graph.checkpoint()
     }
 
     fn validate_agent_name(agent_name: &str) -> Result<String> {

--- a/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
@@ -673,3 +673,168 @@ fn special_characters_round_trip_safely() {
     assert_eq!(facts.len(), 1);
     assert_eq!(facts[0].content, nasty_content);
 }
+
+// ---------------------------------------------------------------------------
+// Durability: recovery from an unclean shutdown + checkpoint API (issue #88)
+// ---------------------------------------------------------------------------
+
+use std::fs;
+use std::path::Path;
+
+use crate::graph::lbug_store::wal_path_for;
+
+/// Write one record of every memory type, tagged so seeds are distinguishable.
+fn write_all_types(cm: &mut CognitiveMemory, tag: &str) {
+    cm.store_episode(&format!("episode {tag}"), "ops", Some(1), None)
+        .unwrap();
+    cm.store_fact(
+        &format!("concept-{tag}"),
+        &format!("durable knowledge {tag}"),
+        0.9,
+        "book",
+        Some(&steps(&["rust", "memory"])),
+        None,
+    )
+    .unwrap();
+    cm.store_procedure(&format!("proc-{tag}"), &steps(&["a", "b", "c"]), None)
+        .unwrap();
+    cm.store_prospective(&format!("trigger {tag}"), "outage", "page on-call", 5)
+        .unwrap();
+    cm.store_sensory("text", &format!("observation {tag}"), 3600)
+        .unwrap();
+    cm.store_working("note", &format!("scratch {tag}"), "task-1", 0.5)
+        .unwrap();
+}
+
+/// Copy every file in `from` into `to` — a snapshot of a killed process' files.
+fn copy_dir_files(from: &Path, to: &Path) {
+    for entry in fs::read_dir(from).unwrap() {
+        let p = entry.unwrap().path();
+        if p.is_file() {
+            fs::copy(&p, to.join(p.file_name().unwrap())).unwrap();
+        }
+    }
+}
+
+/// Truncate `wal` mid-record so a strict reopen fails to replay it.
+fn corrupt_wal_tail(wal: &Path) {
+    let len = fs::metadata(wal).unwrap().len();
+    assert!(len > 64, "WAL must be non-empty to corrupt (was {len})");
+    let f = fs::OpenOptions::new().write(true).open(wal).unwrap();
+    f.set_len(len - 41).unwrap();
+    f.sync_all().unwrap();
+}
+
+/// Return the first sibling of `wal` that looks like a quarantined corrupt WAL.
+fn find_quarantine(dir: &Path) -> Option<std::path::PathBuf> {
+    fs::read_dir(dir).unwrap().flatten().find_map(|e| {
+        let p = e.path();
+        if p.file_name()?.to_string_lossy().contains(".wal.corrupt-") {
+            Some(p)
+        } else {
+            None
+        }
+    })
+}
+
+#[test]
+fn unclean_shutdown_recovers_without_crash_and_keeps_checkpointed_records() {
+    let live = tempfile::tempdir().unwrap();
+    let live_db = live.path().join("cognitive.ladybug");
+
+    // 1. Open, write across all memory types, and CHECKPOINT so this batch is
+    //    durable in the main DB file (survives even a destroyed WAL).
+    let mut cm = CognitiveMemory::open_persistent(&live_db, "agent").unwrap();
+    write_all_types(&mut cm, "durable");
+    cm.checkpoint().unwrap();
+    let durable = cm.get_memory_stats();
+    let durable_total = *durable.get("total").unwrap();
+    assert!(durable_total >= 6, "expected >= 6 durable records");
+
+    // 2. Write more records that live only in the WAL (uncheckpointed). The
+    //    default auto-checkpoint interval is far higher than this, so nothing is
+    //    flushed implicitly.
+    write_all_types(&mut cm, "wal-only");
+
+    // 3. Simulate an UNCLEAN shutdown: snapshot the on-disk files mid-WAL, then
+    //    abandon the handle without a clean close (no final checkpoint).
+    let crash = tempfile::tempdir().unwrap();
+    copy_dir_files(live.path(), crash.path());
+    std::mem::forget(cm);
+
+    let crash_db = crash.path().join("cognitive.ladybug");
+    let crash_wal = wal_path_for(&crash_db);
+    assert!(crash_wal.exists(), "snapshot must contain the live WAL");
+    corrupt_wal_tail(&crash_wal);
+
+    // 4. A plain strict reopen of the corrupt copy fails — this is the incident.
+    assert!(
+        crate::graph::lbug_store::LbugGraphStore::open(&crash_db, Some("cognitive-agent")).is_err(),
+        "strict open of the corrupt WAL should fail"
+    );
+
+    // 5. The recovery path opens successfully (no crash) and returns at least the
+    //    checkpointed records — no total loss.
+    let cm2 = CognitiveMemory::open_persistent_with_recovery(&crash_db, "agent")
+        .expect("recovery open must succeed");
+    let stats = cm2.get_memory_stats();
+    assert!(
+        *stats.get("total").unwrap() >= durable_total,
+        "recovery must return >= the {durable_total} checkpointed records, got {:?}",
+        stats.get("total")
+    );
+    for ty in [
+        "episodic",
+        "semantic",
+        "procedural",
+        "prospective",
+        "sensory",
+        "working",
+    ] {
+        assert!(
+            stats.get(ty).copied().unwrap_or(0) >= 1,
+            "checkpointed {ty} record must survive recovery: {stats:?}"
+        );
+    }
+
+    // 6. The corrupt WAL was moved aside, never deleted.
+    assert!(
+        find_quarantine(crash.path()).is_some(),
+        "a <wal>.corrupt-<ts> artifact must exist after recovery"
+    );
+
+    // 7. The transparent entry point (`open_persistent`) also recovers, proving
+    //    existing callers gain crash-resilience with no code change.
+    drop(cm2);
+    let cm3 = CognitiveMemory::open_persistent(&crash_db, "agent")
+        .expect("open_persistent must transparently recover");
+    assert!(*cm3.get_memory_stats().get("total").unwrap() >= durable_total);
+}
+
+#[test]
+fn checkpoint_then_reopen_returns_all_records_and_needs_no_replay() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("cognitive.ladybug");
+    let wal = wal_path_for(&path);
+
+    let expected_total;
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        write_all_types(&mut cm, "a");
+        write_all_types(&mut cm, "b");
+        cm.checkpoint().unwrap();
+        expected_total = *cm.get_memory_stats().get("total").unwrap();
+
+        // After an explicit checkpoint there is no WAL left to replay.
+        let wal_len = fs::metadata(&wal).map(|m| m.len()).unwrap_or(0);
+        assert!(
+            wal_len == 0 || !wal.exists(),
+            "WAL should be empty/absent after checkpoint, was {wal_len} bytes"
+        );
+        std::mem::forget(cm); // no clean close: rely solely on the checkpoint
+    }
+
+    // A reopen sees every record even though the handle was never closed.
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    assert_eq!(*cm.get_memory_stats().get("total").unwrap(), expected_total);
+}

--- a/rust/amplihack-memory/src/graph/lbug_store/mod.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/mod.rs
@@ -26,6 +26,18 @@
 //!   all committed writes. Without the barrier a crash between two writes could
 //!   lose an acknowledged write, since LadybugDB only flushes its WAL on
 //!   `Database::drop`.
+//! * **Bounded crash loss** — the store auto-checkpoints after every
+//!   [`AUTO_CHECKPOINT_WRITES`] mutating operations (and always on `close` /
+//!   `Drop`), flushing the write-ahead log into the main database file. An
+//!   unclean shutdown therefore loses at most the handful of writes accumulated
+//!   since the last checkpoint, rather than every uncheckpointed record.
+//! * **Corrupt-WAL recovery** — [`LbugGraphStore::open_with_recovery`] opens a
+//!   store whose WAL was left partially written by an unclean shutdown. A strict
+//!   open is attempted first; if it fails because the WAL replay cannot complete
+//!   (the failure mode that previously made the store permanently unopenable),
+//!   the corrupt WAL is quarantined to `<wal>.corrupt-<ts>`, a resilient open
+//!   replays the good prefix, and a `CHECKPOINT` folds the recovered records into
+//!   the main database file so a subsequent clean reopen needs no replay.
 //! * **Injection-safe** — table/column/edge identifiers are validated against
 //!   `[A-Za-z_][A-Za-z0-9_]*`, all string values are escaped via `escape_cypher`,
 //!   and `LIMIT` is a type-safe `usize`.
@@ -37,13 +49,65 @@ mod tests;
 
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use lbug::{Connection, Database, SystemConfig, Value};
 use tracing::{debug, warn};
 
 use crate::MemoryError;
+
+/// Number of mutating operations after which the store auto-checkpoints,
+/// folding the write-ahead log into the main database file. This bounds how
+/// much acknowledged-but-uncheckpointed data an unclean shutdown can strand in
+/// the WAL (and therefore put at risk if that WAL is later found corrupt).
+pub const AUTO_CHECKPOINT_WRITES: u64 = 128;
+
+/// How [`LbugGraphStore::open_with_recovery`] opened the store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalRecoveryOutcome {
+    /// The write-ahead log replayed cleanly; no recovery was performed and no
+    /// artifact was written.
+    Clean,
+    /// A corrupt WAL tail was quarantined; the good prefix was replayed and
+    /// checkpointed into the main database file.
+    RecoveredPrefix,
+    /// The WAL was unusable even in resilient mode; it was quarantined and the
+    /// store was opened from the last good checkpoint only.
+    CheckpointOnly,
+}
+
+/// Structured report describing a recovery open. Surfaced via a `warn!` log and
+/// returned from [`LbugGraphStore::open_with_recovery`] so callers (and tests)
+/// can see how many records survived and where the corrupt WAL was moved.
+#[derive(Debug, Clone)]
+pub struct WalRecovery {
+    /// How the store was opened.
+    pub outcome: WalRecoveryOutcome,
+    /// Number of records (graph nodes) present after recovery. Only computed on
+    /// a recovery path; `0` for [`WalRecoveryOutcome::Clean`].
+    pub recovered_records: usize,
+    /// Where the corrupt WAL (and any sidecars) were quarantined, if recovery
+    /// ran. The bad WAL is moved aside — never deleted.
+    pub quarantined_wal: Option<PathBuf>,
+}
+
+impl WalRecovery {
+    fn clean() -> Self {
+        Self {
+            outcome: WalRecoveryOutcome::Clean,
+            recovered_records: 0,
+            quarantined_wal: None,
+        }
+    }
+
+    /// `true` if a corrupt WAL was detected and recovery (of any kind) ran.
+    pub fn recovered(&self) -> bool {
+        self.outcome != WalRecoveryOutcome::Clean
+    }
+}
 
 /// LadybugDB-backed persistent [`GraphStore`](crate::graph::protocol::GraphStore).
 pub struct LbugGraphStore {
@@ -60,6 +124,11 @@ pub struct LbugGraphStore {
     pub(crate) known_rel_tables: RefCell<HashSet<(String, String, String)>>,
     /// node_id -> node table, to resolve a node's label without scanning.
     pub(crate) id_table_cache: RefCell<HashMap<String, String>>,
+    /// Mutating operations applied since the last checkpoint.
+    pub(crate) writes_since_checkpoint: Cell<u64>,
+    /// Auto-checkpoint after this many writes (`0` disables count-based
+    /// checkpointing; used by tests that need data to remain in the WAL).
+    pub(crate) checkpoint_interval: Cell<u64>,
 }
 
 // SAFETY: lbug::Database is internally synchronized (it declares Send + Sync).
@@ -70,11 +139,149 @@ unsafe impl Send for LbugGraphStore {}
 impl LbugGraphStore {
     /// Open (or create) a LadybugDB database at `db_path`.
     ///
+    /// This is the strict open: if the on-disk write-ahead log cannot be fully
+    /// replayed (e.g. it was left partially written by an unclean shutdown) this
+    /// returns an error. Use [`open_with_recovery`](Self::open_with_recovery)
+    /// (or [`CognitiveMemory::open_persistent`](crate::cognitive_memory::CognitiveMemory::open_persistent),
+    /// which wraps it) to tolerate a corrupt WAL.
+    ///
     /// # Errors
     ///
     /// Returns [`MemoryError::Storage`] if the parent directory cannot be created
     /// or the database cannot be opened.
     pub fn open(db_path: &Path, store_id: Option<&str>) -> crate::Result<Self> {
+        Self::prepare_parent(db_path)?;
+        let db = open_database(db_path, true).map_err(|e| {
+            MemoryError::Storage(format!(
+                "failed to open LadybugDB at {}: {e}",
+                db_path.display()
+            ))
+        })?;
+        Ok(Self::from_parts(db, db_path, store_id))
+    }
+
+    /// Open (or create) a LadybugDB database at `db_path`, recovering from a
+    /// corrupt / partially-written WAL instead of failing.
+    ///
+    /// A strict [`open`](Self::open) is attempted first. If it succeeds the store
+    /// is returned with [`WalRecoveryOutcome::Clean`] and no artifact is written.
+    /// If the strict open fails *and* a WAL file is present (the signature of an
+    /// unclean shutdown), the WAL — which can no longer be replayed — is
+    /// quarantined to `<wal>.corrupt-<unix_ts>` (moved aside, never deleted), a
+    /// resilient open replays the recoverable prefix, and a `CHECKPOINT` folds
+    /// the recovered records into the main database file so the next clean reopen
+    /// needs no replay. The returned [`WalRecovery`] reports the outcome and how
+    /// many records survived; a `warn!` is also emitted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Storage`] if the database cannot be opened even
+    /// after quarantining the WAL (e.g. the parent directory is unwritable or the
+    /// main database file itself is unreadable).
+    pub fn open_with_recovery(
+        db_path: &Path,
+        store_id: Option<&str>,
+    ) -> crate::Result<(Self, WalRecovery)> {
+        Self::prepare_parent(db_path)?;
+
+        // 1. Fast path: strict open. A corrupt WAL surfaces as Err (lbug/cxx
+        //    converts the C++ replay assertion into a Rust error rather than
+        //    aborting); catch_unwind additionally contains any panic.
+        match try_open_database(db_path, true) {
+            Ok(db) => Ok((
+                Self::from_parts(db, db_path, store_id),
+                WalRecovery::clean(),
+            )),
+            Err(strict_err) => {
+                let wal = wal_path_for(db_path);
+                if !wal.exists() {
+                    // No WAL: the failure is not WAL-replay related (bad path,
+                    // quota, permissions, ...). Surface it unchanged.
+                    return Err(MemoryError::Storage(format!(
+                        "failed to open LadybugDB at {}: {strict_err}",
+                        db_path.display()
+                    )));
+                }
+                warn!(
+                    db_path = %db_path.display(),
+                    error = %strict_err,
+                    "lbug_store: WAL replay failed on open; attempting recovery"
+                );
+                Self::recover(db_path, store_id, &wal)
+            }
+        }
+    }
+
+    /// Recovery slow path: quarantine the corrupt WAL, then open resiliently and
+    /// checkpoint, falling back to a checkpoint-only open if even that fails.
+    fn recover(
+        db_path: &Path,
+        store_id: Option<&str>,
+        wal: &Path,
+    ) -> crate::Result<(Self, WalRecovery)> {
+        // Preserve the incident artifact *before* a resilient open (which will
+        // consume/truncate the WAL) gets a chance to mutate it.
+        let quarantine = quarantine_path(wal);
+        let copied = copy_wal_aside(db_path, wal, &quarantine);
+
+        // 2. Resilient open: replay the good prefix, ignore the unreplayable tail.
+        match try_open_database(db_path, false) {
+            Ok(db) => {
+                let store = Self::from_parts(db, db_path, store_id);
+                // Fold the recovered prefix into the main DB so a later clean
+                // reopen needs no replay, then count what survived.
+                if let Err(e) = store.do_checkpoint() {
+                    warn!("lbug_store: checkpoint after recovery failed: {e}");
+                }
+                let recovered = store.count_all_nodes();
+                let report = WalRecovery {
+                    outcome: WalRecoveryOutcome::RecoveredPrefix,
+                    recovered_records: recovered,
+                    quarantined_wal: copied.clone(),
+                };
+                warn!(
+                    db_path = %db_path.display(),
+                    recovered_records = recovered,
+                    quarantined_wal = ?copied,
+                    "lbug_store: recovered from corrupt WAL (good prefix replayed + checkpointed)"
+                );
+                Ok((store, report))
+            }
+            Err(resilient_err) => {
+                // 3. Hard fallback: even resilient replay failed. Move the WAL
+                //    (and any sidecars) fully aside so the engine opens from the
+                //    last good checkpoint with no WAL to replay.
+                warn!(
+                    db_path = %db_path.display(),
+                    error = %resilient_err,
+                    "lbug_store: resilient WAL replay failed; opening from last checkpoint only"
+                );
+                let moved = move_wal_aside(db_path, wal, &quarantine, copied.is_some());
+                let db = open_database(db_path, true).map_err(|e| {
+                    MemoryError::Storage(format!(
+                        "failed to open LadybugDB at {} even after quarantining the WAL: {e}",
+                        db_path.display()
+                    ))
+                })?;
+                let store = Self::from_parts(db, db_path, store_id);
+                let recovered = store.count_all_nodes();
+                let report = WalRecovery {
+                    outcome: WalRecoveryOutcome::CheckpointOnly,
+                    recovered_records: recovered,
+                    quarantined_wal: moved.or(copied),
+                };
+                warn!(
+                    db_path = %db_path.display(),
+                    recovered_records = recovered,
+                    "lbug_store: opened from last checkpoint after unrecoverable WAL"
+                );
+                Ok((store, report))
+            }
+        }
+    }
+
+    /// Create the parent directory of `db_path` if needed.
+    fn prepare_parent(db_path: &Path) -> crate::Result<()> {
         if let Some(parent) = db_path.parent() {
             if !parent.as_os_str().is_empty() {
                 std::fs::create_dir_all(parent).map_err(|e| {
@@ -85,25 +292,15 @@ impl LbugGraphStore {
                 })?;
             }
         }
+        Ok(())
+    }
 
+    /// Assemble a store around an already-opened [`Database`].
+    fn from_parts(db: Database, db_path: &Path, store_id: Option<&str>) -> Self {
         let id = store_id
             .map(String::from)
             .unwrap_or_else(|| format!("lbug-{}", &uuid::Uuid::new_v4().to_string()[..8]));
-
-        let config = SystemConfig::default()
-            // Cap the mmap reservation so we don't request a huge address space
-            // in constrained environments (mirrors the Kùzu backend).
-            .max_db_size(1 << 30)
-            .buffer_pool_size(128 * 1024 * 1024);
-
-        let db = Database::new(db_path, config).map_err(|e| {
-            MemoryError::Storage(format!(
-                "failed to open LadybugDB at {}: {e}",
-                db_path.display()
-            ))
-        })?;
-
-        Ok(Self {
+        Self {
             store_id: id,
             db_path: db_path.to_path_buf(),
             db,
@@ -113,12 +310,99 @@ impl LbugGraphStore {
             node_table_columns: RefCell::new(HashMap::new()),
             known_rel_tables: RefCell::new(HashSet::new()),
             id_table_cache: RefCell::new(HashMap::new()),
-        })
+            writes_since_checkpoint: Cell::new(0),
+            checkpoint_interval: Cell::new(AUTO_CHECKPOINT_WRITES),
+        }
     }
 
     /// The on-disk database path.
     pub fn db_path(&self) -> &Path {
         &self.db_path
+    }
+
+    /// Override the auto-checkpoint write interval (`0` disables count-based
+    /// checkpointing). Intended for in-crate tests that need writes to remain in
+    /// the WAL so an unclean shutdown can be simulated.
+    #[cfg(test)]
+    pub(crate) fn set_checkpoint_interval(&self, writes: u64) {
+        self.checkpoint_interval.set(writes);
+    }
+
+    /// Mutating operations applied since the last checkpoint (test introspection).
+    #[cfg(test)]
+    pub(crate) fn pending_writes(&self) -> u64 {
+        self.writes_since_checkpoint.get()
+    }
+
+    /// Force a checkpoint: flush the write-ahead log into the main database file
+    /// so a subsequent clean reopen needs no WAL replay.
+    ///
+    /// Acquires the write lock; safe to call concurrently with reads/writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryError::Storage`] if the `CHECKPOINT` statement or the
+    /// durability barrier fails.
+    pub fn checkpoint(&self) -> crate::Result<()> {
+        let _guard = self.acquire_lock();
+        self.do_checkpoint()
+    }
+
+    /// Issue `CHECKPOINT` + durability barrier and reset the write counter.
+    /// Caller is responsible for holding [`acquire_lock`](Self::acquire_lock)
+    /// when used outside single-threaded recovery.
+    pub(crate) fn do_checkpoint(&self) -> crate::Result<()> {
+        self.execute("CHECKPOINT")?;
+        self.writes_since_checkpoint.set(0);
+        self.post_write_barrier()?;
+        Ok(())
+    }
+
+    /// Record a mutating operation and checkpoint once the configured interval is
+    /// reached. Best-effort: a failed checkpoint is logged, not propagated (the
+    /// write itself already succeeded and was fsync'd). Caller must hold the
+    /// write lock.
+    pub(crate) fn note_write_and_maybe_checkpoint(&self) {
+        let interval = self.checkpoint_interval.get();
+        if interval == 0 {
+            return;
+        }
+        let next = self.writes_since_checkpoint.get().saturating_add(1);
+        if next >= interval {
+            if let Err(e) = self.do_checkpoint() {
+                warn!("lbug_store: auto-checkpoint failed: {e}");
+                // do_checkpoint resets the counter only on success; reset here so
+                // we retry on the next write rather than every write.
+                self.writes_since_checkpoint.set(0);
+            }
+        } else {
+            self.writes_since_checkpoint.set(next);
+        }
+    }
+
+    /// Total number of graph nodes across every node table. Used to report how
+    /// many records survived a recovery open.
+    pub(crate) fn count_all_nodes(&self) -> usize {
+        let mut total = 0usize;
+        let rows = match self.query_rows("CALL show_tables() RETURN *") {
+            Ok(r) => r,
+            Err(_) => return 0,
+        };
+        for row in rows {
+            let (name, ttype) = match table_row_name_and_type(&row) {
+                Some(v) => v,
+                None => continue,
+            };
+            if !ttype.to_ascii_uppercase().contains("NODE") || !is_valid_identifier(&name) {
+                continue;
+            }
+            if let Ok(cnt) = self.query_rows(&format!("MATCH (n:{name}) RETURN count(n)")) {
+                if let Some(v) = cnt.first().and_then(|r| r.first()) {
+                    total += value_as_usize(v);
+                }
+            }
+        }
+        total
     }
 
     // -- connection / execution helpers --------------------------------------
@@ -362,9 +646,183 @@ impl LbugGraphStore {
     }
 }
 
+impl Drop for LbugGraphStore {
+    /// Always-on durability: checkpoint the WAL into the main database file when
+    /// the store is dropped, so even a forgotten `close` leaves the data durable
+    /// without an unbounded WAL to replay. Best-effort and silent on error —
+    /// LadybugDB also force-checkpoints on its own drop as a backstop.
+    fn drop(&mut self) {
+        if let Err(e) = self.execute("CHECKPOINT") {
+            debug!("lbug_store: checkpoint on drop failed (engine will retry): {e}");
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Free helpers
 // ---------------------------------------------------------------------------
+
+/// The system configuration used for every open.
+///
+/// `auto_checkpoint(true)` lets LadybugDB bound the WAL on its own as a safety
+/// net; the store additionally checkpoints every [`AUTO_CHECKPOINT_WRITES`]
+/// writes (see [`LbugGraphStore::note_write_and_maybe_checkpoint`]).
+/// `throw_on_wal_replay_failure` selects strict vs. resilient WAL replay: strict
+/// (`true`) errors on a corrupt WAL, resilient (`false`) replays the good prefix
+/// and ignores the unreplayable tail.
+fn system_config(throw_on_wal_replay_failure: bool) -> SystemConfig {
+    SystemConfig::default()
+        // Cap the mmap reservation so we don't request a huge address space in
+        // constrained environments (mirrors the Kùzu backend).
+        .max_db_size(1 << 30)
+        .buffer_pool_size(128 * 1024 * 1024)
+        .auto_checkpoint(true)
+        .throw_on_wal_replay_failure(throw_on_wal_replay_failure)
+}
+
+/// Open a [`Database`] with the given replay strictness, mapping the engine
+/// error to a `String`.
+fn open_database(db_path: &Path, strict: bool) -> std::result::Result<Database, String> {
+    Database::new(db_path, system_config(strict)).map_err(|e| e.to_string())
+}
+
+/// Open a [`Database`], additionally containing any panic (a corrupt WAL surfaces
+/// as `Err` in practice, but `catch_unwind` guarantees we never crash the
+/// process during a recovery attempt).
+fn try_open_database(db_path: &Path, strict: bool) -> std::result::Result<Database, String> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        open_database(db_path, strict)
+    })) {
+        Ok(res) => res,
+        Err(panic) => Err(format!("panic during open: {}", panic_message(panic))),
+    }
+}
+
+fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+/// The write-ahead-log path for `db_path`.
+///
+/// LadybugDB appends `.wal` to the *full* database filename (extension included),
+/// so `cognitive.ladybug` -> `cognitive.ladybug.wal`. (This is intentionally not
+/// `Path::with_extension`, which would wrongly produce `cognitive.wal`.)
+pub(crate) fn wal_path_for(db_path: &Path) -> PathBuf {
+    let mut name: OsString = db_path.as_os_str().to_os_string();
+    name.push(".wal");
+    PathBuf::from(name)
+}
+
+/// Quarantine target for a corrupt WAL: `<wal>.corrupt-<unix_ts>`.
+fn quarantine_path(wal: &Path) -> PathBuf {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut name: OsString = wal.as_os_str().to_os_string();
+    name.push(format!(".corrupt-{ts}"));
+    PathBuf::from(name)
+}
+
+/// Sidecar files LadybugDB may write alongside the WAL (shadow pages, temporary
+/// WAL segments). Returns existing siblings whose name starts with the WAL or db
+/// filename and carries a `.shadow` / `.wal.` infix.
+fn wal_sidecars(db_path: &Path, wal: &Path) -> Vec<PathBuf> {
+    let parent = wal.parent().unwrap_or_else(|| Path::new("."));
+    let db_name = db_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let wal_name = wal
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(parent) {
+        for entry in entries.flatten() {
+            let fname = entry.file_name().to_string_lossy().to_string();
+            if fname == wal_name {
+                continue; // the WAL itself is handled separately
+            }
+            let is_sidecar = fname.starts_with(&format!("{wal_name}."))
+                || (fname.starts_with(&db_name) && fname.contains(".shadow"));
+            if is_sidecar {
+                out.push(entry.path());
+            }
+        }
+    }
+    out
+}
+
+/// Copy the corrupt WAL (and any sidecars) to `quarantine`, preserving the
+/// incident artifact before a resilient open consumes the live WAL. Returns the
+/// quarantine path on success.
+fn copy_wal_aside(db_path: &Path, wal: &Path, quarantine: &Path) -> Option<PathBuf> {
+    match std::fs::copy(wal, quarantine) {
+        Ok(_) => {
+            for sidecar in wal_sidecars(db_path, wal) {
+                if let Some(name) = sidecar.file_name() {
+                    let mut dst: OsString = quarantine.as_os_str().to_os_string();
+                    dst.push(".");
+                    dst.push(name);
+                    let _ = std::fs::copy(&sidecar, PathBuf::from(dst));
+                }
+            }
+            Some(quarantine.to_path_buf())
+        }
+        Err(e) => {
+            warn!(
+                "lbug_store: failed to quarantine corrupt WAL {}: {e}",
+                wal.display()
+            );
+            None
+        }
+    }
+}
+
+/// Move the WAL (and sidecars) fully aside so the engine opens with no WAL to
+/// replay. If a copy was already quarantined, the live WAL is just removed (the
+/// artifact is already preserved); otherwise it is renamed to `quarantine`.
+fn move_wal_aside(
+    db_path: &Path,
+    wal: &Path,
+    quarantine: &Path,
+    already_copied: bool,
+) -> Option<PathBuf> {
+    let result = if already_copied {
+        let _ = std::fs::remove_file(wal);
+        Some(quarantine.to_path_buf())
+    } else {
+        match std::fs::rename(wal, quarantine) {
+            Ok(_) => Some(quarantine.to_path_buf()),
+            Err(_) => {
+                let _ = std::fs::remove_file(wal);
+                None
+            }
+        }
+    };
+    for sidecar in wal_sidecars(db_path, wal) {
+        let _ = std::fs::remove_file(&sidecar);
+    }
+    result
+}
+
+/// Interpret a scalar [`Value`] as a `usize` count (from `count(n)` results).
+fn value_as_usize(v: &Value) -> usize {
+    match v {
+        Value::Int64(i) => (*i).max(0) as usize,
+        Value::Int32(i) => (*i).max(0) as usize,
+        Value::UInt64(i) => *i as usize,
+        Value::UInt32(i) => *i as usize,
+        other => value_to_string(other).parse::<usize>().unwrap_or(0),
+    }
+}
 
 /// `true` if `name` is a safe Cypher identifier (`[A-Za-z_][A-Za-z0-9_]*`).
 pub(crate) fn is_valid_identifier(name: &str) -> bool {

--- a/rust/amplihack-memory/src/graph/lbug_store/mod.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/mod.rs
@@ -20,14 +20,14 @@
 //! * **Reopen-safe** — on first access the existing catalog is introspected
 //!   (`CALL show_tables` / `CALL table_info`) so data written in a previous
 //!   process is visible after `close` + reopen.
-//! * **Durability** — writes are serialized through a [`Mutex`], every mutating
+//! * **Durability** — writes are serialized through a [`Mutex`](std::sync::Mutex), every mutating
 //!   operation issues a per-write `fsync` barrier (data file + parent
 //!   directory), and `close` issues a `CHECKPOINT` so a subsequent reopen sees
 //!   all committed writes. Without the barrier a crash between two writes could
 //!   lose an acknowledged write, since LadybugDB only flushes its WAL on
 //!   `Database::drop`.
 //! * **Bounded crash loss** — the store auto-checkpoints after every
-//!   [`AUTO_CHECKPOINT_WRITES`] mutating operations (and always on `close` /
+//!   [`AUTO_CHECKPOINT_WRITES`](crate::graph::lbug_store::AUTO_CHECKPOINT_WRITES) mutating operations (and always on `close` /
 //!   `Drop`), flushing the write-ahead log into the main database file. An
 //!   unclean shutdown therefore loses at most the handful of writes accumulated
 //!   since the last checkpoint, rather than every uncheckpointed record.

--- a/rust/amplihack-memory/src/graph/lbug_store/store_impl.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/store_impl.rs
@@ -276,6 +276,7 @@ impl GraphStore for LbugGraphStore {
         let cypher = format!("CREATE (:{node_type} {{{}}})", parts.join(", "));
         self.execute(&cypher)?;
         self.post_write_barrier()?;
+        self.note_write_and_maybe_checkpoint();
 
         self.id_table_cache
             .borrow_mut()
@@ -436,6 +437,7 @@ impl GraphStore for LbugGraphStore {
             if let Err(e) = self.post_write_barrier() {
                 warn!("update_node: durability barrier failed for {node_id}: {e}");
             }
+            self.note_write_and_maybe_checkpoint();
             true
         } else {
             false
@@ -458,6 +460,7 @@ impl GraphStore for LbugGraphStore {
             if let Err(e) = self.post_write_barrier() {
                 warn!("delete_node: durability barrier failed for {node_id}: {e}");
             }
+            self.note_write_and_maybe_checkpoint();
             true
         } else {
             false
@@ -516,6 +519,7 @@ impl GraphStore for LbugGraphStore {
         );
         self.execute(&cypher)?;
         self.post_write_barrier()?;
+        self.note_write_and_maybe_checkpoint();
 
         Ok(GraphEdge {
             edge_id: eid,
@@ -598,6 +602,7 @@ impl GraphStore for LbugGraphStore {
             if let Err(e) = self.post_write_barrier() {
                 warn!("delete_edge: durability barrier failed for {source_id}->{target_id}: {e}");
             }
+            self.note_write_and_maybe_checkpoint();
             true
         } else {
             false
@@ -627,11 +632,16 @@ impl GraphStore for LbugGraphStore {
         )
     }
 
+    fn checkpoint(&self) -> crate::Result<()> {
+        let _guard = self.acquire_lock();
+        self.do_checkpoint()
+    }
+
     fn close(&mut self) {
         let _guard = self.acquire_lock();
         // Best-effort: flush the WAL into the main DB file so a subsequent open
         // (after this handle is dropped) sees all committed writes.
-        if let Err(e) = self.execute("CHECKPOINT") {
+        if let Err(e) = self.do_checkpoint() {
             warn!("close: CHECKPOINT failed; relying on WAL flush at drop: {e}");
         }
         self.id_table_cache.borrow_mut().clear();

--- a/rust/amplihack-memory/src/graph/lbug_store/tests.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/tests.rs
@@ -278,3 +278,192 @@ fn execute_error_does_not_leak_query_values() {
     );
     assert!(qerr.to_string().contains("Cypher query failed"));
 }
+
+// ---------------------------------------------------------------------------
+// Durability: corrupt-WAL recovery + checkpoint API + auto-checkpoint
+// ---------------------------------------------------------------------------
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::{wal_path_for, WalRecoveryOutcome};
+
+/// Insert `n` simple nodes into a fresh "T" table.
+fn add_things(store: &mut LbugGraphStore, start: usize, n: usize) {
+    for i in start..start + n {
+        let id = format!("n{i}");
+        store
+            .add_node(
+                "T",
+                props(&[("node_id", &id), ("agent_id", "a")]),
+                Some(&id),
+            )
+            .unwrap();
+    }
+}
+
+/// Copy every file in `from` into a fresh dir, returning the dir + the copied
+/// db path. Mimics snapshotting the on-disk state of a killed process.
+fn crash_snapshot(from: &Path, db_name: &str) -> (tempfile::TempDir, PathBuf) {
+    let crash = tempfile::tempdir().unwrap();
+    for entry in fs::read_dir(from).unwrap() {
+        let p = entry.unwrap().path();
+        if p.is_file() {
+            fs::copy(&p, crash.path().join(p.file_name().unwrap())).unwrap();
+        }
+    }
+    let db = crash.path().join(db_name);
+    (crash, db)
+}
+
+/// Truncate `wal` mid-record so a strict open fails to replay it.
+fn corrupt_wal_tail(wal: &Path) {
+    let len = fs::metadata(wal).unwrap().len();
+    assert!(len > 64, "WAL should be non-empty to corrupt: {}", len);
+    let f = fs::OpenOptions::new().write(true).open(wal).unwrap();
+    f.set_len(len - 41).unwrap();
+    f.sync_all().unwrap();
+}
+
+#[test]
+fn checkpoint_makes_clean_reopen_need_no_wal_replay() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.ladybug");
+    let wal = wal_path_for(&path);
+
+    {
+        let mut store = LbugGraphStore::open(&path, Some("s")).unwrap();
+        store.set_checkpoint_interval(0); // keep everything in the WAL until we ask
+        add_things(&mut store, 0, 40);
+        // The WAL holds the writes; checkpoint folds them into the main DB file.
+        store.checkpoint().unwrap();
+        // After a checkpoint there is nothing left to replay.
+        let wal_len = fs::metadata(&wal).map(|m| m.len()).unwrap_or(0);
+        assert!(
+            wal_len == 0 || !wal.exists(),
+            "WAL should be empty/absent after checkpoint, was {wal_len} bytes"
+        );
+        assert_eq!(store.pending_writes(), 0, "checkpoint resets write counter");
+        // Forget so Drop/close doesn't run another checkpoint — prove the
+        // explicit checkpoint alone made the data durable.
+        std::mem::forget(store);
+    }
+
+    // A strict reopen (the one that crashes on a bad WAL) succeeds and sees all
+    // records, because the checkpoint left no WAL to replay.
+    let store = LbugGraphStore::open(&path, Some("s")).unwrap();
+    assert_eq!(store.count_all_nodes(), 40);
+}
+
+#[test]
+fn open_with_recovery_survives_corrupt_wal_and_returns_checkpointed_records() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.ladybug");
+
+    {
+        let mut store = LbugGraphStore::open(&path, Some("s")).unwrap();
+        store.set_checkpoint_interval(0);
+        // Durable batch: checkpointed into the main DB file.
+        add_things(&mut store, 0, 30);
+        store.checkpoint().unwrap();
+        // Uncheckpointed batch: lives only in the WAL.
+        add_things(&mut store, 30, 30);
+        std::mem::forget(store); // unclean: no close, no final checkpoint
+    }
+
+    // Snapshot the on-disk files and corrupt the WAL tail of the copy.
+    let (crash, crash_db) = crash_snapshot(path.parent().unwrap(), "graph.ladybug");
+    let crash_wal = wal_path_for(&crash_db);
+    assert!(crash_wal.exists(), "snapshot must include the WAL");
+    corrupt_wal_tail(&crash_wal);
+
+    // A strict open of the corrupt copy must fail (this is the incident).
+    assert!(
+        LbugGraphStore::open(&crash_db, Some("s")).is_err(),
+        "strict open of a corrupt WAL should error"
+    );
+
+    // Recovery opens successfully (no crash) and reports the outcome.
+    let (store, report) =
+        LbugGraphStore::open_with_recovery(&crash_db, Some("s")).expect("recovery must open");
+    assert_eq!(report.outcome, WalRecoveryOutcome::RecoveredPrefix);
+    assert!(report.recovered(), "report should flag that recovery ran");
+    assert!(
+        report.recovered_records >= 30,
+        "at least the 30 checkpointed records must survive, got {}",
+        report.recovered_records
+    );
+    assert_eq!(store.count_all_nodes(), report.recovered_records);
+
+    // The corrupt WAL was moved aside (never deleted).
+    let quarantine = report.quarantined_wal.expect("a quarantine path");
+    assert!(
+        quarantine.exists(),
+        "corrupt WAL must be preserved at {quarantine:?}"
+    );
+    assert!(quarantine
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .contains(".corrupt-"));
+
+    drop(store);
+
+    // Recovery checkpointed the survivors, so a subsequent STRICT reopen of the
+    // same path now needs no replay and no longer crashes.
+    let reopened = LbugGraphStore::open(&crash_db, Some("s")).expect("clean reopen after recovery");
+    assert!(reopened.count_all_nodes() >= 30);
+
+    drop(crash);
+}
+
+#[test]
+fn open_with_recovery_is_a_noop_on_a_clean_store() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.ladybug");
+    {
+        let mut store = LbugGraphStore::open(&path, Some("s")).unwrap();
+        add_things(&mut store, 0, 10);
+        store.close();
+    }
+    let (store, report) = LbugGraphStore::open_with_recovery(&path, Some("s")).unwrap();
+    assert_eq!(report.outcome, WalRecoveryOutcome::Clean);
+    assert!(!report.recovered());
+    assert!(report.quarantined_wal.is_none());
+    assert_eq!(store.count_all_nodes(), 10);
+}
+
+#[test]
+fn auto_checkpoint_bounds_uncheckpointed_writes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.ladybug");
+
+    let mut store = LbugGraphStore::open(&path, Some("s")).unwrap();
+    store.set_checkpoint_interval(4); // checkpoint every 4 writes
+    add_things(&mut store, 0, 10); // checkpoints fire after writes 4 and 8
+    assert!(
+        store.pending_writes() < 4,
+        "at most interval-1 writes may be uncheckpointed, was {}",
+        store.pending_writes()
+    );
+
+    // Snapshot, drop the WAL entirely (simulate total WAL loss), strict-open:
+    // only the auto-checkpointed records survive — and there must be some,
+    // proving auto-checkpoint persisted data with no explicit checkpoint/close.
+    let (crash, crash_db) = crash_snapshot(path.parent().unwrap(), "graph.ladybug");
+    std::mem::forget(store);
+    let crash_wal = wal_path_for(&crash_db);
+    let _ = fs::remove_file(&crash_wal);
+
+    let recovered = LbugGraphStore::open(&crash_db, Some("s")).unwrap();
+    let n = recovered.count_all_nodes();
+    assert!(
+        n >= 8,
+        "auto-checkpoint should have persisted >= 8 of 10 records, got {n}"
+    );
+    assert!(
+        n < 10,
+        "the last writes should still have been WAL-only, got {n}"
+    );
+    drop(crash);
+}

--- a/rust/amplihack-memory/src/graph/mod.rs
+++ b/rust/amplihack-memory/src/graph/mod.rs
@@ -30,7 +30,7 @@ pub use in_memory_store::InMemoryGraphStore;
 pub use kuzu_store::KuzuGraphStore;
 /// LadybugDB-backed persistent graph store implementation.
 #[cfg(feature = "persistent")]
-pub use lbug_store::LbugGraphStore;
+pub use lbug_store::{LbugGraphStore, WalRecovery, WalRecoveryOutcome};
 /// The common `GraphStore` trait all backends implement.
 pub use protocol::GraphStore;
 /// Core graph primitives re-exported for convenience.

--- a/rust/amplihack-memory/src/graph/protocol.rs
+++ b/rust/amplihack-memory/src/graph/protocol.rs
@@ -87,6 +87,17 @@ pub trait GraphStore {
         node_filter: Option<&HashMap<String, String>>,
     ) -> TraversalResult;
 
+    /// Flush any write-ahead log into durable storage so a subsequent reopen
+    /// needs no replay. A no-op for volatile backends (the default).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the backend supports checkpointing but the flush
+    /// fails.
+    fn checkpoint(&self) -> crate::Result<()> {
+        Ok(())
+    }
+
     /// Release resources held by the store.
     fn close(&mut self);
 }


### PR DESCRIPTION
## Summary

Fixes a **critical durability bug** (#88) in the persistent `CognitiveMemory` (`LbugGraphStore`). After an unclean shutdown (process killed mid-write), the LadybugDB write-ahead log (WAL) is left partially written, and `open_persistent` previously failed on a C++ WAL-replay assertion (`UNREACHABLE_CODE`). The store became **permanently unopenable** — the only "recovery" was deleting the `.wal`, which lost every uncheckpointed record (in the live incident, 308 of 361 records lived only in the WAL).

This PR makes the persistent backend **recover instead of crash**, adds a **checkpoint API**, and **auto-checkpoints** to bound crash loss. Additive and fully backward compatible.

## What changed

### 1. Recover, don't crash
- `LbugGraphStore::open_with_recovery(path, id) -> (Self, WalRecovery)` and `CognitiveMemory::open_persistent_with_recovery(path, agent)`:
  1. Try a **strict** open (unchanged fast path). On success → return immediately, no artifact.
  2. On a WAL-replay failure with a WAL present → **copy the corrupt WAL aside** to `<wal>.corrupt-<timestamp>` (moved aside, **never deleted**), open **resiliently** (`throw_on_wal_replay_failure(false)`) to replay the good prefix, `CHECKPOINT` it into the main DB, count survivors, and emit a structured `warn!`.
  3. Hard fallback: if even the resilient open fails, move the WAL fully aside and open from the last good checkpoint.
- `open_persistent` now **delegates to the recovery path**, so existing callers gain crash-resilience with **no code change**.
- Returns a structured `WalRecovery { outcome, recovered_records, quarantined_wal }`.

### 2. Checkpoint API
- `CognitiveMemory::checkpoint()` and `GraphStore::checkpoint()` (default no-op for volatile backends) force the WAL into the main DB file, so a clean reopen needs no replay.

### 3. Aggressive / auto checkpoint
- Auto-checkpoint after every `AUTO_CHECKPOINT_WRITES` (128) mutating ops, plus on `close` **and** `Drop`, with LadybugDB's size-based auto-checkpoint as a safety net. Bounds how much an unclean shutdown can strand in the WAL. Policy documented in module docs + README.

### 4. Tests (TDD — reproduce + prove)
- `unclean_shutdown_recovers_without_crash_and_keeps_checkpointed_records`: writes across all memory types, snapshots files mid-WAL, corrupts the WAL, asserts a plain strict open fails, then the recovery path opens (no crash), returns the checkpointed records, and the `<wal>.corrupt-<ts>` artifact exists.
- `checkpoint_then_reopen_returns_all_records_and_needs_no_replay`: `checkpoint()` empties the WAL; a reopen with no clean close returns all records.
- Store-level tests for recovery counts, clean-open no-op, and that auto-checkpoint bounds uncheckpointed writes.
- A real corrupt WAL from the incident (`/tmp/corrupt-wal-fixture`) was used for reference only; the tests synthesize an equivalent in-process (it is **not** committed).

## Empirical grounding

A throwaway probe (since removed) against `lbug 0.15.3` confirmed:
- The WAL path is `<db_path>.wal` (`.wal` **appended** to the full filename), e.g. `cognitive.ladybug` → `cognitive.ladybug.wal`.
- A strict open of a corrupt WAL surfaces as a **catchable `Err`** (cxx converts the C++ assertion to `Result::Err`; no process abort), matching the incident's "propagates this as an Err".
- A resilient open replays the good prefix (e.g. 99/200 after mid-WAL corruption); `CHECKPOINT` then makes a subsequent strict reopen need no replay.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` (default) ✅ and `cargo clippy --features persistent --lib -- -D warnings` ✅
- `cargo test` ✅ (454 default lib tests)
- `cargo test --features persistent` ✅ (490 lib tests, incl. new durability tests)
- `cargo check --features python` ✅

The pre-existing `ladybug` feature does not compile on `main` (unresolved `ladybug_graph_rs` imports) — verified by stashing these changes; it is unrelated to this PR.

Fixes #88