### PR TITLE
feat(cognitive-memory): Jaccard SIMILAR_TO auto-linking

### DIFF
--- a/rust/amplihack-memory/README.md
+++ b/rust/amplihack-memory/README.md
@@ -278,6 +278,84 @@ killed mid-write and the write-ahead log (WAL) is left partially written:
   as a safety net. An unclean shutdown therefore strands at most a small,
   bounded number of writes in the WAL rather than every uncheckpointed record.
 
+### Automatic `SIMILAR_TO` linking between facts
+
+`CognitiveMemory` can automatically connect related semantic facts with
+`SIMILAR_TO` edges, so knowledge about the same topic becomes traversable
+without manual bookkeeping. Similarity is computed with the crate's existing
+deterministic helpers — no embeddings, no network calls: a composite **Jaccard**
+score that blends word overlap (0.5), tag overlap (0.2), and concept overlap
+(0.3). The word and concept components are tokenized first — lower-cased, with
+English stop words and tokens of two characters or fewer removed — so only
+meaningful words drive the score. An edge is created when that score is **at or
+above** a configurable threshold (default `0.60`).
+
+Linking is **opt-in and additive** — `store_fact` and
+`store_fact_with_provenance` are unchanged and never create `SIMILAR_TO` edges
+on their own. You drive it explicitly with `auto_link_similar_facts`, in bulk
+with `rebuild_similarity_links`, or at store time with `store_fact_with_options`.
+Linking is strictly **same-agent** and **idempotent** — existing edges are never
+duplicated.
+
+`SimilarityOptions` controls the behaviour (it is `Copy`; pass
+`&SimilarityOptions::default()` for the defaults):
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `enabled` | `bool` | `true` | Master switch. `false` makes every entry point an inert no-op. |
+| `threshold` | `f64` | `0.60` | Inclusive composite score (`>=`) required to create an edge. |
+| `candidate_limit` | `usize` | `50` | Max other same-agent facts scored per source fact, taken highest-confidence first. |
+| `bidirectional` | `bool` | `true` | Also create the reciprocal `B → A` edge. |
+
+```rust
+use amplihack_memory::{CognitiveMemory, SimilarityOptions, StoreFactOptions};
+
+let mut mem = CognitiveMemory::new("research-agent")?;
+
+let rust_tags = ["rust".to_string()];
+let a = mem.store_fact("rust-safety",
+    "the rust borrow checker guarantees memory safety", 0.9, "s1", Some(&rust_tags), None)?;
+let _b = mem.store_fact("rust-safety",
+    "rust enforces memory safety at compile time via its borrow checker", 0.85, "s2", Some(&rust_tags), None)?;
+let _c = mem.store_fact("cooking",
+    "simmer onions in butter until soft", 0.8, "s3", Some(&["food".to_string()]), None)?;
+
+// Explicit: link `a` to every fact at/above the threshold (here: `b`, not `c`).
+// Returns the number of NEW unordered pairs linked this call.
+let linked = mem.auto_link_similar_facts(&a, &SimilarityOptions::default())?;
+assert_eq!(linked, 1);
+
+// Idempotent: a second call creates nothing new.
+assert_eq!(mem.auto_link_similar_facts(&a, &SimilarityOptions::default())?, 0);
+
+// Backfill / maintenance across the whole agent (additive, non-destructive).
+let report = mem.rebuild_similarity_links(&SimilarityOptions::default())?;
+println!("processed {} facts, {} new links", report.facts_processed, report.links_created);
+
+// Opt-in store-time linking: wire up each new fact as it lands.
+let opts = StoreFactOptions { similarity: Some(SimilarityOptions::default()) };
+let _id = mem.store_fact_with_options("rust-safety",
+    "memory safety in rust comes from ownership and the borrow checker",
+    0.88, "s4", Some(&rust_tags), None, &[], &opts)?;
+```
+
+Each auto-created edge is `SemanticMemory --SIMILAR_TO--> SemanticMemory` between
+two facts of the same agent, carrying a single `similarity_score` property — the
+score as a fixed 4-decimal string (e.g. `"0.7321"`), parseable with
+`parse::<f64>()`. With `StoreFactOptions::default()` (`similarity: None`),
+`store_fact_with_options` is a byte-for-byte drop-in for
+`store_fact_with_provenance` and creates no edges. On the `persistent` backend,
+`SIMILAR_TO` edges and their scores are durable — they survive `checkpoint()`,
+`drop`, and reopen.
+
+This feature is **write-only for now**: it creates `SIMILAR_TO` edges but does
+not yet add a public API to read them back (the graph is a private field; a
+`similar_facts` reader is a deliberate, backward-compatible future addition).
+
+See [`docs/similarity_linking.md`](docs/similarity_linking.md) for the full
+reference, threshold-tuning guidance, directionality semantics, and a worked
+tutorial.
+
 ### Pattern detection
 
 ```rust
@@ -389,7 +467,7 @@ contradiction = detect_contradiction("sky is blue", "sky is green", "sky", "sky"
 | Module                 | Description                                                      |
 |------------------------|------------------------------------------------------------------|
 | `backends`             | `MemoryBackend` / `ExperienceBackend` traits and implementations (SQLite, Kuzu, LadybugDB) |
-| `cognitive_memory`     | Six-type cognitive memory over a pluggable `GraphStore` (in-memory by default; durable LadybugDB via the `persistent` feature) |
+| `cognitive_memory`     | Six-type cognitive memory over a pluggable `GraphStore` (in-memory by default; durable LadybugDB via the `persistent` feature); optional automatic `SIMILAR_TO` linking between related facts |
 | `connector`            | `MemoryConnector` — factory for backend lifecycle management     |
 | `contradiction`        | Contradiction detection between semantic facts                   |
 | `entity_extraction`    | Entity-name extraction from free text                            |

--- a/rust/amplihack-memory/docs/similarity_linking.md
+++ b/rust/amplihack-memory/docs/similarity_linking.md
@@ -1,0 +1,524 @@
+# Automatic `SIMILAR_TO` Linking Between Facts
+
+`CognitiveMemory` can automatically connect related semantic facts with
+`SIMILAR_TO` edges so that knowledge about the same topic becomes traversable —
+without any manual bookkeeping. This page is the complete reference for the
+feature: how similarity is scored, how to configure linking, the public API, the
+edge data model, and an end-to-end tutorial.
+
+- **Deterministic.** Similarity is computed with the crate's existing
+  `similarity` helpers — plain text/tag/concept Jaccard math. No embeddings, no
+  model downloads, no network calls.
+- **Additive and opt-in.** `store_fact` and `store_fact_with_provenance` are
+  unchanged and never create `SIMILAR_TO` edges on their own. You choose when
+  linking happens.
+- **Same-agent only.** A `CognitiveMemory` instance is scoped to one agent;
+  linking only ever considers facts owned by that agent. Facts belonging to
+  other agents are never connected.
+- **Idempotent.** Re-running any entry point never duplicates an existing edge.
+- **Write-only for now.** This feature *creates* `SIMILAR_TO` edges; it does not
+  yet add a public API to read them back. See
+  [Reading edges back](#reading-edges-back).
+
+---
+
+## Table of contents
+
+1. [When to use it](#when-to-use-it)
+2. [How similarity is computed](#how-similarity-is-computed)
+3. [Configuration — `SimilarityOptions`](#configuration--similarityoptions)
+4. [API reference](#api-reference)
+   - [`auto_link_similar_facts`](#auto_link_similar_factsfact_id-options---resultusize)
+   - [`rebuild_similarity_links`](#rebuild_similarity_linksoptions---resultsimilarityreport)
+   - [`store_fact_with_options`](#store_fact_with_options---resultstring)
+   - [`SimilarityReport`](#similarityreport)
+   - [`StoreFactOptions`](#storefactoptions)
+5. [Edge data model](#edge-data-model)
+   - [Reading edges back](#reading-edges-back)
+6. [Idempotency and directionality](#idempotency-and-directionality)
+7. [Persistence](#persistence)
+8. [Tutorial: building a linked knowledge base](#tutorial-building-a-linked-knowledge-base)
+9. [Relationship to manual `link_similar_facts`](#relationship-to-manual-link_similar_facts)
+10. [Compatibility and guarantees](#compatibility-and-guarantees)
+
+---
+
+## When to use it
+
+| You want to… | Use |
+|--------------|-----|
+| Link one freshly created or known fact to its neighbours | [`auto_link_similar_facts`](#auto_link_similar_factsfact_id-options---resultusize) |
+| Backfill links across an entire agent's existing facts (import, migration, threshold change) | [`rebuild_similarity_links`](#rebuild_similarity_linksoptions---resultsimilarityreport) |
+| Wire up every new fact automatically as it is stored | [`store_fact_with_options`](#store_fact_with_options---resultstring) |
+| Connect two specific facts with a score you computed yourself | the existing `link_similar_facts(a, b, score)` |
+
+If you only ever search facts by keyword (`search_facts`) and never traverse the
+graph, you do not need `SIMILAR_TO` edges at all — linking is purely additive.
+
+---
+
+## How similarity is computed
+
+Two facts are compared with the crate's composite **Jaccard** similarity
+(`amplihack_memory::similarity::compute_similarity`). The score is a weighted
+blend of three independent Jaccard overlaps:
+
+```text
+score = 0.5 · word_overlap(content_a, content_b)
+      + 0.2 · tag_overlap(tags_a,    tags_b)
+      + 0.3 · concept_overlap(concept_a, concept_b)
+```
+
+| Component | Weight | Source field | Overlap of |
+|-----------|--------|--------------|------------|
+| Word      | 0.5    | `content`    | tokenized word sets (see below) |
+| Tag       | 0.2    | `tags`       | lower-cased, trimmed tag sets |
+| Concept   | 0.3    | `concept`    | tokenized word sets (same tokenizer as `content`) |
+
+**Tokenization matters.** Both the word and concept components run their text
+through the crate's tokenizer before the Jaccard comparison. Tokenization
+lower-cases the text, splits on whitespace, strips surrounding punctuation
+(`.,;:!?()[]{}"'`), and then **removes English stop words** (`the`, `is`, `of`,
+`with`, `and`, …) and **any token of two characters or fewer**. Only the
+remaining meaningful words count toward overlap — short connective words and
+one/two-letter tokens are ignored entirely. This affects tuning: two facts that
+differ only in stop words score higher than a naive word-for-word comparison
+would suggest, while very short distinguishing tokens contribute nothing.
+
+The result is always finite and in `[0.0, 1.0]`. An edge is created when
+
+```text
+score >= options.threshold      (inclusive)
+```
+
+### Picking a threshold
+
+Because word overlap is capped at `0.5` of the total, a high threshold like the
+default **`0.60`** effectively requires facts to share *both* substantial
+content overlap *and* an overlapping concept (and ideally a shared tag).
+Unrelated facts score at or near `0.0`.
+
+| Threshold | Behaviour |
+|-----------|-----------|
+| `0.40`    | Loose — links facts that merely share a topic word or two. More edges, more noise. |
+| `0.60` (default) | Balanced — links facts that clearly describe the same thing. |
+| `0.80`    | Strict — near-duplicates only. |
+
+Tune the threshold to your corpus and re-run
+[`rebuild_similarity_links`](#rebuild_similarity_linksoptions---resultsimilarityreport)
+to apply the change. Because rebuild is additive, **lowering** the threshold and
+re-running adds the newly qualifying edges; raising it does not remove existing
+edges (delete those manually if you need to).
+
+---
+
+## Configuration — `SimilarityOptions`
+
+```rust
+pub struct SimilarityOptions {
+    pub enabled: bool,
+    pub threshold: f64,
+    pub candidate_limit: usize,
+    pub bidirectional: bool,
+}
+```
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `enabled` | `bool` | `true` | Master switch. When `false`, every entry point becomes an inert no-op (returns `Ok(0)` / an empty report and writes nothing). Lets a single options value also gate the store-time hook. |
+| `threshold` | `f64` | `0.60` | Inclusive composite score (`>=`) required to create an edge. Valid range `[0.0, 1.0]`. |
+| `candidate_limit` | `usize` | `50` | Upper bound on how many *other* same-agent facts are scored per source fact. Candidates are taken **highest-confidence first** (the same order as `get_all_facts`), then truncated to this limit — so on a corpus larger than the limit only the most-confident facts are considered, and a textually similar but low-confidence fact beyond the cutoff may never be scored. Bounds cost on large corpora. |
+| `bidirectional` | `bool` | `true` | When `true`, also create the reciprocal `B → A` edge so directional (`Outgoing`) queries find the pair from either side. |
+
+`SimilarityOptions` derives `Debug, Clone, Copy, PartialEq` (it contains an
+`f64`, so it is intentionally **not** `Eq`/`Hash`). `Default` yields
+`{ enabled: true, threshold: 0.60, candidate_limit: 50, bidirectional: true }`.
+
+```rust
+use amplihack_memory::SimilarityOptions;
+
+// Defaults.
+let opts = SimilarityOptions::default();
+
+// A stricter, one-directional, capped configuration.
+let strict = SimilarityOptions {
+    threshold: 0.75,
+    candidate_limit: 20,
+    bidirectional: false,
+    ..SimilarityOptions::default()
+};
+```
+
+All methods take `options` by reference (`&SimilarityOptions`) for signature
+consistency even though the type is `Copy`; pass `&SimilarityOptions::default()`
+for the defaults.
+
+---
+
+## API reference
+
+All three methods are inherent methods on `CognitiveMemory` and return
+`amplihack_memory::Result<T>` (`Result<T, MemoryError>`).
+
+### `auto_link_similar_facts(fact_id, options) -> Result<usize>`
+
+```rust
+pub fn auto_link_similar_facts(
+    &mut self,
+    fact_id: &str,
+    options: &SimilarityOptions,
+) -> Result<usize>;
+```
+
+Creates `SIMILAR_TO` edges from `fact_id` to every other same-agent fact whose
+composite similarity is `>= options.threshold`.
+
+**Parameters**
+
+- `fact_id` — the `node_id` of the source semantic fact (as returned by
+  `store_fact` / `store_fact_with_provenance`).
+- `options` — see [`SimilarityOptions`](#configuration--similarityoptions).
+
+**Returns** — the number of **new unordered pairs** linked by this call. A
+reciprocal edge created under `bidirectional == true` is part of the same pair
+and is *not* counted separately.
+
+**Behaviour and guarantees**
+
+- `options.enabled == false` → returns `Ok(0)` and writes nothing.
+- `fact_id` not found among this agent's semantic facts → logs a `warn!` and
+  returns `Ok(0)` (lenient; not an error).
+- Scores at most `candidate_limit` other facts — selected **highest-confidence
+  first** (the `get_all_facts` order) — with the source fact itself always
+  excluded (no self-loops). On a corpus larger than the limit, low-confidence
+  facts beyond the cutoff are not scored and so are never linked.
+- For each candidate `c` with `score >= threshold` that is **not already**
+  connected to `fact_id` by a `SIMILAR_TO` edge in *either* direction: creates
+  `fact_id → c`, plus `c → fact_id` when `bidirectional`.
+- **Idempotent** — a candidate already linked in either direction is skipped, so
+  calling the method again returns `Ok(0)`.
+
+**Errors** — propagates `MemoryError::Storage` only if the backend fails to write
+an edge between two existing nodes (degenerate; both endpoints come from the
+agent's own fact set). There is no `InvalidInput` path.
+
+```rust
+let n = mem.auto_link_similar_facts(&fact_id, &SimilarityOptions::default())?;
+println!("linked {n} new neighbour(s)");
+```
+
+### `rebuild_similarity_links(options) -> Result<SimilarityReport>`
+
+```rust
+pub fn rebuild_similarity_links(
+    &mut self,
+    options: &SimilarityOptions,
+) -> Result<SimilarityReport>;
+```
+
+Backfill / maintenance: applies the same above-threshold linking across **all**
+of the agent's semantic facts. Use it after importing facts in bulk, after a
+migration, or after changing the threshold.
+
+**Returns** — a [`SimilarityReport`](#similarityreport).
+
+**Behaviour and guarantees**
+
+- `options.enabled == false` → returns
+  `Ok(SimilarityReport { facts_processed: 0, links_created: 0 })`.
+- **Non-destructive** — never deletes edges. Existing `SIMILAR_TO` edges
+  (including ones you created manually with `link_similar_facts`) are preserved
+  and suppress duplicate creation.
+- **Idempotent** — every unordered pair is counted and created at most once even
+  when `bidirectional == false` (once `A → B` exists, processing `B` sees `A`
+  and skips). An immediate second run reports `links_created == 0`.
+- Bounded cost — at most `facts_processed · candidate_limit` similarity
+  computations.
+
+```rust
+let report = mem.rebuild_similarity_links(&SimilarityOptions::default())?;
+println!(
+    "processed {} facts, created {} new links",
+    report.facts_processed, report.links_created,
+);
+```
+
+### `store_fact_with_options(...) -> Result<String>`
+
+```rust
+pub fn store_fact_with_options(
+    &mut self,
+    concept: &str,
+    content: &str,
+    confidence: f64,
+    source_id: &str,
+    tags: Option<&[String]>,
+    metadata: Option<&HashMap<String, serde_json::Value>>,
+    source_episode_ids: &[String],
+    options: &StoreFactOptions,
+) -> Result<String>;
+```
+
+Stores a semantic fact exactly like `store_fact_with_provenance`, then —
+**only** if `options.similarity` is `Some(opts)` and `opts.enabled` — calls
+`auto_link_similar_facts(new_id, &opts)` on the freshly stored fact.
+
+**Returns** — the new fact's `node_id` (identical to
+`store_fact_with_provenance`). The auto-link count is intentionally discarded; if
+you need it, call `auto_link_similar_facts` yourself.
+
+**Behaviour**
+
+- `options.similarity == None` (the default) → **byte-for-byte equivalent** to
+  `store_fact_with_provenance(...)`; zero `SIMILAR_TO` edges. Safe drop-in.
+- `Some(opts)` with `opts.enabled == false` → fact stored, no linking.
+- `Some(opts)` with `opts.enabled == true` → fact stored *and* linked to its
+  similar neighbours.
+
+**Errors** — inherits everything `store_fact_with_provenance` can return
+(`MemoryError::InvalidInput` when `confidence ∉ [0.0, 1.0]`,
+`MemoryError::Storage` on a node/edge write failure), plus any error propagated
+from the auto-link step.
+
+### `SimilarityReport`
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimilarityReport {
+    pub facts_processed: usize,
+    pub links_created: usize,
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `facts_processed` | Number of same-agent semantic facts iterated during the rebuild. |
+| `links_created` | Number of **new unordered `SIMILAR_TO` pairs** created this pass. |
+
+It derives `Eq`, so tests can assert exact values:
+
+```rust
+assert_eq!(
+    mem.rebuild_similarity_links(&SimilarityOptions::default())?.links_created,
+    0, // second pass adds nothing
+);
+```
+
+### `StoreFactOptions`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct StoreFactOptions {
+    pub similarity: Option<SimilarityOptions>,
+}
+```
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `similarity` | `None` | `Some(opts)` (with `opts.enabled`) ⇒ auto-link the freshly stored fact; `None` ⇒ inert, behaves like `store_fact_with_provenance`. |
+
+`StoreFactOptions::default()` is `{ similarity: None }`, so the store-time hook is
+**off by default** for backward compatibility.
+
+---
+
+## Edge data model
+
+Each auto-created edge is:
+
+```text
+SemanticMemory --SIMILAR_TO--> SemanticMemory
+```
+
+between two facts owned by the **same agent**, carrying a single property:
+
+| Property | Value |
+|----------|-------|
+| `similarity_score` | The composite score formatted as a fixed **4-decimal** string, e.g. `"0.7321"`. Always parseable with `parse::<f64>()`, and equal to the score to 4 dp. |
+
+The fixed `{:.4}` format makes persistence assertions exact and round-trips
+cleanly: `props["similarity_score"].parse::<f64>()` always succeeds and equals
+the score to 4 decimal places.
+
+### Reading edges back
+
+> **This feature is write-only for now: there is currently no public API to read
+> `SIMILAR_TO` edges back.** `CognitiveMemory` owns its graph through a
+> **private** field, and the only edge readers it exposes today
+> (`fact_provenance`, `procedure_provenance`) are specific to `DERIVES_FROM`
+> provenance — not `SIMILAR_TO`. The crate's own tests verify these edges via
+> crate-internal field access
+> (`cm.graph.query_neighbors(id, Some("SIMILAR_TO"), Direction::Both, limit)`),
+> which is **not** reachable from outside the crate.
+>
+> A higher-level convenience reader — e.g.
+> `similar_facts(fact_id) -> Vec<(String, f64)>` returning each neighbour id with
+> its parsed `similarity_score` — is the natural complement to this write side. It
+> is recorded as a deliberate, **backward-compatible future addition** (see the
+> API contract §9) and is intentionally out of scope for the initial feature.
+> Until it lands, auto-linking builds graph structure that a graph-layer consumer
+> can use; there is no supported way to read the edges back through the public
+> `CognitiveMemory` surface.
+
+---
+
+## Idempotency and directionality
+
+**Idempotency** is keyed on the **unordered pair** `{A, B}`. Before linking, the
+pair is checked for an existing `SIMILAR_TO` edge in *either* direction; if one
+exists, the whole pair is skipped (no reciprocal is added either). Consequences:
+
+- Calling `auto_link_similar_facts` twice on the same fact: the second call
+  returns `Ok(0)`.
+- `rebuild_similarity_links` run twice: the second run reports
+  `links_created == 0`.
+- Manually-created `link_similar_facts` edges count as "already linked" and are
+  never duplicated by the auto-linker.
+
+**Directionality** is controlled by `bidirectional`:
+
+| `bidirectional` | Edges written for a new pair `{A, B}` (source `A`) | `Direction::Outgoing` from `A` finds `B` | from `B` finds `A` |
+|-----------------|---------------------------------------------------|------------------------------------------|--------------------|
+| `true` (default) | `A → B` **and** `B → A` | yes | yes |
+| `false`          | `A → B` only | yes | no (use `Direction::Both`) |
+
+In both cases a `Direction::Both` neighbour query sees the pair from either
+endpoint, so default traversal is unaffected by the flag.
+
+---
+
+## Persistence
+
+On the `persistent` backend (`CognitiveMemory::open_persistent(...)`), the
+`SIMILAR_TO` relationship table is created on first use and the edges — including
+the `similarity_score` property — are durable. They survive `checkpoint()`,
+`drop`, and reopen exactly like every other node and edge:
+
+```rust
+# #[cfg(feature = "persistent")]
+# fn demo() -> amplihack_memory::Result<()> {
+use amplihack_memory::{CognitiveMemory, SimilarityOptions};
+
+let path = "/var/lib/agent/cognitive.ladybug";
+{
+    let mut mem = CognitiveMemory::open_persistent(path, "agent-1")?;
+    let a = mem.store_fact("rust", "rust borrow checker memory safety", 0.9, "s", None, None)?;
+    let _b = mem.store_fact("rust", "rust borrow checker enforces memory safety", 0.9, "s", None, None)?;
+    mem.auto_link_similar_facts(&a, &SimilarityOptions::default())?;
+    mem.checkpoint()?;
+} // dropped → checkpointed
+
+// Reopen — the SIMILAR_TO edge and its similarity_score persist with the database.
+let _mem = CognitiveMemory::open_persistent(path, "agent-1")?;
+// The edge is durable; reading it back requires a graph-layer consumer —
+// no public reader is exposed yet (see "Reading edges back").
+# Ok(())
+# }
+```
+
+No schema migration is required: enabling linking on an existing database simply
+starts creating `SIMILAR_TO` edges on the next call.
+
+---
+
+## Tutorial: building a linked knowledge base
+
+This walkthrough stores a mix of related and unrelated facts, links them, backfills,
+and shows idempotency.
+
+```rust
+use amplihack_memory::{CognitiveMemory, SimilarityOptions, StoreFactOptions};
+
+fn main() -> amplihack_memory::Result<()> {
+    let mut mem = CognitiveMemory::new("research-agent")?;
+
+    // 1. Store three facts: two about Rust memory safety (related), one about cooking.
+    let rust_tags = ["rust".to_string(), "memory".to_string()];
+    let a = mem.store_fact(
+        "rust-safety",
+        "the rust borrow checker guarantees memory safety without a garbage collector",
+        0.90, "src-1", Some(&rust_tags), None,
+    )?;
+    let b = mem.store_fact(
+        "rust-safety",
+        "rust enforces memory safety at compile time through its borrow checker",
+        0.85, "src-2", Some(&rust_tags), None,
+    )?;
+    let cooking_tags = ["food".to_string()];
+    let _c = mem.store_fact(
+        "cooking",
+        "simmer onions gently in butter until soft and translucent",
+        0.80, "src-3", Some(&cooking_tags), None,
+    )?;
+
+    // 2. Explicitly link `a`. Only `b` clears the default 0.60 threshold; `c` does not.
+    let linked = mem.auto_link_similar_facts(&a, &SimilarityOptions::default())?;
+    assert_eq!(linked, 1, "a should link to b only");
+
+    // 3. Idempotency: a second call creates nothing new.
+    assert_eq!(mem.auto_link_similar_facts(&a, &SimilarityOptions::default())?, 0);
+
+    // 4. Backfill the whole agent. The a<->b pair already exists, so 0 new links.
+    let report = mem.rebuild_similarity_links(&SimilarityOptions::default())?;
+    assert_eq!(report.facts_processed, 3);
+    assert_eq!(report.links_created, 0);
+
+    // 5. Add a new fact that auto-links on store.
+    let opts = StoreFactOptions { similarity: Some(SimilarityOptions::default()) };
+    let _d = mem.store_fact_with_options(
+        "rust-safety",
+        "memory safety in rust comes from ownership and the borrow checker",
+        0.88, "src-4", Some(&rust_tags), None, &[], &opts,
+    )?;
+    // `d` is already connected to a and b.
+
+    Ok(())
+}
+```
+
+To tune the corpus, adjust `SimilarityOptions::threshold` and re-run
+`rebuild_similarity_links`. Lowering the threshold adds the newly-qualifying
+edges; the call remains idempotent and non-destructive.
+
+---
+
+## Relationship to manual `link_similar_facts`
+
+`CognitiveMemory::link_similar_facts(a, b, score)` predates this feature and is
+**unchanged**. It creates a single directed `SIMILAR_TO` edge with whatever
+score you supply, stored as the raw `score.to_string()`.
+
+| | `link_similar_facts` (manual) | auto-link path (this feature) |
+|---|---|---|
+| Score source | caller-supplied `f64` | computed via `compute_similarity` |
+| `similarity_score` format | raw `score.to_string()` | fixed `format!("{score:.4}")` |
+| Direction | single `a → b` | `a → b` (+ reciprocal if `bidirectional`) |
+| Dedup | none (caller's responsibility) | unordered-pair idempotency |
+
+The two coexist on the same `SIMILAR_TO` edge type. The auto-linker treats
+manually-created edges as "already linked" (so it never duplicates them), and
+`rebuild_similarity_links` preserves them. Because the two producers may write
+the `similarity_score` property in different precisions, **consumers should treat
+`similarity_score` as a parseable `f64` string** rather than assuming a fixed
+number of decimal places across both.
+
+---
+
+## Compatibility and guarantees
+
+- **Purely additive.** No existing public item changes signature or behaviour:
+  `store_fact`, `store_fact_with_provenance`, `store_fact_with_provenance_strict`,
+  `link_similar_facts`, `link_fact_to_episode(s)`, and `get_all_facts` are
+  untouched. `store_fact` still never creates `SIMILAR_TO` edges.
+- **New public surface** (re-exported at the crate root,
+  `amplihack_memory::{...}`): the types `SimilarityOptions`, `SimilarityReport`,
+  `StoreFactOptions`, and the three `CognitiveMemory` methods above.
+- **No new dependencies and no new math** — built entirely on the existing
+  `similarity` module helpers.
+- **Same-agent isolation** is never crossed.
+- **Works on both backends** — default in-memory and `--features persistent` —
+  with identical semantics; edges and scores are durable on the persistent
+  backend.
+
+See the crate [`README.md`](../README.md) for the short version embedded in the
+cognitive-memory quick start.

--- a/rust/amplihack-memory/src/cognitive_memory/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/mod.rs
@@ -18,9 +18,11 @@ mod procedural;
 mod prospective;
 mod semantic;
 mod sensory;
+mod similarity;
 mod types;
 mod working;
 
+pub use similarity::{SimilarityOptions, SimilarityReport, StoreFactOptions};
 pub use types::WORKING_MEMORY_CAPACITY;
 
 use std::collections::HashMap;

--- a/rust/amplihack-memory/src/cognitive_memory/similarity.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/similarity.rs
@@ -1,0 +1,302 @@
+//! Automatic `SIMILAR_TO` linking for semantic facts.
+//!
+//! Connects related semantic facts with `SIMILAR_TO` edges using the
+//! deterministic Jaccard/tag/concept composite score from
+//! [`crate::similarity::compute_similarity`] (no ML embeddings required).
+//!
+//! Two entry points are provided on [`CognitiveMemory`]:
+//!
+//! * [`auto_link_similar_facts`](CognitiveMemory::auto_link_similar_facts) —
+//!   link one fact to its above-threshold neighbours. The primary, explicit
+//!   call.
+//! * [`rebuild_similarity_links`](CognitiveMemory::rebuild_similarity_links) —
+//!   backfill/maintenance pass that ensures every above-threshold pair across
+//!   all facts is linked.
+//!
+//! Both are additive and idempotent: an existing `SIMILAR_TO` edge (whether
+//! auto- or manually created via
+//! [`link_similar_facts`](CognitiveMemory::link_similar_facts)) suppresses a
+//! duplicate for that unordered pair, and re-running creates nothing new.
+
+use std::collections::HashMap;
+
+use tracing::warn;
+
+use crate::graph::types::Direction;
+use crate::memory_types::SemanticFact;
+use crate::similarity::compute_similarity;
+use crate::{MemoryError, Result};
+
+use super::types::ET_SIMILAR_TO;
+use super::CognitiveMemory;
+
+/// Tuning knobs for automatic `SIMILAR_TO` linking.
+///
+/// [`Default`] enables linking with a `0.60` composite threshold, scoring up to
+/// `50` candidate facts per source and storing reciprocal (bidirectional)
+/// edges.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SimilarityOptions {
+    /// When `false`, linking methods are inert no-ops (return `0` / an empty
+    /// report and write no edges). Lets a single options value also gate the
+    /// store-time hook.
+    pub enabled: bool,
+    /// Minimum composite similarity (`0.5*word + 0.2*tag + 0.3*concept`) for a
+    /// pair to be linked. A pair is linked when `score >= threshold`.
+    pub threshold: f64,
+    /// Upper bound on how many other facts are scored per source fact.
+    pub candidate_limit: usize,
+    /// When `true`, store both `A -> B` and `B -> A`; when `false`, only the
+    /// forward `source -> candidate` edge.
+    pub bidirectional: bool,
+}
+
+impl Default for SimilarityOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            threshold: 0.60,
+            candidate_limit: 50,
+            bidirectional: true,
+        }
+    }
+}
+
+/// Summary of a [`rebuild_similarity_links`](CognitiveMemory::rebuild_similarity_links)
+/// pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimilarityReport {
+    /// Number of semantic facts considered.
+    pub facts_processed: usize,
+    /// Number of new unordered pairs linked this pass (pre-existing edges are
+    /// preserved and not counted).
+    pub links_created: usize,
+}
+
+/// Options for [`store_fact_with_options`](CognitiveMemory::store_fact_with_options).
+///
+/// [`Default`] (`similarity: None`) makes the call behave exactly like
+/// [`store_fact`](CognitiveMemory::store_fact): no `SIMILAR_TO` edges are
+/// created, preserving backward compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct StoreFactOptions {
+    /// When `Some(opts)` (and `opts.enabled`), the freshly stored fact is
+    /// auto-linked to its above-threshold neighbours after storage.
+    pub similarity: Option<SimilarityOptions>,
+}
+
+/// Build the property map [`compute_similarity`] expects from a fact.
+fn fact_to_sim_map(fact: &SemanticFact) -> HashMap<String, serde_json::Value> {
+    let mut map = HashMap::with_capacity(3);
+    map.insert(
+        "content".to_string(),
+        serde_json::Value::String(fact.content.clone()),
+    );
+    map.insert(
+        "concept".to_string(),
+        serde_json::Value::String(fact.concept.clone()),
+    );
+    map.insert("tags".to_string(), serde_json::json!(fact.tags));
+    map
+}
+
+impl CognitiveMemory {
+    /// Return `true` if a `SIMILAR_TO` edge already connects `a` and `b` in
+    /// either direction (the unordered-pair idempotency key).
+    fn similar_pair_exists(&self, a: &str, b: &str) -> bool {
+        self.graph
+            .query_neighbors(a, Some(ET_SIMILAR_TO), Direction::Both, usize::MAX)
+            .iter()
+            .any(|(_, neighbor)| neighbor.node_id == b)
+    }
+
+    /// Create a directed `SIMILAR_TO` edge `from -> to` carrying a fixed
+    /// 4-decimal `similarity_score` property. Both endpoints must already exist.
+    fn add_similar_edge(&mut self, from: &str, to: &str, score: f64) -> Result<()> {
+        let mut props = HashMap::with_capacity(1);
+        props.insert("similarity_score".to_string(), format!("{score:.4}"));
+        self.graph
+            .add_edge(from, to, ET_SIMILAR_TO, Some(props))
+            .map_err(|e| MemoryError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Link a single new (unordered) pair, honouring `bidirectional`. Assumes
+    /// the caller has already confirmed the pair is not yet connected.
+    fn link_similar_pair(
+        &mut self,
+        source_id: &str,
+        candidate_id: &str,
+        score: f64,
+        options: &SimilarityOptions,
+    ) -> Result<()> {
+        self.add_similar_edge(source_id, candidate_id, score)?;
+        if options.bidirectional {
+            self.add_similar_edge(candidate_id, source_id, score)?;
+        }
+        Ok(())
+    }
+
+    /// Auto-link `fact_id` to every other same-agent semantic fact whose
+    /// composite similarity is at or above `options.threshold`.
+    ///
+    /// For each newly linked pair a `SIMILAR_TO` edge (carrying a
+    /// `similarity_score` property) is created from `fact_id` to the candidate,
+    /// plus a reciprocal edge when `options.bidirectional`. At most
+    /// `options.candidate_limit` other facts are scored. Returns the number of
+    /// candidate facts newly linked this call (unordered pairs created); a
+    /// reciprocal edge is part of a pair, not counted separately.
+    ///
+    /// Idempotent: a pair already connected by a `SIMILAR_TO` edge (in either
+    /// direction, auto- or manually created) is skipped, so re-running returns
+    /// `0` and creates no duplicates. Never creates a self-loop.
+    ///
+    /// Lenient: when `options.enabled` is `false` this is an inert no-op
+    /// (`Ok(0)`), and an unknown `fact_id` logs a warning and returns `Ok(0)`
+    /// rather than erroring.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Storage` if the backend rejects an edge write.
+    pub fn auto_link_similar_facts(
+        &mut self,
+        fact_id: &str,
+        options: &SimilarityOptions,
+    ) -> Result<usize> {
+        if !options.enabled {
+            return Ok(0);
+        }
+
+        let facts = self.get_all_facts(usize::MAX);
+        let Some(source) = facts.iter().find(|f| f.node_id == fact_id) else {
+            warn!("auto_link_similar_facts: fact {fact_id} not found; skipping");
+            return Ok(0);
+        };
+        let source_map = fact_to_sim_map(source);
+
+        let candidates: Vec<SemanticFact> = facts
+            .iter()
+            .filter(|f| f.node_id != fact_id)
+            .take(options.candidate_limit)
+            .cloned()
+            .collect();
+
+        let mut created = 0usize;
+        for candidate in &candidates {
+            if self.similar_pair_exists(fact_id, &candidate.node_id) {
+                continue;
+            }
+            let score = compute_similarity(&source_map, &fact_to_sim_map(candidate));
+            if score >= options.threshold {
+                self.link_similar_pair(fact_id, &candidate.node_id, score, options)?;
+                created += 1;
+            }
+        }
+
+        Ok(created)
+    }
+
+    /// Recompute `SIMILAR_TO` links across all of this agent's semantic facts
+    /// for backfill / maintenance.
+    ///
+    /// Additive and non-destructive: existing edges (including manual ones from
+    /// [`link_similar_facts`](Self::link_similar_facts)) are preserved and
+    /// suppress duplicates for their pair. Every above-threshold unordered pair
+    /// ends up linked exactly once. Each fact scores at most
+    /// `options.candidate_limit` others. Running twice creates `0` new links.
+    ///
+    /// When `options.enabled` is `false` this is an inert no-op returning an
+    /// empty [`SimilarityReport`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::Storage` if the backend rejects an edge write.
+    pub fn rebuild_similarity_links(
+        &mut self,
+        options: &SimilarityOptions,
+    ) -> Result<SimilarityReport> {
+        if !options.enabled {
+            return Ok(SimilarityReport {
+                facts_processed: 0,
+                links_created: 0,
+            });
+        }
+
+        let facts = self.get_all_facts(usize::MAX);
+        let mut report = SimilarityReport {
+            facts_processed: facts.len(),
+            links_created: 0,
+        };
+
+        for i in 0..facts.len() {
+            let source = &facts[i];
+            let source_map = fact_to_sim_map(source);
+
+            let candidates: Vec<&SemanticFact> = facts
+                .iter()
+                .filter(|f| f.node_id != source.node_id)
+                .take(options.candidate_limit)
+                .collect();
+
+            for candidate in candidates {
+                if self.similar_pair_exists(&source.node_id, &candidate.node_id) {
+                    continue;
+                }
+                let score = compute_similarity(&source_map, &fact_to_sim_map(candidate));
+                if score >= options.threshold {
+                    self.link_similar_pair(&source.node_id, &candidate.node_id, score, options)?;
+                    report.links_created += 1;
+                }
+            }
+        }
+
+        Ok(report)
+    }
+
+    /// Store a semantic fact and optionally auto-link it on store.
+    ///
+    /// Identical to
+    /// [`store_fact_with_provenance`](Self::store_fact_with_provenance) for the
+    /// storage and provenance behaviour, then — when
+    /// `options.similarity = Some(opts)` and `opts.enabled` — runs
+    /// [`auto_link_similar_facts`](Self::auto_link_similar_facts) on the new
+    /// fact. With the default `options.similarity = None` no `SIMILAR_TO` edges
+    /// are created, so this is a backward-compatible superset of
+    /// [`store_fact`](Self::store_fact).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::InvalidInput` if `confidence` is out of range, or
+    /// `MemoryError::Storage` if the node, a provenance edge, or a similarity
+    /// edge cannot be persisted.
+    #[allow(clippy::too_many_arguments)]
+    pub fn store_fact_with_options(
+        &mut self,
+        concept: &str,
+        content: &str,
+        confidence: f64,
+        source_id: &str,
+        tags: Option<&[String]>,
+        metadata: Option<&HashMap<String, serde_json::Value>>,
+        source_episode_ids: &[String],
+        options: &StoreFactOptions,
+    ) -> Result<String> {
+        let node_id = self.store_fact_with_provenance(
+            concept,
+            content,
+            confidence,
+            source_id,
+            tags,
+            metadata,
+            source_episode_ids,
+        )?;
+
+        if let Some(sim_opts) = &options.similarity {
+            if sim_opts.enabled {
+                self.auto_link_similar_facts(&node_id, sim_opts)?;
+            }
+        }
+
+        Ok(node_id)
+    }
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/mod.rs
@@ -8,4 +8,5 @@ mod procedural_tests;
 mod prospective_tests;
 mod semantic_tests;
 mod sensory_tests;
+mod similarity_tests;
 mod working_tests;

--- a/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
@@ -941,3 +941,109 @@ fn procedure_provenance_edge_survives_reopen() {
     assert_eq!(neighbors.len(), 1);
     assert_eq!(neighbors[0].1.node_id, ep_id);
 }
+
+// ===========================================================================
+// SIMILAR_TO auto-linking (issue #90): durability across close + reopen
+//
+// File: rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+//
+// Failing-first TDD test proving auto-created SIMILAR_TO edges -- including
+// their `similarity_score` property -- survive a drop + reopen on the
+// LadybugDB persistent backend, and that auto-linking stays idempotent after
+// the edge is reloaded from disk. (Invariants I4, I9.)
+// Gated by the `persistent` feature via the parent `tests` module.
+// ===========================================================================
+
+#[test]
+fn similar_to_edge_survives_reopen() {
+    use crate::cognitive_memory::types::ET_SIMILAR_TO;
+    use crate::cognitive_memory::SimilarityOptions;
+    use crate::graph::Direction;
+
+    let tags: Vec<String> = vec!["rust".to_string(), "systems".to_string()];
+    let (_tmp, path) = temp_db();
+    let a_id;
+    let b_id;
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        a_id = cm
+            .store_fact(
+                "memory-safety",
+                "rust borrow checker prevents memory bugs",
+                0.95,
+                "",
+                Some(&tags),
+                None,
+            )
+            .unwrap();
+        b_id = cm
+            .store_fact(
+                "memory-safety",
+                "rust borrow checker prevents memory leaks",
+                0.90,
+                "",
+                Some(&tags),
+                None,
+            )
+            .unwrap();
+
+        let n = cm
+            .auto_link_similar_facts(&a_id, &SimilarityOptions::default())
+            .unwrap();
+        assert_eq!(n, 1, "the two related facts must be linked before close");
+
+        // similarity_score present and parseable before close.
+        let edges = cm
+            .graph
+            .query_neighbors(&a_id, Some(ET_SIMILAR_TO), Direction::Outgoing, 10);
+        assert_eq!(edges.len(), 1);
+        let score: f64 = edges[0]
+            .0
+            .properties
+            .get("similarity_score")
+            .expect("similarity_score property")
+            .parse()
+            .expect("score parses as f64");
+        assert!(score >= 0.60);
+
+        cm.close();
+    } // dropped -> LadybugDB flushed to disk
+
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+
+    // The SIMILAR_TO edge + its similarity_score survived close + reopen.
+    let edges = cm
+        .graph
+        .query_neighbors(&a_id, Some(ET_SIMILAR_TO), Direction::Outgoing, 10);
+    assert_eq!(
+        edges.len(),
+        1,
+        "SIMILAR_TO edge must persist across close + reopen"
+    );
+    assert_eq!(edges[0].0.target_id, b_id);
+    let score: f64 = edges[0]
+        .0
+        .properties
+        .get("similarity_score")
+        .expect("similarity_score must persist across reopen")
+        .parse()
+        .expect("persisted score parses as f64");
+    assert!(
+        score >= 0.60,
+        "persisted similarity_score must be >= threshold"
+    );
+
+    // Idempotent after reopen: the surviving edge suppresses a duplicate.
+    let n = cm
+        .auto_link_similar_facts(&a_id, &SimilarityOptions::default())
+        .unwrap();
+    assert_eq!(n, 0, "auto-link must stay idempotent across reopen");
+    let after = cm
+        .graph
+        .query_neighbors(&a_id, Some(ET_SIMILAR_TO), Direction::Outgoing, 10);
+    assert_eq!(
+        after.len(),
+        1,
+        "no duplicate SIMILAR_TO edge after reopen + re-link"
+    );
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/similarity_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/similarity_tests.rs
@@ -4,8 +4,8 @@
 //! (issue #90). These bind to the not-yet-implemented public contract:
 //!   - types  `SimilarityOptions`, `SimilarityReport`, `StoreFactOptions`
 //!   - methods `CognitiveMemory::auto_link_similar_facts`,
-//!             `CognitiveMemory::rebuild_similarity_links`,
-//!             `CognitiveMemory::store_fact_with_options`
+//!     `CognitiveMemory::rebuild_similarity_links`,
+//!     `CognitiveMemory::store_fact_with_options`
 //!
 //! They are backend-agnostic (default in-memory gate); the same behavior is
 //! re-proven for durability under `--features persistent` in

--- a/rust/amplihack-memory/src/cognitive_memory/tests/similarity_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/similarity_tests.rs
@@ -1,0 +1,641 @@
+//! File: rust/amplihack-memory/src/cognitive_memory/tests/similarity_tests.rs
+//!
+//! Failing-first TDD tests for automatic Jaccard `SIMILAR_TO` auto-linking
+//! (issue #90). These bind to the not-yet-implemented public contract:
+//!   - types  `SimilarityOptions`, `SimilarityReport`, `StoreFactOptions`
+//!   - methods `CognitiveMemory::auto_link_similar_facts`,
+//!             `CognitiveMemory::rebuild_similarity_links`,
+//!             `CognitiveMemory::store_fact_with_options`
+//!
+//! They are backend-agnostic (default in-memory gate); the same behavior is
+//! re-proven for durability under `--features persistent` in
+//! `persistent_tests.rs::similar_to_edge_survives_reopen`.
+//!
+//! Fixture design (so the boundary is deterministic against the composite
+//! score `0.5*word + 0.2*tag + 0.3*concept`, see src/similarity.rs):
+//!   - `a`,`b`,`c` share concept "memory-safety" + tags ["rust","systems"] +
+//!     most content tokens  -> pairwise composite in [0.75, 0.86] (>= 0.60).
+//!   - `d`,`e` share nothing with the cluster or each other -> composite 0.0.
+
+use super::super::types::ET_SIMILAR_TO;
+use super::super::*;
+use crate::graph::Direction;
+
+fn make_cm() -> CognitiveMemory {
+    CognitiveMemory::new(&format!("test-agent-{}", uuid::Uuid::new_v4())).unwrap()
+}
+
+fn tags(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
+}
+
+/// Store a fact (plain, no auto-linking) and return its id.
+fn store(cm: &mut CognitiveMemory, concept: &str, content: &str, conf: f64, t: &[&str]) -> String {
+    let tg = tags(t);
+    cm.store_fact(concept, content, conf, "", Some(&tg), None)
+        .unwrap()
+}
+
+/// Three mutually-related facts (`a`,`b`,`c`) + two unrelated (`d`,`e`).
+/// Distinct, descending confidences keep `get_all_facts` ordering stable so
+/// the `candidate_limit` bound is testable.
+struct Corpus {
+    a: String,
+    b: String,
+    c: String,
+    d: String,
+    e: String,
+}
+
+fn build_corpus(cm: &mut CognitiveMemory) -> Corpus {
+    Corpus {
+        a: store(
+            cm,
+            "memory-safety",
+            "rust borrow checker prevents memory bugs",
+            0.95,
+            &["rust", "systems"],
+        ),
+        b: store(
+            cm,
+            "memory-safety",
+            "rust borrow checker prevents memory leaks",
+            0.90,
+            &["rust", "systems"],
+        ),
+        c: store(
+            cm,
+            "memory-safety",
+            "rust borrow checker stops memory errors",
+            0.85,
+            &["rust", "systems"],
+        ),
+        d: store(
+            cm,
+            "web-frontend",
+            "javascript renders dynamic browser interface",
+            0.80,
+            &["frontend", "javascript"],
+        ),
+        e: store(
+            cm,
+            "database-indexing",
+            "postgres btree index speeds query lookups",
+            0.75,
+            &["database", "sql"],
+        ),
+    }
+}
+
+fn has_similar_edge(cm: &CognitiveMemory, from: &str, to: &str) -> bool {
+    cm.graph
+        .query_neighbors(from, Some(ET_SIMILAR_TO), Direction::Outgoing, 100)
+        .iter()
+        .any(|(e, _)| e.target_id == to)
+}
+
+fn similar_out_count(cm: &CognitiveMemory, id: &str) -> usize {
+    cm.graph
+        .query_neighbors(id, Some(ET_SIMILAR_TO), Direction::Outgoing, 100)
+        .len()
+}
+
+fn similar_in_count(cm: &CognitiveMemory, id: &str) -> usize {
+    cm.graph
+        .query_neighbors(id, Some(ET_SIMILAR_TO), Direction::Incoming, 100)
+        .len()
+}
+
+fn similar_degree(cm: &CognitiveMemory, id: &str) -> usize {
+    cm.graph
+        .query_neighbors(id, Some(ET_SIMILAR_TO), Direction::Both, 100)
+        .len()
+}
+
+// ---------------------------------------------------------------------------
+// auto_link_similar_facts
+// ---------------------------------------------------------------------------
+
+/// Core behavior: a `SIMILAR_TO` edge is created from the source fact to every
+/// OTHER same-agent fact at/above threshold, and to none below it. (I1, I2.)
+#[test]
+fn auto_link_creates_edges_only_between_related_facts() {
+    let mut cm = make_cm();
+    let c = build_corpus(&mut cm);
+
+    let n = cm
+        .auto_link_similar_facts(&c.a, &SimilarityOptions::default())
+        .unwrap();
+
+    // a links to the two related facts (b, c); never to the unrelated d, e.
+    assert_eq!(n, 2, "exactly the two related facts should be linked");
+    assert!(has_similar_edge(&cm, &c.a, &c.b));
+    assert!(has_similar_edge(&cm, &c.a, &c.c));
+    assert!(!has_similar_edge(&cm, &c.a, &c.d));
+    assert!(!has_similar_edge(&cm, &c.a, &c.e));
+
+    // Default is bidirectional: reciprocal edges exist back to a.
+    assert!(has_similar_edge(&cm, &c.b, &c.a));
+    assert!(has_similar_edge(&cm, &c.c, &c.a));
+
+    // The unrelated facts gained no SIMILAR_TO edges at all.
+    assert_eq!(similar_degree(&cm, &c.d), 0);
+    assert_eq!(similar_degree(&cm, &c.e), 0);
+}
+
+/// No self-loops: the source fact is never a candidate for itself. (I3.)
+#[test]
+fn auto_link_never_creates_self_loop() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+
+    let n = cm
+        .auto_link_similar_facts(&a, &SimilarityOptions::default())
+        .unwrap();
+
+    assert_eq!(n, 0, "a lone fact links to nothing");
+    assert!(!has_similar_edge(&cm, &a, &a), "no self SIMILAR_TO edge");
+    assert_eq!(similar_degree(&cm, &a), 0);
+}
+
+/// Idempotency: a re-run links nothing new and creates no duplicate edge. (I4.)
+#[test]
+fn auto_link_is_idempotent() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+
+    let first = cm
+        .auto_link_similar_facts(&a, &SimilarityOptions::default())
+        .unwrap();
+    assert_eq!(first, 1);
+    assert_eq!(similar_out_count(&cm, &a), 1);
+
+    let second = cm
+        .auto_link_similar_facts(&a, &SimilarityOptions::default())
+        .unwrap();
+    assert_eq!(second, 0, "second pass must link nothing new");
+    assert_eq!(
+        similar_out_count(&cm, &a),
+        1,
+        "no duplicate SIMILAR_TO edge on re-run"
+    );
+    let _ = b;
+}
+
+/// The threshold gates linking: with a stricter threshold the weaker (but still
+/// positive) pair is excluded. composite(a,b)=~0.857, composite(a,c)=0.75. (I2.)
+#[test]
+fn auto_link_respects_threshold() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+    let c = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker stops memory errors",
+        0.85,
+        &["rust", "systems"],
+    );
+
+    let opts = SimilarityOptions {
+        threshold: 0.80,
+        ..SimilarityOptions::default()
+    };
+    let n = cm.auto_link_similar_facts(&a, &opts).unwrap();
+
+    assert_eq!(n, 1, "only the >=0.80 pair (a,b) links at threshold 0.80");
+    assert!(has_similar_edge(&cm, &a, &b));
+    assert!(
+        !has_similar_edge(&cm, &a, &c),
+        "the 0.75 pair (a,c) is below the 0.80 threshold"
+    );
+}
+
+/// `enabled = false` is an inert no-op: returns 0 and writes nothing. (I8.)
+#[test]
+fn auto_link_disabled_is_noop() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let _b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+
+    let opts = SimilarityOptions {
+        enabled: false,
+        ..SimilarityOptions::default()
+    };
+    let n = cm.auto_link_similar_facts(&a, &opts).unwrap();
+
+    assert_eq!(n, 0);
+    assert_eq!(similar_degree(&cm, &a), 0, "disabled must write no edges");
+}
+
+/// A missing/unknown fact id is lenient: warn + `Ok(0)`, never an error.
+#[test]
+fn auto_link_missing_fact_is_lenient() {
+    let mut cm = make_cm();
+    let _a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+
+    let n = cm
+        .auto_link_similar_facts("sem_does_not_exist", &SimilarityOptions::default())
+        .expect("missing fact must be lenient, not an error");
+    assert_eq!(n, 0);
+}
+
+/// `bidirectional = false` creates only the forward edge a -> b. (I5.)
+#[test]
+fn auto_link_bidirectional_false_only_forward() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+
+    let opts = SimilarityOptions {
+        bidirectional: false,
+        ..SimilarityOptions::default()
+    };
+    let n = cm.auto_link_similar_facts(&a, &opts).unwrap();
+
+    assert_eq!(n, 1);
+    assert!(has_similar_edge(&cm, &a, &b), "forward edge a -> b exists");
+    assert_eq!(similar_out_count(&cm, &b), 0, "no reciprocal edge b -> a");
+    assert_eq!(
+        similar_in_count(&cm, &b),
+        1,
+        "b only receives the inbound a -> b edge"
+    );
+}
+
+/// `bidirectional = true` (default) also creates the reciprocal b -> a. (I5.)
+#[test]
+fn auto_link_bidirectional_true_creates_reciprocal() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+
+    let n = cm
+        .auto_link_similar_facts(&a, &SimilarityOptions::default())
+        .unwrap();
+
+    assert_eq!(n, 1, "the pair is counted once, not per directed edge");
+    assert!(has_similar_edge(&cm, &a, &b));
+    assert!(has_similar_edge(&cm, &b, &a), "reciprocal edge present");
+}
+
+/// The created edge carries a `similarity_score` property that is a fixed
+/// 4-decimal, parseable `f64` string at/above threshold. (Edge data contract.)
+#[test]
+fn auto_link_writes_parseable_similarity_score_property() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let _b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+
+    cm.auto_link_similar_facts(&a, &SimilarityOptions::default())
+        .unwrap();
+
+    let edges = cm
+        .graph
+        .query_neighbors(&a, Some(ET_SIMILAR_TO), Direction::Outgoing, 10);
+    assert_eq!(edges.len(), 1);
+
+    let raw = edges[0]
+        .0
+        .properties
+        .get("similarity_score")
+        .expect("edge must carry a similarity_score property");
+    let score: f64 = raw.parse().expect("similarity_score must parse as f64");
+    assert!(
+        (0.60..=1.0).contains(&score),
+        "score {score} must be in [threshold, 1.0]"
+    );
+
+    // Fixed `{:.4}` format: exactly four digits after the decimal point.
+    let frac = raw
+        .split_once('.')
+        .map(|(_, f)| f)
+        .unwrap_or_else(|| panic!("similarity_score '{raw}' must be a decimal"));
+    assert_eq!(
+        frac.len(),
+        4,
+        "similarity_score '{raw}' must use 4-decimal formatting"
+    );
+}
+
+/// `candidate_limit` bounds how many other facts are scored per source. With a
+/// limit of 1, at most one link can be created even with two valid candidates.
+/// (I7.)
+#[test]
+fn auto_link_bounded_by_candidate_limit() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let _b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+    let _c = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker stops memory errors",
+        0.85,
+        &["rust", "systems"],
+    );
+
+    let opts = SimilarityOptions {
+        candidate_limit: 1,
+        ..SimilarityOptions::default()
+    };
+    let n = cm.auto_link_similar_facts(&a, &opts).unwrap();
+
+    assert!(
+        n <= 1,
+        "at most candidate_limit (1) facts may be scored/linked, got {n}"
+    );
+    assert!(similar_out_count(&cm, &a) <= 1);
+}
+
+// ---------------------------------------------------------------------------
+// store_fact does NOT auto-link; store_fact_with_options opt-in does
+// ---------------------------------------------------------------------------
+
+/// Backward compatibility: plain `store_fact` never creates `SIMILAR_TO`
+/// edges, even between strongly related facts.
+#[test]
+fn store_fact_does_not_auto_link() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+
+    assert_eq!(similar_degree(&cm, &a), 0);
+    assert_eq!(similar_degree(&cm, &b), 0);
+}
+
+/// `store_fact_with_options` with `similarity: None` is observably identical to
+/// the non-linking store path (no `SIMILAR_TO` edges).
+#[test]
+fn store_fact_with_options_none_does_not_link() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+
+    let tg = tags(&["rust", "systems"]);
+    let opts = StoreFactOptions { similarity: None };
+    let b = cm
+        .store_fact_with_options(
+            "memory-safety",
+            "rust borrow checker prevents memory leaks",
+            0.90,
+            "",
+            Some(&tg),
+            None,
+            &[],
+            &opts,
+        )
+        .unwrap();
+
+    assert!(b.starts_with("sem_"));
+    assert!(!has_similar_edge(&cm, &b, &a));
+    assert_eq!(similar_degree(&cm, &b), 0);
+}
+
+/// `store_fact_with_options` with `similarity: Some(enabled)` auto-links the
+/// freshly stored fact to the existing related fact.
+#[test]
+fn store_fact_with_options_some_auto_links() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+
+    let tg = tags(&["rust", "systems"]);
+    let opts = StoreFactOptions {
+        similarity: Some(SimilarityOptions::default()),
+    };
+    let b = cm
+        .store_fact_with_options(
+            "memory-safety",
+            "rust borrow checker prevents memory leaks",
+            0.90,
+            "",
+            Some(&tg),
+            None,
+            &[],
+            &opts,
+        )
+        .unwrap();
+
+    assert!(
+        has_similar_edge(&cm, &b, &a),
+        "the new fact must be linked to the related existing fact"
+    );
+    // Default options are bidirectional.
+    assert!(has_similar_edge(&cm, &a, &b));
+}
+
+// ---------------------------------------------------------------------------
+// rebuild_similarity_links
+// ---------------------------------------------------------------------------
+
+/// A full rebuild links every above-threshold pair across all facts exactly
+/// once, reports accurate counts, and is idempotent on a second pass. (I4, I6.)
+#[test]
+fn rebuild_links_all_related_pairs_and_is_idempotent() {
+    let mut cm = make_cm();
+    let c = build_corpus(&mut cm);
+
+    let report = cm
+        .rebuild_similarity_links(&SimilarityOptions::default())
+        .unwrap();
+
+    assert_eq!(
+        report,
+        SimilarityReport {
+            facts_processed: 5,
+            links_created: 3,
+        },
+        "three related pairs (a-b, a-c, b-c); d, e isolated"
+    );
+
+    assert!(has_similar_edge(&cm, &c.a, &c.b));
+    assert!(has_similar_edge(&cm, &c.a, &c.c));
+    assert!(has_similar_edge(&cm, &c.b, &c.c));
+    assert_eq!(similar_degree(&cm, &c.d), 0);
+    assert_eq!(similar_degree(&cm, &c.e), 0);
+
+    // Re-running creates nothing new (non-destructive + idempotent).
+    let again = cm
+        .rebuild_similarity_links(&SimilarityOptions::default())
+        .unwrap();
+    assert_eq!(again.links_created, 0, "rebuild must be idempotent");
+    assert_eq!(again.facts_processed, 5);
+}
+
+/// Disabled rebuild is an inert no-op with an empty report. (I8.)
+#[test]
+fn rebuild_disabled_is_noop() {
+    let mut cm = make_cm();
+    let c = build_corpus(&mut cm);
+
+    let opts = SimilarityOptions {
+        enabled: false,
+        ..SimilarityOptions::default()
+    };
+    let report = cm.rebuild_similarity_links(&opts).unwrap();
+
+    assert_eq!(
+        report,
+        SimilarityReport {
+            facts_processed: 0,
+            links_created: 0,
+        }
+    );
+    assert_eq!(similar_degree(&cm, &c.a), 0, "disabled writes no edges");
+}
+
+/// Rebuild is non-destructive: a pre-existing (manual) `SIMILAR_TO` edge is
+/// preserved and suppresses a duplicate for that pair. (I4, non-destructive.)
+#[test]
+fn rebuild_preserves_existing_manual_links() {
+    let mut cm = make_cm();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+    let b = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.90,
+        &["rust", "systems"],
+    );
+
+    // A manually created edge already connects the only related pair.
+    cm.link_similar_facts(&a, &b, 0.5).unwrap();
+    assert!(has_similar_edge(&cm, &a, &b));
+
+    let report = cm
+        .rebuild_similarity_links(&SimilarityOptions::default())
+        .unwrap();
+
+    assert_eq!(
+        report.links_created, 0,
+        "the manually-linked pair must not be re-created"
+    );
+    // The manual edge is still present (non-destructive) and not duplicated.
+    assert!(has_similar_edge(&cm, &a, &b));
+    assert_eq!(similar_out_count(&cm, &a), 1);
+}

