### PR TITLE
feat(cognitive-memory): provenance edges (DERIVES_FROM / PROCEDURE_DERIVES_FROM)

### DIFF
--- a/rust/amplihack-memory/src/cognitive_memory/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/mod.rs
@@ -27,11 +27,13 @@ use std::collections::HashMap;
 
 use crate::graph::in_memory_store::InMemoryGraphStore;
 use crate::graph::protocol::GraphStore;
+use crate::graph::types::Direction;
 use crate::memory_types::MemoryCategory;
 use crate::{MemoryError, Result};
 
 use types::{
-    agent_filter, NT_EPISODIC, NT_PROCEDURAL, NT_PROSPECTIVE, NT_SEMANTIC, NT_SENSORY, NT_WORKING,
+    agent_filter, ts_now, NT_EPISODIC, NT_PROCEDURAL, NT_PROSPECTIVE, NT_SEMANTIC, NT_SENSORY,
+    NT_WORKING,
 };
 
 // ---------------------------------------------------------------------------
@@ -273,6 +275,49 @@ impl CognitiveMemory {
     /// Alias matching the Python method name `get_statistics`.
     pub fn get_statistics(&self) -> HashMap<String, usize> {
         self.get_memory_stats()
+    }
+
+    // ======================================================================
+    // PROVENANCE (shared helpers)
+    // ======================================================================
+
+    /// Return `true` if `id` refers to an existing episodic-memory node.
+    ///
+    /// Used to gate provenance-edge creation: a `DERIVES_FROM` /
+    /// `PROCEDURE_DERIVES_FROM` edge may only target a real
+    /// [`EpisodicMemory`](crate::memory_types::EpisodicMemory) node, and both
+    /// graph backends reject [`add_edge`](crate::graph::GraphStore::add_edge)
+    /// for a missing endpoint, so callers must pre-check.
+    fn is_source_episode(&self, id: &str) -> bool {
+        self.graph
+            .get_node(id)
+            .is_some_and(|n| n.node_type == NT_EPISODIC)
+    }
+
+    /// Create a provenance edge `source_id --edge_type--> episode_id` carrying a
+    /// `derived_at` timestamp. Both endpoints must already exist.
+    fn add_provenance_edge(
+        &mut self,
+        source_id: &str,
+        episode_id: &str,
+        edge_type: &str,
+    ) -> Result<()> {
+        let mut props = HashMap::new();
+        props.insert("derived_at".to_string(), ts_now().to_string());
+        self.graph
+            .add_edge(source_id, episode_id, edge_type, Some(props))
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Return the ids of every node reachable from `node_id` along an outgoing
+    /// `edge_type` edge. Empty for unknown ids or nodes with no such edges.
+    fn provenance_targets(&self, node_id: &str, edge_type: &str) -> Vec<String> {
+        self.graph
+            .query_neighbors(node_id, Some(edge_type), Direction::Outgoing, usize::MAX)
+            .into_iter()
+            .map(|(_, node)| node.node_id)
+            .collect()
     }
 
     // ======================================================================

--- a/rust/amplihack-memory/src/cognitive_memory/procedural.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/procedural.rs
@@ -8,7 +8,7 @@ use crate::{MemoryError, Result};
 use tracing::warn;
 
 use super::converters::node_to_procedural;
-use super::types::{agent_filter, new_id, ts_now, NT_PROCEDURAL};
+use super::types::{agent_filter, new_id, ts_now, ET_PROCEDURE_DERIVES_FROM, NT_PROCEDURAL};
 use super::CognitiveMemory;
 
 impl CognitiveMemory {
@@ -19,7 +19,119 @@ impl CognitiveMemory {
     /// place and returns its `node_id` rather than creating a duplicate. This
     /// matches the semantics consumers expect when re-registering procedures
     /// (e.g. on agent restart) and avoids unbounded duplicate accumulation.
+    ///
+    /// Backward-compatible: this is exactly
+    /// [`store_procedure_with_provenance`](Self::store_procedure_with_provenance)
+    /// with no source episodes, so it never creates provenance edges.
     pub fn store_procedure(
+        &mut self,
+        name: &str,
+        steps: &[String],
+        prerequisites: Option<&[String]>,
+    ) -> Result<String> {
+        self.store_procedure_with_provenance(name, steps, prerequisites, &[])
+    }
+
+    /// Store a procedure and link it to the episodes it was derived from.
+    ///
+    /// Identical to [`store_procedure`](Self::store_procedure) — including the
+    /// idempotent upsert-by-name — but additionally creates a
+    /// `PROCEDURE_DERIVES_FROM` edge from the (possibly pre-existing) procedure
+    /// node to each id in `source_episode_ids`. Re-storing the same name reuses
+    /// the canonical node, so provenance edges from multiple calls all attach to
+    /// a single node rather than forking it.
+    ///
+    /// Lenient: a source-episode id that does not resolve to an existing
+    /// [`EpisodicMemory`](crate::memory_types::EpisodicMemory) node is skipped
+    /// with a warning. Use
+    /// [`store_procedure_with_provenance_strict`](Self::store_procedure_with_provenance_strict)
+    /// to reject missing episodes instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Storage` if the node or an edge cannot be
+    /// persisted.
+    pub fn store_procedure_with_provenance(
+        &mut self,
+        name: &str,
+        steps: &[String],
+        prerequisites: Option<&[String]>,
+        source_episode_ids: &[String],
+    ) -> Result<String> {
+        self.store_procedure_with_provenance_inner(
+            name,
+            steps,
+            prerequisites,
+            source_episode_ids,
+            false,
+        )
+    }
+
+    /// Strict variant of
+    /// [`store_procedure_with_provenance`](Self::store_procedure_with_provenance):
+    /// any id in `source_episode_ids` that is not an existing episode node makes
+    /// the whole call fail with `MemoryError::InvalidInput` and write zero edges
+    /// (and perform no upsert), giving validate-then-emit atomicity.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::InvalidInput` if any source episode is missing, or
+    /// `MemoryError::Storage` on a backend failure.
+    pub fn store_procedure_with_provenance_strict(
+        &mut self,
+        name: &str,
+        steps: &[String],
+        prerequisites: Option<&[String]>,
+        source_episode_ids: &[String],
+    ) -> Result<String> {
+        self.store_procedure_with_provenance_inner(
+            name,
+            steps,
+            prerequisites,
+            source_episode_ids,
+            true,
+        )
+    }
+
+    fn store_procedure_with_provenance_inner(
+        &mut self,
+        name: &str,
+        steps: &[String],
+        prerequisites: Option<&[String]>,
+        source_episode_ids: &[String],
+        strict: bool,
+    ) -> Result<String> {
+        // Validate-then-emit: in strict mode reject before any write (including
+        // the upsert) so a failure changes nothing.
+        if strict {
+            for ep in source_episode_ids {
+                if !self.is_source_episode(ep) {
+                    return Err(MemoryError::InvalidInput(format!(
+                        "source episode {ep} not found"
+                    )));
+                }
+            }
+        }
+
+        let node_id = self.upsert_procedure(name, steps, prerequisites)?;
+
+        for ep in source_episode_ids {
+            if self.is_source_episode(ep) {
+                self.add_provenance_edge(&node_id, ep, ET_PROCEDURE_DERIVES_FROM)?;
+            } else {
+                warn!(
+                    "store_procedure_with_provenance: source episode {ep} not found; \
+                     skipping PROCEDURE_DERIVES_FROM edge"
+                );
+            }
+        }
+
+        Ok(node_id)
+    }
+
+    /// Idempotent upsert-by-name: update an existing procedure's
+    /// steps/prerequisites in place (returning its id) or insert a new node.
+    fn upsert_procedure(
         &mut self,
         name: &str,
         steps: &[String],
@@ -66,6 +178,15 @@ impl CognitiveMemory {
             .map_err(|e| MemoryError::Storage(e.to_string()))?;
 
         Ok(node_id)
+    }
+
+    /// Return the ids of the episodes a procedure was derived from.
+    ///
+    /// Reads the `PROCEDURE_DERIVES_FROM` provenance edges outgoing from
+    /// `procedure_id`. Returns an empty vector for an unknown id or a procedure
+    /// with no provenance.
+    pub fn procedure_provenance(&self, procedure_id: &str) -> Vec<String> {
+        self.provenance_targets(procedure_id, ET_PROCEDURE_DERIVES_FROM)
     }
 
     /// Return the `node_id` of an existing procedure with `name` for this agent,

--- a/rust/amplihack-memory/src/cognitive_memory/semantic.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/semantic.rs
@@ -16,6 +16,10 @@ impl CognitiveMemory {
     ///
     /// Vector embeddings are not available in the Rust port; keyword search
     /// is used for retrieval.
+    ///
+    /// Backward-compatible: this is exactly
+    /// [`store_fact_with_provenance`](Self::store_fact_with_provenance) with no
+    /// source episodes, so it never creates provenance edges.
     pub fn store_fact(
         &mut self,
         concept: &str,
@@ -25,10 +29,121 @@ impl CognitiveMemory {
         tags: Option<&[String]>,
         metadata: Option<&HashMap<String, serde_json::Value>>,
     ) -> Result<String> {
+        self.store_fact_with_provenance(
+            concept,
+            content,
+            confidence,
+            source_id,
+            tags,
+            metadata,
+            &[],
+        )
+    }
+
+    /// Store a semantic fact and link it to the episodes it was derived from.
+    ///
+    /// Identical to [`store_fact`](Self::store_fact) but additionally creates a
+    /// `DERIVES_FROM` edge from the new fact node to each id in
+    /// `source_episode_ids`, turning the flat fact store into a connected
+    /// provenance graph. `source_id` remains an opaque string property and is
+    /// never auto-converted into an edge.
+    ///
+    /// Lenient: a source-episode id that does not resolve to an existing
+    /// [`EpisodicMemory`](crate::memory_types::EpisodicMemory) node is skipped
+    /// with a warning rather than failing the call. Use
+    /// [`store_fact_with_provenance_strict`](Self::store_fact_with_provenance_strict)
+    /// to reject missing episodes instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::InvalidInput` if `confidence` is outside
+    /// `0.0..=1.0`, or `MemoryError::Storage` if the node or an edge cannot be
+    /// persisted.
+    #[allow(clippy::too_many_arguments)]
+    pub fn store_fact_with_provenance(
+        &mut self,
+        concept: &str,
+        content: &str,
+        confidence: f64,
+        source_id: &str,
+        tags: Option<&[String]>,
+        metadata: Option<&HashMap<String, serde_json::Value>>,
+        source_episode_ids: &[String],
+    ) -> Result<String> {
+        self.store_fact_with_provenance_inner(
+            concept,
+            content,
+            confidence,
+            source_id,
+            tags,
+            metadata,
+            source_episode_ids,
+            false,
+        )
+    }
+
+    /// Strict variant of
+    /// [`store_fact_with_provenance`](Self::store_fact_with_provenance): any id
+    /// in `source_episode_ids` that is not an existing episode node makes the
+    /// whole call fail with `MemoryError::InvalidInput` and write zero edges
+    /// (validate-then-emit atomicity).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::InvalidInput` if `confidence` is out of range or
+    /// any source episode is missing, or `MemoryError::Storage` on a backend
+    /// failure.
+    #[allow(clippy::too_many_arguments)]
+    pub fn store_fact_with_provenance_strict(
+        &mut self,
+        concept: &str,
+        content: &str,
+        confidence: f64,
+        source_id: &str,
+        tags: Option<&[String]>,
+        metadata: Option<&HashMap<String, serde_json::Value>>,
+        source_episode_ids: &[String],
+    ) -> Result<String> {
+        self.store_fact_with_provenance_inner(
+            concept,
+            content,
+            confidence,
+            source_id,
+            tags,
+            metadata,
+            source_episode_ids,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn store_fact_with_provenance_inner(
+        &mut self,
+        concept: &str,
+        content: &str,
+        confidence: f64,
+        source_id: &str,
+        tags: Option<&[String]>,
+        metadata: Option<&HashMap<String, serde_json::Value>>,
+        source_episode_ids: &[String],
+        strict: bool,
+    ) -> Result<String> {
         if confidence.is_nan() || !(0.0..=1.0).contains(&confidence) {
             return Err(MemoryError::InvalidInput(
                 "confidence must be between 0.0 and 1.0".into(),
             ));
+        }
+
+        // Validate-then-emit: in strict mode reject before any write so a
+        // failure leaves neither a node nor any provenance edge behind.
+        if strict {
+            for ep in source_episode_ids {
+                if !self.is_source_episode(ep) {
+                    return Err(MemoryError::InvalidInput(format!(
+                        "source episode {ep} not found"
+                    )));
+                }
+            }
         }
 
         let node_id = new_id("sem");
@@ -64,6 +179,17 @@ impl CognitiveMemory {
         self.graph
             .add_node(NT_SEMANTIC, props, Some(&node_id))
             .map_err(|e| MemoryError::Storage(e.to_string()))?;
+
+        for ep in source_episode_ids {
+            if self.is_source_episode(ep) {
+                self.add_provenance_edge(&node_id, ep, ET_DERIVES_FROM)?;
+            } else {
+                warn!(
+                    "store_fact_with_provenance: source episode {ep} not found; \
+                     skipping DERIVES_FROM edge"
+                );
+            }
+        }
 
         Ok(node_id)
     }
@@ -177,5 +303,43 @@ impl CognitiveMemory {
             .add_edge(fact_id, episode_id, ET_DERIVES_FROM, Some(props))
             .map_err(|e| MemoryError::Storage(e.to_string()))?;
         Ok(())
+    }
+
+    /// Link a fact to several source episodes at once, returning how many edges
+    /// were actually created.
+    ///
+    /// Lenient, mirroring
+    /// [`store_fact_with_provenance`](Self::store_fact_with_provenance): each id
+    /// in `episode_ids` that resolves to an existing episode node gets a
+    /// `DERIVES_FROM` edge from `fact_id`; ids that do not are skipped with a
+    /// warning. The returned count reflects only the edges created.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Storage` if the backend rejects an edge whose
+    /// endpoints both exist (e.g. `fact_id` itself is missing).
+    pub fn link_fact_to_episodes(
+        &mut self,
+        fact_id: &str,
+        episode_ids: &[String],
+    ) -> Result<usize> {
+        let mut created = 0;
+        for ep in episode_ids {
+            if self.is_source_episode(ep) {
+                self.add_provenance_edge(fact_id, ep, ET_DERIVES_FROM)?;
+                created += 1;
+            } else {
+                warn!("link_fact_to_episodes: source episode {ep} not found; skipping");
+            }
+        }
+        Ok(created)
+    }
+
+    /// Return the ids of the episodes a fact was derived from.
+    ///
+    /// Reads the `DERIVES_FROM` provenance edges outgoing from `fact_id`.
+    /// Returns an empty vector for an unknown id or a fact with no provenance.
+    pub fn fact_provenance(&self, fact_id: &str) -> Vec<String> {
+        self.provenance_targets(fact_id, ET_DERIVES_FROM)
     }
 }

--- a/rust/amplihack-memory/src/cognitive_memory/tests/integration_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/integration_tests.rs
@@ -140,3 +140,98 @@ fn test_get_memory_stats_all_categories() {
     assert!(stats.contains_key("prospective"));
     assert!(stats.contains_key("total"));
 }
+
+// ===========================================================================
+// Provenance edges (issue #90): plural linking + typed read path
+//
+// File: rust/amplihack-memory/src/cognitive_memory/tests/integration_tests.rs
+//
+// Failing-first TDD tests for the not-yet-implemented `link_fact_to_episodes`,
+// `fact_provenance`, and `procedure_provenance`.
+// ===========================================================================
+
+/// `link_fact_to_episodes` is lenient and returns the count of edges actually
+/// created: 2 valid + 1 missing episode id -> returns 2, two edges present.
+/// (Invariants I2, I3.)
+#[test]
+fn test_link_fact_to_episodes_counts_created_edges() {
+    let mut cm = make_cm();
+    let fact = cm
+        .store_fact("topic", "a general fact", 0.8, "", None, None)
+        .unwrap();
+    let ep1 = cm.store_episode("episode one", "src", None, None).unwrap();
+    let ep2 = cm.store_episode("episode two", "src", None, None).unwrap();
+
+    let created = cm
+        .link_fact_to_episodes(
+            &fact,
+            &[ep1.clone(), ep2.clone(), "epi_missing".to_string()],
+        )
+        .expect("link_fact_to_episodes is lenient and must succeed");
+    assert_eq!(
+        created, 2,
+        "only the two valid episodes should be linked (the missing id is skipped)"
+    );
+
+    use crate::graph::Direction as Dir;
+    let neighbors = cm
+        .graph
+        .query_neighbors(&fact, Some(ET_DERIVES_FROM), Dir::Outgoing, 10);
+    assert_eq!(neighbors.len(), 2);
+    let targets: std::collections::HashSet<String> =
+        neighbors.iter().map(|(_, n)| n.node_id.clone()).collect();
+    assert!(targets.contains(&ep1));
+    assert!(targets.contains(&ep2));
+
+    // Read path agrees.
+    let mut prov = cm.fact_provenance(&fact);
+    prov.sort();
+    let mut want = vec![ep1, ep2];
+    want.sort();
+    assert_eq!(prov, want);
+}
+
+/// The typed read methods return the linked episode ids and `[]` for unknown
+/// ids or nodes with no provenance, for both facts and procedures. They keep
+/// the `graph` field private from external consumers. (Invariant I8.)
+#[test]
+fn test_fact_and_procedure_provenance_read_path() {
+    let mut cm = make_cm();
+
+    // Unknown ids return empty (no panic).
+    assert!(cm.fact_provenance("does-not-exist").is_empty());
+    assert!(cm.procedure_provenance("does-not-exist").is_empty());
+
+    let ep1 = cm.store_episode("ep one", "src", None, None).unwrap();
+    let ep2 = cm.store_episode("ep two", "src", None, None).unwrap();
+
+    // A node with no provenance edges returns [].
+    let plain = cm
+        .store_fact("c", "no provenance", 0.5, "", None, None)
+        .unwrap();
+    assert!(cm.fact_provenance(&plain).is_empty());
+
+    // A fact stored with provenance surfaces all its source episodes.
+    let fact = cm
+        .store_fact_with_provenance(
+            "c",
+            "derived",
+            0.9,
+            "",
+            None,
+            None,
+            &[ep1.clone(), ep2.clone()],
+        )
+        .unwrap();
+    let mut got = cm.fact_provenance(&fact);
+    got.sort();
+    let mut want = vec![ep1.clone(), ep2.clone()];
+    want.sort();
+    assert_eq!(got, want, "fact_provenance must return all linked episodes");
+
+    // Procedure read path mirrors the fact read path.
+    let proc = cm
+        .store_procedure_with_provenance("p", &["s".to_string()], None, std::slice::from_ref(&ep1))
+        .unwrap();
+    assert_eq!(cm.procedure_provenance(&proc), vec![ep1]);
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
@@ -838,3 +838,106 @@ fn checkpoint_then_reopen_returns_all_records_and_needs_no_replay() {
     let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
     assert_eq!(*cm.get_memory_stats().get("total").unwrap(), expected_total);
 }
+
+// ===========================================================================
+// Provenance edges (issue #90): durability across close + reopen
+//
+// File: rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+//
+// Failing-first TDD tests proving DERIVES_FROM / PROCEDURE_DERIVES_FROM edges
+// survive a drop + reopen on the LadybugDB persistent backend (which also
+// proves the new PROCEDURE_DERIVES_FROM rel table is reintrospected on reopen).
+// Gated by the `persistent` feature via the parent `tests` module.
+// (Invariant I7.)
+// ===========================================================================
+
+#[test]
+fn fact_provenance_edge_survives_reopen() {
+    use crate::cognitive_memory::types::ET_DERIVES_FROM;
+    use crate::graph::Direction;
+
+    let (_tmp, path) = temp_db();
+    let fact_id;
+    let ep_id;
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        ep_id = cm
+            .store_episode("source episode", "src", Some(1), None)
+            .unwrap();
+        fact_id = cm
+            .store_fact_with_provenance(
+                "concept",
+                "derived knowledge",
+                0.9,
+                "",
+                None,
+                None,
+                std::slice::from_ref(&ep_id),
+            )
+            .unwrap();
+
+        // Edge present before close.
+        assert_eq!(cm.fact_provenance(&fact_id), vec![ep_id.clone()]);
+        cm.close();
+    } // dropped -> LadybugDB flushed to disk
+
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+
+    // The DERIVES_FROM edge survived close + reopen, observable via both the
+    // public read path and a raw neighbor query.
+    assert_eq!(
+        cm.fact_provenance(&fact_id),
+        vec![ep_id.clone()],
+        "fact provenance edge must persist across close + reopen"
+    );
+    let neighbors =
+        cm.graph
+            .query_neighbors(&fact_id, Some(ET_DERIVES_FROM), Direction::Outgoing, 10);
+    assert_eq!(neighbors.len(), 1);
+    assert_eq!(neighbors[0].1.node_id, ep_id);
+}
+
+#[test]
+fn procedure_provenance_edge_survives_reopen() {
+    use crate::cognitive_memory::types::ET_PROCEDURE_DERIVES_FROM;
+    use crate::graph::Direction;
+
+    let (_tmp, path) = temp_db();
+    let proc_id;
+    let ep_id;
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        ep_id = cm
+            .store_episode("deploy event", "ops", Some(1), None)
+            .unwrap();
+        proc_id = cm
+            .store_procedure_with_provenance(
+                "deploy",
+                &steps(&["build", "rollout"]),
+                None,
+                std::slice::from_ref(&ep_id),
+            )
+            .unwrap();
+
+        assert_eq!(cm.procedure_provenance(&proc_id), vec![ep_id.clone()]);
+        cm.close();
+    } // dropped -> LadybugDB flushed to disk
+
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+
+    // The PROCEDURE_DERIVES_FROM edge survived reopen; reaching it also proves
+    // the new rel table was reintrospected.
+    assert_eq!(
+        cm.procedure_provenance(&proc_id),
+        vec![ep_id.clone()],
+        "procedure provenance edge must persist across close + reopen"
+    );
+    let neighbors = cm.graph.query_neighbors(
+        &proc_id,
+        Some(ET_PROCEDURE_DERIVES_FROM),
+        Direction::Outgoing,
+        10,
+    );
+    assert_eq!(neighbors.len(), 1);
+    assert_eq!(neighbors[0].1.node_id, ep_id);
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/procedural_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/procedural_tests.rs
@@ -1,4 +1,7 @@
+use super::super::types::ET_PROCEDURE_DERIVES_FROM;
 use super::super::*;
+use crate::graph::Direction;
+use crate::MemoryError;
 
 fn make_cm() -> CognitiveMemory {
     CognitiveMemory::new(&format!("test-agent-{}", uuid::Uuid::new_v4())).unwrap()
@@ -164,4 +167,181 @@ fn test_recall_procedure_increments_and_orders_by_usage() {
     let ranked = cm.search_procedures("shared", 10);
     assert_eq!(ranked[0].usage_count, 4);
     assert_eq!(ranked[1].usage_count, 1);
+}
+
+// ===========================================================================
+// Provenance edges (issue #90):
+//   ProceduralMemory --PROCEDURE_DERIVES_FROM--> EpisodicMemory
+//
+// File: rust/amplihack-memory/src/cognitive_memory/tests/procedural_tests.rs
+//
+// Failing-first TDD tests for the not-yet-implemented
+// `store_procedure_with_provenance`, `store_procedure_with_provenance_strict`,
+// the new `ET_PROCEDURE_DERIVES_FROM` constant, and `procedure_provenance`.
+// ===========================================================================
+
+/// A procedure stored with one source episode gets exactly one outgoing
+/// `PROCEDURE_DERIVES_FROM` edge procedure -> episode. (Invariants I1, I8.)
+#[test]
+fn test_store_procedure_with_provenance_creates_edge() {
+    let mut cm = make_cm();
+    let ep = cm
+        .store_episode("watched a production deploy", "ops", None, None)
+        .unwrap();
+
+    let proc = cm
+        .store_procedure_with_provenance(
+            "deploy",
+            &["build".to_string(), "rollout".to_string()],
+            None,
+            std::slice::from_ref(&ep),
+        )
+        .unwrap();
+    assert!(proc.starts_with("proc_"));
+
+    let neighbors = cm.graph.query_neighbors(
+        &proc,
+        Some(ET_PROCEDURE_DERIVES_FROM),
+        Direction::Outgoing,
+        10,
+    );
+    assert_eq!(
+        neighbors.len(),
+        1,
+        "expected exactly one PROCEDURE_DERIVES_FROM edge"
+    );
+    assert_eq!(neighbors[0].0.edge_type, ET_PROCEDURE_DERIVES_FROM);
+    assert_eq!(neighbors[0].1.node_id, ep);
+
+    // The procedure is otherwise stored normally.
+    let procs = cm.search_procedures("deploy", 10);
+    assert_eq!(procs.len(), 1);
+    assert_eq!(
+        procs[0].steps,
+        vec!["build".to_string(), "rollout".to_string()]
+    );
+
+    // Public typed read path.
+    assert_eq!(cm.procedure_provenance(&proc), vec![ep]);
+}
+
+/// Lenient mode skips a missing source episode and still succeeds.
+/// (Invariant I2.)
+#[test]
+fn test_store_procedure_with_provenance_lenient_skips_missing() {
+    let mut cm = make_cm();
+    let ep = cm.store_episode("real episode", "src", None, None).unwrap();
+
+    let proc = cm
+        .store_procedure_with_provenance(
+            "p",
+            &["s".to_string()],
+            None,
+            &[ep.clone(), "epi_missing".to_string()],
+        )
+        .expect("lenient procedure provenance store must succeed");
+
+    assert_eq!(cm.procedure_provenance(&proc), vec![ep]);
+}
+
+/// Strict mode rejects a missing source episode with `InvalidInput` and writes
+/// zero edges. (Invariant I4.)
+#[test]
+fn test_store_procedure_with_provenance_strict_errors_on_missing() {
+    let mut cm = make_cm();
+    let ep = cm.store_episode("real episode", "src", None, None).unwrap();
+
+    let result = cm.store_procedure_with_provenance_strict(
+        "p",
+        &["s".to_string()],
+        None,
+        &[ep.clone(), "epi_missing".to_string()],
+    );
+    assert!(
+        matches!(result, Err(MemoryError::InvalidInput(_))),
+        "strict mode must reject a missing source episode, got {result:?}"
+    );
+
+    let incoming = cm.graph.query_neighbors(
+        &ep,
+        Some(ET_PROCEDURE_DERIVES_FROM),
+        Direction::Incoming,
+        10,
+    );
+    assert!(
+        incoming.is_empty(),
+        "a strict failure must create zero provenance edges (atomicity)"
+    );
+}
+
+/// Plain `store_procedure` stays backward compatible: no provenance edges.
+/// (Invariant I5.)
+#[test]
+fn test_store_procedure_backward_compatible_no_edges() {
+    let mut cm = make_cm();
+    let _ep = cm.store_episode("unrelated", "src", None, None).unwrap();
+
+    let proc = cm.store_procedure("p", &["s".to_string()], None).unwrap();
+
+    let neighbors = cm.graph.query_neighbors(
+        &proc,
+        Some(ET_PROCEDURE_DERIVES_FROM),
+        Direction::Outgoing,
+        10,
+    );
+    assert!(
+        neighbors.is_empty(),
+        "plain store_procedure must not create provenance edges"
+    );
+    assert!(cm.procedure_provenance(&proc).is_empty());
+}
+
+/// The idempotent upsert-by-name is preserved by the provenance variant:
+/// re-storing the same name reuses the node id (provenance never forks the
+/// node), updates steps in place, and attaches provenance edges to the single
+/// canonical node. (Invariant I6.)
+#[test]
+fn test_store_procedure_with_provenance_upsert_preserves_node_id() {
+    let mut cm = make_cm();
+    let ep1 = cm.store_episode("ep1", "src", None, None).unwrap();
+    let ep2 = cm.store_episode("ep2", "src", None, None).unwrap();
+
+    let id1 = cm
+        .store_procedure_with_provenance(
+            "build",
+            &["a".to_string()],
+            None,
+            std::slice::from_ref(&ep1),
+        )
+        .unwrap();
+    let id2 = cm
+        .store_procedure_with_provenance(
+            "build",
+            &["a".to_string(), "b".to_string()],
+            None,
+            std::slice::from_ref(&ep2),
+        )
+        .unwrap();
+
+    assert_eq!(id1, id2, "re-storing the same name must reuse the node id");
+    assert_eq!(
+        cm.get_memory_stats().get("procedural"),
+        Some(&1),
+        "idempotent upsert must not accumulate duplicate procedure nodes"
+    );
+
+    // Steps were updated in place by the second store.
+    let procs = cm.search_procedures("build", 10);
+    assert_eq!(procs.len(), 1);
+    assert_eq!(procs[0].steps, vec!["a".to_string(), "b".to_string()]);
+
+    // Both provenance edges attach to the single canonical node.
+    let mut prov = cm.procedure_provenance(&id1);
+    prov.sort();
+    let mut want = vec![ep1, ep2];
+    want.sort();
+    assert_eq!(
+        prov, want,
+        "provenance edges from both upsert calls attach to the same node"
+    );
 }

--- a/rust/amplihack-memory/src/cognitive_memory/tests/semantic_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/semantic_tests.rs
@@ -1,5 +1,7 @@
+use super::super::types::ET_DERIVES_FROM;
 use super::super::*;
 use crate::graph::Direction;
+use crate::MemoryError;
 
 fn make_cm() -> CognitiveMemory {
     CognitiveMemory::new(&format!("test-agent-{}", uuid::Uuid::new_v4())).unwrap()
@@ -196,4 +198,195 @@ fn test_search_facts_tokenized_multiword_or() {
 
     // No token overlaps -> no match.
     assert!(cm.search_facts("elephant zebra", 10, 0.0).is_empty());
+}
+
+// ===========================================================================
+// Provenance edges (issue #90): SemanticMemory --DERIVES_FROM--> EpisodicMemory
+//
+// File: rust/amplihack-memory/src/cognitive_memory/tests/semantic_tests.rs
+//
+// These are failing-first TDD tests. They exercise the not-yet-implemented
+// `store_fact_with_provenance`, `store_fact_with_provenance_strict`, and the
+// `fact_provenance` read path. Direction is derived -> episode (Outgoing from
+// the fact), matching the existing `link_fact_to_episode` assertion pattern.
+// ===========================================================================
+
+/// A fact stored with one real source episode gets exactly one outgoing
+/// `DERIVES_FROM` edge pointing fact -> episode, and the public read path
+/// surfaces that episode id. (Invariants I1, I2, I8.)
+#[test]
+fn test_store_fact_with_provenance_creates_derives_from_edge() {
+    let mut cm = make_cm();
+    let ep = cm
+        .store_episode("observed that rust compiles", "reading", None, None)
+        .unwrap();
+
+    let fact = cm
+        .store_fact_with_provenance(
+            "rust",
+            "Rust is memory safe",
+            0.95,
+            "",
+            None,
+            None,
+            std::slice::from_ref(&ep),
+        )
+        .unwrap();
+
+    // The fact node itself is stored and searchable, exactly like store_fact.
+    assert!(fact.starts_with("sem_"));
+    assert!(cm
+        .search_facts("rust", 10, 0.0)
+        .iter()
+        .any(|f| f.node_id == fact));
+
+    // Exactly one DERIVES_FROM edge, fact -> episode.
+    let neighbors = cm
+        .graph
+        .query_neighbors(&fact, Some(ET_DERIVES_FROM), Direction::Outgoing, 10);
+    assert_eq!(
+        neighbors.len(),
+        1,
+        "expected exactly one DERIVES_FROM edge from the fact"
+    );
+    assert_eq!(neighbors[0].0.edge_type, ET_DERIVES_FROM);
+    assert_eq!(neighbors[0].1.node_id, ep);
+
+    // Public typed read path returns the same source episode id.
+    assert_eq!(cm.fact_provenance(&fact), vec![ep]);
+}
+
+/// Lenient mode: a missing source episode id is skipped with a warning (the
+/// call still succeeds) and only the valid episode is linked. (Invariant I2.)
+#[test]
+fn test_store_fact_with_provenance_lenient_skips_missing_episode() {
+    let mut cm = make_cm();
+    let ep = cm.store_episode("real episode", "src", None, None).unwrap();
+
+    let fact = cm
+        .store_fact_with_provenance(
+            "topic",
+            "a derived fact",
+            0.8,
+            "",
+            None,
+            None,
+            &[ep.clone(), "epi_does_not_exist".to_string()],
+        )
+        .expect("lenient provenance store must succeed despite a missing episode");
+
+    let neighbors = cm
+        .graph
+        .query_neighbors(&fact, Some(ET_DERIVES_FROM), Direction::Outgoing, 10);
+    assert_eq!(
+        neighbors.len(),
+        1,
+        "the missing episode id must be skipped, only the valid one linked"
+    );
+    assert_eq!(neighbors[0].1.node_id, ep);
+    assert_eq!(cm.fact_provenance(&fact), vec![ep]);
+}
+
+/// Strict mode: any missing source episode id makes the call return
+/// `InvalidInput` and write ZERO provenance edges (validate-then-emit
+/// atomicity). (Invariant I4.)
+#[test]
+fn test_store_fact_with_provenance_strict_errors_on_missing_episode() {
+    let mut cm = make_cm();
+    let ep = cm.store_episode("real episode", "src", None, None).unwrap();
+
+    let result = cm.store_fact_with_provenance_strict(
+        "topic",
+        "a derived fact",
+        0.8,
+        "",
+        None,
+        None,
+        &[ep.clone(), "epi_missing".to_string()],
+    );
+    assert!(
+        matches!(result, Err(MemoryError::InvalidInput(_))),
+        "strict mode must reject a missing source episode with InvalidInput, got {result:?}"
+    );
+
+    // Atomicity: not even the valid episode may receive an edge from the failed
+    // call. No DERIVES_FROM edge points at the episode.
+    let incoming = cm
+        .graph
+        .query_neighbors(&ep, Some(ET_DERIVES_FROM), Direction::Incoming, 10);
+    assert!(
+        incoming.is_empty(),
+        "a strict failure must create zero provenance edges (atomicity)"
+    );
+}
+
+/// An empty `source_episode_ids` slice creates no edges: the provenance API is
+/// observably identical to plain `store_fact` on the no-provenance path.
+/// (Invariant I5.)
+#[test]
+fn test_store_fact_with_provenance_empty_slice_creates_no_edges() {
+    let mut cm = make_cm();
+    let fact = cm
+        .store_fact_with_provenance("c", "content", 0.5, "src", None, None, &[])
+        .unwrap();
+
+    let neighbors = cm
+        .graph
+        .query_neighbors(&fact, Some(ET_DERIVES_FROM), Direction::Outgoing, 10);
+    assert!(
+        neighbors.is_empty(),
+        "empty provenance must create no edges"
+    );
+    assert!(cm.fact_provenance(&fact).is_empty());
+
+    // Node stored normally.
+    let facts = cm.search_facts("content", 10, 0.0);
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].node_id, fact);
+}
+
+/// Plain `store_fact` stays backward compatible: it creates no provenance
+/// edges and stores the node (including the `source_id` string property)
+/// exactly as before. (Invariant I5.)
+#[test]
+fn test_store_fact_backward_compatible_creates_no_edges() {
+    let mut cm = make_cm();
+    let _ep = cm
+        .store_episode("an unrelated episode", "src", None, None)
+        .unwrap();
+
+    let fact = cm
+        .store_fact("plain", "a plain fact", 0.9, "src-string", None, None)
+        .unwrap();
+
+    let neighbors = cm
+        .graph
+        .query_neighbors(&fact, Some(ET_DERIVES_FROM), Direction::Outgoing, 10);
+    assert!(
+        neighbors.is_empty(),
+        "plain store_fact must not create provenance edges"
+    );
+    assert!(cm.fact_provenance(&fact).is_empty());
+
+    // source_id remains a plain string property; it is never auto-converted to
+    // an edge.
+    let facts = cm.search_facts("plain", 10, 0.0);
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].source_id, "src-string");
+}
+
+/// The provenance variant keeps the same confidence validation as
+/// `store_fact`.
+#[test]
+fn test_store_fact_with_provenance_validates_confidence() {
+    let mut cm = make_cm();
+    assert!(cm
+        .store_fact_with_provenance("c", "x", f64::NAN, "", None, None, &[])
+        .is_err());
+    assert!(cm
+        .store_fact_with_provenance("c", "x", 1.5, "", None, None, &[])
+        .is_err());
+    assert!(cm
+        .store_fact_with_provenance("c", "x", -0.1, "", None, None, &[])
+        .is_err());
 }

--- a/rust/amplihack-memory/src/cognitive_memory/types.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/types.rs
@@ -69,4 +69,13 @@ pub(crate) const ET_CONSOLIDATES: &str = "CONSOLIDATES";
 /// Edge-type label for similarity links between nodes.
 pub(crate) const ET_SIMILAR_TO: &str = "SIMILAR_TO";
 /// Edge-type label indicating one node derives from another.
+///
+/// Used for semantic-fact provenance: `SemanticMemory --DERIVES_FROM--> EpisodicMemory`.
 pub(crate) const ET_DERIVES_FROM: &str = "DERIVES_FROM";
+/// Edge-type label indicating a procedure derives from a source episode.
+///
+/// Used for procedural provenance:
+/// `ProceduralMemory --PROCEDURE_DERIVES_FROM--> EpisodicMemory`. A dedicated
+/// edge type (rather than reusing [`ET_DERIVES_FROM`]) keeps fact and procedure
+/// provenance independently queryable.
+pub(crate) const ET_PROCEDURE_DERIVES_FROM: &str = "PROCEDURE_DERIVES_FROM";


### PR DESCRIPTION
## Summary

Adds **provenance edges** to the persistent `CognitiveMemory` so consumers (e.g. Simard) can link distilled facts and procedures back to the episodes they were derived from — turning the flat node store into a connected knowledge graph. Closes #90.

Additive and fully backward compatible.

## What changed

### Semantic facts (`SemanticMemory --DERIVES_FROM--> EpisodicMemory`)
- `store_fact_with_provenance(concept, content, confidence, source_id, tags, metadata, source_episode_ids: &[String]) -> Result<String>` — stores the fact node **and** a `DERIVES_FROM` edge to each source episode. Lenient: a source-episode id that doesn't resolve to an existing episode node is skipped with a `warn!`.
- `store_fact_with_provenance_strict(...)` — same signature; a missing source episode returns `MemoryError::InvalidInput` and writes **zero** edges (validate-then-emit).
- `link_fact_to_episodes(fact_id, episode_ids: &[String]) -> Result<usize>` — adds `DERIVES_FROM` edges, returns the count actually created (missing episodes skipped).
- `fact_provenance(fact_id) -> Vec<String>` — typed read path returning the linked episode ids.

### Procedures (`ProceduralMemory --PROCEDURE_DERIVES_FROM--> EpisodicMemory`)
- New edge type `ET_PROCEDURE_DERIVES_FROM`.
- `store_procedure_with_provenance(name, steps, prerequisites, source_episode_ids) -> Result<String>` and `_strict` variant — create `PROCEDURE_DERIVES_FROM` edges while **preserving the idempotent upsert-by-name**: edges from repeated upserts attach to the single canonical node rather than forking it.
- `procedure_provenance(procedure_id) -> Vec<String>` — typed read path.

### Backward compatibility
- `store_fact` / `store_procedure` keep their exact signatures and now delegate to the provenance variants with an empty episode slice (zero edges, identical node shapes).
- `source_id` remains an opaque string property and is never auto-converted to an edge.
- Edges are persisted by the LadybugDB backend; the new rel table is auto-created via `ensure_rel_table` and reintrospected on reopen (no manual schema).

## Design notes
- A source episode is valid iff `get_node(id)` returns a node of type `EpisodicMemory`; both graph backends reject `add_edge` for a missing endpoint, so callers must pre-check.
- Strict mode validates all episode ids *before* any write, giving atomic all-or-nothing edge creation.
- Edges carry a `derived_at` timestamp and point derived-node -> episode (Outgoing).

## Tests (strict TDD, failing-first)
In-memory (`InMemoryGraphStore`) and persistent (`lbug`) backends:
- exactly-one `DERIVES_FROM` edge fact->episode + typed read path;
- lenient skip of missing episode; strict `InvalidInput` with zero edges;
- `link_fact_to_episodes` returns created count (2 valid + 1 missing -> 2);
- procedure `PROCEDURE_DERIVES_FROM` edges, idempotent-upsert provenance, strict atomicity;
- backward-compat: plain `store_fact` / `store_procedure` create zero provenance edges;
- **persistent durability**: fact and procedure provenance edges survive `close()` + `open_persistent` reopen (also proves the new rel table is reintrospected).

All green:
- `cargo test` (default): **467** lib tests pass.
- `cargo test --features persistent`: **505** lib tests pass.
- `cargo fmt --check` clean; `cargo clippy --all-targets` and `--features persistent` introduce no new warnings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>