--- a/rust/amplihack-memory/src/lib.rs
+++ b/rust/amplihack-memory/src/lib.rs
@@ -147,6 +147,8 @@ pub use backends::LadybugBackend;
 pub use backends::{ExperienceBackend, MemoryBackend, SqliteBackend};
 /// Unified cognitive memory interface over the graph layer.
 pub use cognitive_memory::CognitiveMemory;
+/// Automatic `SIMILAR_TO` linking options and report types.
+pub use cognitive_memory::{SimilarityOptions, SimilarityReport, StoreFactOptions};
 /// Backend selector and memory connector entry point.
 pub use connector::{BackendType, MemoryConnector};
 /// Hierarchical knowledge graph with classification, subgraph queries, and edge types.


### PR DESCRIPTION
## Summary

Closes #90.

`CognitiveMemory` can now automatically connect related semantic facts with `SIMILAR_TO` edges, using the crate's **existing** deterministic composite Jaccard helpers (`0.5*word + 0.2*tag + 0.3*concept`, `similarity.rs`) — no embeddings, no network calls. Linking is **opt-in, additive, and backward compatible**: `store_fact` / `store_fact_with_provenance` are unchanged and never create `SIMILAR_TO` edges on their own.

## New public API (`cognitive_memory::similarity`, re-exported from `lib.rs`)

- **`SimilarityOptions { enabled, threshold, candidate_limit, bidirectional }`** — `Copy`, `Default = { true, 0.60, 50, true }`.
- **`auto_link_similar_facts(fact_id, &opts) -> Result<usize>`** (the priority, explicit call): links a fact to every other same-agent fact whose composite score is **at or above** `threshold` (`>=`), bounded by `candidate_limit` (highest-confidence first). Each edge carries a `similarity_score` property as a fixed 4-decimal string. Returns the number of **new unordered pairs** linked. **Idempotent** (never duplicates an existing edge in either direction), never self-loops, lenient on a missing/disabled fact (`Ok(0)`).
- **`rebuild_similarity_links(&opts) -> Result<SimilarityReport>`**: additive, **non-destructive** backfill/maintenance across all facts. Preserves manual links from `link_similar_facts` and is idempotent (second pass → `links_created == 0`).
- **`StoreFactOptions { similarity: Option<SimilarityOptions> }` + `store_fact_with_options(...)`**: opt-in store-time linking. Default `similarity: None` is a drop-in for `store_fact_with_provenance` (no edges).

## Behavior notes

- **Same-agent only.** Candidates come from `get_all_facts` (confidence-desc), excluding the source.
- **`bidirectional`** (default `true`) also writes the reciprocal `B → A` edge; idempotency is keyed on the unordered pair via `query_neighbors(.., Direction::Both)`.
- **Durable.** On the `persistent` backend, `SIMILAR_TO` edges and their scores survive `checkpoint()`, drop, and reopen.

## Tests (TDD, both backends)

- 14 backend-agnostic tests in `cognitive_memory/tests/similarity_tests.rs`: related-vs-unrelated linking, threshold gating, idempotency, no self-loop, bidirectional on/off, `candidate_limit` bound, `similarity_score` format, disabled no-op, `store_fact` non-linking, both `store_fact_with_options` paths, full rebuild + idempotency, rebuild preserves manual links.
- `persistent_tests.rs::similar_to_edge_survives_reopen`: edge + score survive drop/reopen and stay idempotent after reload.
- Existing suites stay green: **483** default lib tests, **522** with `--features persistent`.

## Verification

```
cargo fmt --check                       # clean
cargo clippy -- -D warnings             # clean (default + python features, as CI runs)
cargo test                              # 483 lib + integration/property/doc tests pass
cargo test --features persistent        # 522 lib tests pass, incl. durability test
```

## Docs

- `README.md`: new "Automatic `SIMILAR_TO` linking between facts" section with options table + worked example.
- `docs/similarity_linking.md`: full reference (threshold tuning, directionality, edge data model, tutorial).