### PR TITLE
feat(cognitive-memory): fact dedup, SUPERSEDES, retention/prune

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -171,7 +171,19 @@ CognitiveMemory(
 |--------|-----------|---------|
 | `store_fact` | `(concept: str, content: str, confidence: float = 1.0, source_id: str = "", tags: list[str] \| None = None, temporal_metadata: dict \| None = None) -> str` | `node_id` |
 | `search_facts` | `(query: str, limit: int = 10, min_confidence: float = 0.0) -> list[SemanticFact]` | Matching facts |
-| `get_all_facts` | `(limit: int = 50) -> list[SemanticFact]` | All facts by confidence DESC |
+| `get_all_facts` | `(limit: int = 50) -> list[SemanticFact]` | All facts by confidence DESC (archived flagged) |
+
+#### Fact Lifecycle Methods
+
+Deduplication, supersession, and retention for semantic facts. See
+[Fact Lifecycle](fact_lifecycle.md) for full semantics and the Rust API.
+
+| Method | Signature (Rust) | Returns |
+|--------|------------------|---------|
+| `upsert_fact` | `(input: FactInput, options: &StoreFactOptions) -> Result<StoreFactOutcome>` | `StoreFactOutcome { node_id, dedup_action, content_hash, .. }` |
+| `find_duplicate_facts` | `(options: &DedupOptions, limit: usize) -> Vec<DuplicateFactGroup>` | Duplicate groups (≥2 members) |
+| `supersede_fact` | `(old_id: &str, new_id: &str, reason: &str) -> Result<()>` | `()` |
+| `prune_semantic_memory` | `(policy: &RetentionPolicy) -> Result<PruneReport>` | `PruneReport { archived, deleted, would_archive, would_delete }` |
 
 ### Procedural Memory Methods
 
@@ -246,6 +258,96 @@ from amplihack_memory import KnowledgeSubgraph
 **Methods:**
 
 - `to_llm_context(chronological: bool = False) -> str` -- Format as LLM-readable text
+
+### Fact Lifecycle Types
+
+Rust types for semantic-fact deduplication, supersession, and retention. See
+[Fact Lifecycle](fact_lifecycle.md) for behavior and examples.
+
+#### DedupMode
+
+```rust
+enum DedupMode { None, ExactContentHash, CallerKey(String), SameConceptSimilarity }
+```
+
+#### DedupOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `DedupMode` | `None` | Deduplication strategy |
+| `similarity_threshold` | `f64` | `0.60` | Min composite similarity for `SameConceptSimilarity` |
+| `same_concept_only` | `bool` | `true` | Restrict candidate scan to the same concept |
+
+#### FactInput
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `concept` | `String` | required | Concept / lookup key |
+| `content` | `String` | required | Factual content |
+| `confidence` | `f64` | required | Confidence (0.0-1.0) |
+| `source_id` | `String` | `""` | Opaque provenance string |
+| `tags` | `Vec<String>` | `[]` | Tags |
+| `metadata` | `HashMap<String, Value>` | `{}` | Metadata |
+| `importance` | `Option<f64>` | `None` ⇒ `confidence` | Retention weight |
+| `expires_at` | `Option<DateTime<Utc>>` | `None` | Explicit expiry for retention |
+| `dedup_key` | `Option<String>` | `None` | Identity for `CallerKey` mode |
+
+Convenience: `FactInput::new(concept, content, confidence)`.
+
+#### StoreFactOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `similarity` | `Option<SimilarityOptions>` | `None` | Auto-link `SIMILAR_TO` on store |
+| `provenance` | `ProvenanceOptions` | empty / non-strict | `source_episode_ids` for `DERIVES_FROM` (+ `strict` flag) |
+| `dedup` | `DedupOptions` | default (`None`) | Deduplication strategy |
+
+Derives `Debug, Clone, PartialEq, Default` (no longer `Copy`).
+
+#### StoreFactOutcome / DedupAction
+
+```rust
+struct StoreFactOutcome {
+    node_id: String,
+    dedup_action: DedupAction,
+    content_hash: String,
+    similarity_links_created: usize,
+    provenance_edges_created: usize,
+}
+enum DedupAction {
+    Inserted,
+    Reused { existing_id: String },
+    Superseded { old_id: String, new_id: String },
+}
+```
+
+#### DuplicateFactGroup
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | `String` | Shared group identity (content_hash / dedup_key / representative node id) |
+| `fact_ids` | `Vec<String>` | Members (≥2), oldest first |
+| `representative_id` | `String` | Oldest member; always `fact_ids[0]` |
+
+#### RetentionPolicy
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_facts_per_concept` | `Option<usize>` | `None` | Per-concept cap on active facts |
+| `ttl_seconds_by_concept` | `HashMap<String, i64>` | `{}` | Per-concept max age in seconds |
+| `min_importance_to_keep` | `f64` | `0.0` | Deletion-protection floor |
+| `include_superseded` | `bool` | `false` | Treat archived/superseded facts as candidates |
+| `dry_run` | `bool` | `false` | Report counts without mutating |
+
+#### PruneReport
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `archived` | `usize` | Facts archived (real run) |
+| `deleted` | `usize` | Facts deleted (real run) |
+| `would_archive` | `usize` | Facts that would be archived (dry run) |
+| `would_delete` | `usize` | Facts that would be deleted (dry run) |
+
 
 ### MemoryCategory (HierarchicalMemory)
 

--- a/docs/cognitive_memory.md
+++ b/docs/cognitive_memory.md
@@ -182,6 +182,7 @@ cons_id = cog.consolidate_episodes(
 - Confidence scoring
 - Tags and metadata
 - Source provenance tracking
+- Lifecycle management: deduplication, supersession, and retention (see [Fact Lifecycle](fact_lifecycle.md))
 
 ```python
 # Store a fact
@@ -213,6 +214,19 @@ all_facts = cog.get_all_facts(limit=50)
 | `tags` | `list[str]` | Categorisation tags |
 | `metadata` | `dict` | Additional metadata |
 | `created_at` | `datetime` | Creation time |
+| `importance` | `float` | Retention weight (defaults to `confidence`) |
+| `usage_count` | `int` | Times reused via dedup (default `0`) |
+| `last_accessed_at` | `datetime \| None` | Last dedup reuse time (default `None`) |
+| `expires_at` | `datetime \| None` | Optional absolute expiry (default `None`) |
+| `archived` | `bool` | Soft-deleted flag set on supersession or a retention pass; still returned by `get_all_facts` with `archived = true` until a later prune deletes it (default `False`) |
+| `superseded_by` | `str \| None` | `node_id` of the replacing fact (default `None`) |
+| `content_hash` | `str` | Hex SHA-256 of `concept` + `content` |
+| `dedup_key` | `str \| None` | Caller-supplied dedup identity (default `None`) |
+
+The eight fields after `created_at` are additive and backward compatible: facts
+written by earlier versions default-populate them on read. See
+[Fact Lifecycle](fact_lifecycle.md) for deduplication (`upsert_fact`),
+supersession (`supersede_fact`), and pruning (`prune_semantic_memory`).
 
 ---
 

--- a/docs/fact_lifecycle.md
+++ b/docs/fact_lifecycle.md
@@ -1,0 +1,684 @@
+# Fact Lifecycle: Dedup, Supersession & Retention
+
+`CognitiveMemory` semantic facts are long-lived knowledge. Without lifecycle
+management, agents that store facts on every turn accumulate **duplicates**
+(the same fact written many times), **stale revisions** (an older value left
+behind when a newer one arrives), and **unbounded growth** (the fact store
+never shrinks). This page documents the three capabilities that solve that:
+
+| Capability | What it does | Entry point |
+|------------|--------------|-------------|
+| **Deduplication** | Detects and collapses facts that are the same (by content hash, caller-supplied key, or same-concept similarity) | [`upsert_fact`](#upsert_fact), [`find_duplicate_facts`](#find_duplicate_facts) |
+| **Supersession** | Replaces an old fact with a newer one, keeping the history queryable via a `SUPERSEDES` edge | [`supersede_fact`](#supersede_fact) |
+| **Retention / Pruning** | Archives then deletes facts under a configurable policy (per-concept caps, TTL, importance floor), with a non-destructive dry run | [`prune_semantic_memory`](#prune_semantic_memory) |
+
+All three are **additive and backward compatible**. Existing calls
+([`store_fact`](cognitive_memory.md#4-semantic-memory),
+`store_fact_with_provenance`, `get_all_facts`) behave exactly as before; the new
+fields default sensibly for facts written by earlier versions, and no schema
+migration is required on either the in-memory or the persistent (LadybugDB)
+backend.
+
+> **Scope.** This feature lives in the Rust crate `amplihack-memory`
+> (`CognitiveMemory`). The Rust API is the primary, authoritative surface and is
+> documented first. The Python `CognitiveMemory` additively exposes the new fact
+> fields; see [Python parity](#python-parity).
+
+> **Note.** The Rust snippets below use the `?` operator and therefore assume a
+> caller that returns `Result<(), MemoryError>` (e.g. the body of `fn main() ->
+> amplihack_memory::Result<()>`).
+
+---
+
+## Concepts
+
+```
+                       supersede_fact(old, new, reason)
+                       ┌──────────────────────────────┐
+                       │                               │
+                       v                               │
+  new fact ──SUPERSEDES──> old fact (archived=true, superseded_by=new)
+  (current)                (history, excluded from default reads)
+
+
+  upsert_fact(input, { dedup }):
+
+      DedupMode::None                 -> always Inserted
+      DedupMode::ExactContentHash     -> identical content_hash  -> Reused
+      DedupMode::CallerKey("k")       -> same dedup_key,
+                                           same content           -> Reused
+                                           changed content        -> Superseded
+      DedupMode::SameConceptSimilarity-> score >= threshold       -> Reused
+
+
+  prune_semantic_memory(policy):
+
+      candidate && !archived  ->  archive   (run 1)
+      candidate &&  archived  ->  delete     (run 2)   (archive-before-delete)
+```
+
+A fact is a **candidate** for pruning when it exceeds a per-concept cap, has
+passed its concept TTL, or is a superseded record (when
+`include_superseded` is set). Provenance-bearing facts whose `importance` is at
+or above `min_importance_to_keep` are **protected** and never deleted.
+
+---
+
+## Extended `SemanticFact`
+
+[`SemanticFact`](cognitive_memory.md#4-semantic-memory) gains eight fields. Each
+is `#[serde(default)]`, so older serialized facts and pre-existing graph nodes
+deserialize cleanly. When a property is absent from the stored node it is
+default-populated on read (no migration break).
+
+| Field | Type | Default on read | Description |
+|-------|------|-----------------|-------------|
+| `importance` | `f64` | `confidence` | Retention weight in `[0.0, 1.0]`. When a fact is written without an explicit importance it mirrors `confidence`. Pruning protects facts with `importance >= min_importance_to_keep`. |
+| `usage_count` | `i64` | `0` | Number of times this fact has been reused via dedup. Incremented with `saturating_add` on each `Reused` outcome. |
+| `last_accessed_at` | `Option<DateTime<Utc>>` | `None` | Set to "now" whenever the fact is reused by `upsert_fact`. |
+| `expires_at` | `Option<DateTime<Utc>>` | `None` | Optional absolute expiry. Independent of the per-concept TTL applied at prune time. |
+| `archived` | `bool` | `false` | `true` once the fact has been superseded or archived by pruning. Archived facts are excluded from [`get_all_facts`](#reads-and-archived-facts) / `search_facts` by default. |
+| `superseded_by` | `Option<String>` | `None` | `node_id` of the fact that replaced this one (set by [`supersede_fact`](#supersede_fact)). |
+| `content_hash` | `String` | computed | Stable fingerprint of `concept` + `content` (see [content_hash](#content_hash-and-dedup_key)). Recomputed on read if the stored value is empty. |
+| `dedup_key` | `Option<String>` | `None` | Caller-supplied identity used by `DedupMode::CallerKey`. |
+
+### Persistence
+
+The write path always emits all eight properties for every fact, so reads
+round-trip uniformly across the `InMemoryGraphStore` and the persistent
+LadybugDB backend. On the persistent backend the new columns are created lazily
+on first write (LadybugDB auto-`ALTER`s the table) — **there is no migration
+step**. The fields survive close/reopen:
+
+```rust
+// Requires the `persistent` feature.
+use amplihack_memory::CognitiveMemory;
+
+{
+    let mut cog = CognitiveMemory::open_persistent("/tmp/cog_db", "agent")?;
+    cog.store_fact("ports", "staging uses 8080", 0.9, "", None, None)?;
+} // dropped / closed
+
+let cog = CognitiveMemory::open_persistent("/tmp/cog_db", "agent")?;
+let fact = &cog.get_all_facts(10)[0];
+assert_eq!(fact.importance, 0.9);          // defaulted from confidence
+assert_eq!(fact.usage_count, 0);
+assert!(!fact.content_hash.is_empty());    // recomputed if it was empty
+```
+
+### Reads and archived facts
+
+`get_all_facts` and `search_facts` keep their existing signatures and behaviour:
+they return **all** of this agent's facts sorted by confidence descending,
+including any that have been archived. Each archived fact carries
+`archived == true`, so callers that want to exclude supersession/retention
+history filter on that flag. Reads stay `&self` and never mutate:
+`last_accessed_at` and `usage_count` are written only by `upsert_fact`,
+`supersede_fact`, and `prune_semantic_memory`.
+
+### `content_hash` and `dedup_key`
+
+`content_hash` is a hex-encoded SHA-256 over the concept and content joined by a
+unit-separator byte:
+
+```
+content_hash = hex( SHA256( concept ‖ 0x1F ‖ content ) )
+```
+
+* The `0x1F` (ASCII Unit Separator) delimiter prevents boundary-collision: the
+  facts `("ab", "c")` and `("a", "bc")` hash differently.
+* The hash is computed over the **exact bytes** — no trimming or case folding —
+  so `ExactContentHash` dedup is exact.
+* `content_hash` is a fingerprint for equality, **not** a security token.
+
+`dedup_key` is opaque and caller-controlled. It expresses "these writes are
+about the same thing" independent of content, which is what enables
+supersession when the content changes (see [CallerKey](#dedupmode)).
+
+---
+
+## Deduplication
+
+### `DedupMode`
+
+```rust
+pub enum DedupMode {
+    /// No deduplication — every upsert inserts a new fact.
+    None,
+    /// Reuse an existing fact with an identical `content_hash`.
+    ExactContentHash,
+    /// Identity is the caller-supplied `dedup_key`. Same key + same content
+    /// reuses; same key + changed content supersedes.
+    CallerKey(String),
+    /// Reuse the most similar same-concept fact whose composite similarity is
+    /// at or above `similarity_threshold`.
+    SameConceptSimilarity,
+}
+```
+
+### `DedupOptions`
+
+```rust
+pub struct DedupOptions {
+    pub mode: DedupMode,
+    pub similarity_threshold: f64,
+    pub same_concept_only: bool,
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `DedupMode` | `None` | Strategy used to detect a duplicate. |
+| `similarity_threshold` | `f64` | `0.60` | Minimum composite similarity (`0.5*word + 0.2*tag + 0.3*concept`, the same score used by `SIMILAR_TO` linking) for `SameConceptSimilarity` to treat two facts as duplicates. |
+| `same_concept_only` | `bool` | `true` | Restrict candidate scanning to facts that share the new fact's `concept`. Keeps dedup cheap and concept-scoped. |
+
+`DedupOptions::default()` is `{ mode: None, similarity_threshold: 0.60,
+same_concept_only: true }`, i.e. **dedup off** — opt in explicitly.
+
+`similarity_threshold` only applies to `SameConceptSimilarity`; the other modes
+ignore it.
+
+### `upsert_fact`
+
+```rust
+pub fn upsert_fact(
+    &mut self,
+    input: FactInput,
+    options: &StoreFactOptions,
+) -> Result<StoreFactOutcome>
+```
+
+Store a fact, deduplicating per `options.dedup`. On a dedup hit it either
+**reuses** the existing fact (updating `confidence` to the new value,
+incrementing `usage_count`, and stamping `last_accessed_at`) or **supersedes**
+it. Provenance (`options.provenance`) adds a `DERIVES_FROM` edge from the
+surviving node to each source episode, exactly as
+[`store_fact_with_provenance`](cognitive_memory.md#4-semantic-memory) does, and
+`SIMILAR_TO` auto-linking (`options.similarity`) is applied to the surviving
+node exactly as in
+[`store_fact_with_options`](cognitive_memory.md#4-semantic-memory). `upsert_fact`
+is the **only** method that reads `options.provenance` and `options.dedup` (see
+[StoreFactOptions](#storefactoptions)).
+
+#### `FactInput`
+
+```rust
+pub struct FactInput {
+    pub concept: String,
+    pub content: String,
+    pub confidence: f64,
+    pub source_id: String,
+    pub tags: Vec<String>,
+    pub metadata: HashMap<String, serde_json::Value>,
+    pub importance: Option<f64>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub dedup_key: Option<String>,
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `concept` | `String` | required | Concept / lookup key. |
+| `content` | `String` | required | Factual content. |
+| `confidence` | `f64` | required | Confidence in `[0.0, 1.0]`; out-of-range/`NaN` is `MemoryError::InvalidInput`. |
+| `source_id` | `String` | `""` | Opaque provenance string (never auto-converted to an edge). |
+| `tags` | `Vec<String>` | `[]` | Tags used for similarity and filtering. |
+| `metadata` | `HashMap<String, Value>` | `{}` | Arbitrary structured metadata. |
+| `importance` | `Option<f64>` | `None` ⇒ `confidence` | Retention weight; defaults to `confidence` when unset. |
+| `expires_at` | `Option<DateTime<Utc>>` | `None` | Optional absolute expiry used by retention. |
+| `dedup_key` | `Option<String>` | `None` | Required by `DedupMode::CallerKey`; ignored by other modes. |
+
+`FactInput` implements `Default`, and a convenience constructor
+`FactInput::new(concept, content, confidence)` fills the rest with defaults.
+
+#### `StoreFactOptions`
+
+The existing `StoreFactOptions` (introduced for `SIMILAR_TO` auto-linking) is
+extended in place:
+
+```rust
+pub struct StoreFactOptions {
+    pub similarity: Option<SimilarityOptions>,
+    pub provenance: ProvenanceOptions,
+    pub dedup: DedupOptions,
+}
+
+pub struct ProvenanceOptions {
+    pub source_episode_ids: Vec<String>,
+    pub strict: bool,
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `similarity` | `Option<SimilarityOptions>` | `None` | When `Some(opts)` and enabled, auto-link the surviving fact to its `SIMILAR_TO` neighbours. |
+| `provenance` | `ProvenanceOptions` | empty / non-strict | Source episode ids; each existing episode gets a `DERIVES_FROM` edge from the surviving fact. With `strict = true`, a missing episode fails the whole insert atomically. |
+| `dedup` | `DedupOptions` | `DedupOptions::default()` (mode `None`) | Deduplication strategy. |
+
+> **Which methods read which fields.** `provenance` and `dedup` are consumed
+> **only** by [`upsert_fact`](#upsert_fact) (and `dedup` also by
+> [`find_duplicate_facts`](#find_duplicate_facts)). The pre-existing
+> [`store_fact_with_options`](cognitive_memory.md#4-semantic-memory) keeps its
+> exact positional signature and reads **only** `similarity`; it ignores
+> `provenance` and `dedup`. Provenance for that legacy method continues to come
+> from its own `source_episode_ids` argument, so every existing call behaves
+> identically.
+
+`StoreFactOptions` derives `Debug, Clone, PartialEq, Default`. It **no longer
+derives `Copy`** (it now owns a `Vec` and `String`). Construct it with struct
+update syntax:
+
+```rust
+let options = StoreFactOptions {
+    dedup: DedupOptions { mode: DedupMode::ExactContentHash, ..Default::default() },
+    ..Default::default()
+};
+```
+
+`StoreFactOptions::default()` (all fields default) makes `upsert_fact` behave
+like a plain insert with no dedup, no provenance, and no similarity linking.
+
+#### `StoreFactOutcome` and `DedupAction`
+
+```rust
+pub struct StoreFactOutcome {
+    pub node_id: String,
+    pub dedup_action: DedupAction,
+    pub content_hash: String,
+    pub similarity_links_created: usize,
+    pub provenance_edges_created: usize,
+}
+
+pub enum DedupAction {
+    /// A brand-new fact node was created.
+    Inserted,
+    /// An existing fact matched and was reinforced; no new node created.
+    Reused { existing_id: String },
+    /// A new node was created and an older one was archived behind it.
+    Superseded { old_id: String, new_id: String },
+}
+```
+
+`node_id` is always the **surviving / current** fact: the new node for
+`Inserted` and `Superseded`, and the reused node for `Reused`.
+
+#### Decision table
+
+| `mode` | Match condition | Outcome | Side effects |
+|--------|-----------------|---------|--------------|
+| `None` | — | `Inserted` | New node. |
+| `ExactContentHash` | a same-agent fact has an identical `content_hash` | `Reused { existing_id }` | `confidence = new`, `usage_count += 1`, `last_accessed_at = now`. No new node. |
+| `ExactContentHash` | no match | `Inserted` | New node. |
+| `CallerKey(k)` | same `dedup_key`, **identical** content | `Reused { existing_id }` | Reinforced as above (no churn for an unchanged re-write). |
+| `CallerKey(k)` | same `dedup_key`, **changed** content | `Superseded { old_id, new_id }` | New node inserted; old node archived; `SUPERSEDES` edge `new -> old`. |
+| `CallerKey(k)` | no fact with that key | `Inserted` | New node carrying `dedup_key = k`. |
+| `SameConceptSimilarity` | a same-concept fact scores `>= similarity_threshold` | `Reused { existing_id }` | Reinforced; reuses the highest-scoring match. |
+| `SameConceptSimilarity` | no match | `Inserted` | New node. |
+
+Reuse updates **confidence, usage_count, and last_accessed_at only**;
+`importance` is intentionally left untouched so a hand-tuned retention weight is
+never silently lowered by a reuse.
+
+#### Example
+
+```rust
+use amplihack_memory::{
+    CognitiveMemory, DedupMode, DedupOptions, DedupAction, FactInput, StoreFactOptions,
+};
+
+let mut cog = CognitiveMemory::new("agent")?;
+
+let exact = StoreFactOptions {
+    dedup: DedupOptions { mode: DedupMode::ExactContentHash, ..Default::default() },
+    ..Default::default()
+};
+
+let first = cog.upsert_fact(
+    FactInput::new("ports", "staging uses 8080", 0.9),
+    &exact,
+)?;
+assert!(matches!(first.dedup_action, DedupAction::Inserted));
+
+// Identical content -> reused, not a second node.
+let second = cog.upsert_fact(
+    FactInput::new("ports", "staging uses 8080", 0.95),
+    &exact,
+)?;
+assert!(matches!(second.dedup_action, DedupAction::Reused { .. }));
+assert_eq!(first.node_id, second.node_id);
+assert_eq!(cog.get_all_facts(50).len(), 1);
+```
+
+```rust
+// CallerKey: same key, changed content -> supersede, keeping the latest.
+use amplihack_memory::{CognitiveMemory, DedupMode, DedupOptions, DedupAction, FactInput, StoreFactOptions};
+let mut cog = CognitiveMemory::new("agent")?;
+
+let by_key = |k: &str| StoreFactOptions {
+    dedup: DedupOptions { mode: DedupMode::CallerKey(k.into()), ..Default::default() },
+    ..Default::default()
+};
+
+let v1 = cog.upsert_fact(
+    FactInput { dedup_key: Some("staging-port".into()), ..FactInput::new("ports", "staging uses 8080", 0.9) },
+    &by_key("staging-port"),
+)?;
+
+let v2 = cog.upsert_fact(
+    FactInput { dedup_key: Some("staging-port".into()), ..FactInput::new("ports", "staging uses 9090", 0.9) },
+    &by_key("staging-port"),
+)?;
+
+match v2.dedup_action {
+    DedupAction::Superseded { old_id, new_id } => {
+        assert_eq!(old_id, v1.node_id);
+        assert_eq!(new_id, v2.node_id);
+    }
+    _ => panic!("expected supersession"),
+}
+assert_eq!(cog.get_all_facts(50).len(), 1);
+```
+
+### `find_duplicate_facts`
+
+```rust
+pub fn find_duplicate_facts(
+    &self,
+    options: &DedupOptions,
+    limit: usize,
+) -> Vec<DuplicateFactGroup>
+```
+
+Group this agent's **active** facts into duplicate clusters under the given mode
+without modifying anything. Useful for auditing an existing store before
+enabling dedup, or for a periodic cleanup job that feeds
+[`supersede_fact`](#supersede_fact). Only groups with two or more members are
+returned; at most `limit` groups.
+
+```rust
+pub struct DuplicateFactGroup {
+    /// The shared identity for the group: the `content_hash`
+    /// (ExactContentHash), the `dedup_key` (CallerKey), or the representative
+    /// node id (SameConceptSimilarity).
+    pub key: String,
+    /// `node_id`s in the group, oldest first (by creation time, ties broken by
+    /// node id). Always contains at least two ids.
+    pub fact_ids: Vec<String>,
+    /// The representative (oldest) member, equal to `fact_ids[0]`.
+    pub representative_id: String,
+}
+```
+
+| `mode` | Grouping key |
+|--------|--------------|
+| `None` | returns no groups |
+| `ExactContentHash` | identical `content_hash` |
+| `CallerKey(_)` | identical `dedup_key` |
+| `SameConceptSimilarity` | same concept and pairwise similarity `>= similarity_threshold` |
+
+---
+
+## Supersession
+
+### `SUPERSEDES` edge
+
+A new edge type connects a current fact to the record it replaced:
+
+```
+SemanticMemory --SUPERSEDES--> SemanticMemory   (new -> old)
+```
+
+The edge carries a `reason` property and a `superseded_at` timestamp. It is the
+inverse view of the old fact's `superseded_by` field, so supersession history is
+queryable from either direction.
+
+### `supersede_fact`
+
+```rust
+pub fn supersede_fact(
+    &mut self,
+    old_id: &str,
+    new_id: &str,
+    reason: &str,
+) -> Result<()>
+```
+
+Mark `old_id` as replaced by `new_id`:
+
+1. Set `old.superseded_by = new_id` and `old.archived = true` (it disappears
+   from default reads).
+2. Add a `SUPERSEDES` edge `new_id -> old_id` carrying `reason` and
+   `superseded_at`.
+
+Both ids must be this agent's `SemanticMemory` nodes — a guard that prevents one
+agent from archiving another agent's fact by guessing an id. The operation is
+idempotent: re-superseding the same pair re-asserts the state and the single
+edge without error.
+
+#### Errors
+
+* `MemoryError::InvalidInput` — `old_id`/`new_id` is unknown, is not a semantic
+  fact, belongs to another agent, or `old_id == new_id`.
+* `MemoryError::Storage` — the backend rejects the node update or edge write.
+
+```rust
+use amplihack_memory::CognitiveMemory;
+let mut cog = CognitiveMemory::new("agent")?;
+
+let old = cog.store_fact("ports", "staging uses 8080", 0.9, "", None, None)?;
+let new = cog.store_fact("ports", "staging uses 9090", 0.95, "", None, None)?;
+
+cog.supersede_fact(&old, &new, "port reassigned in infra change #214")?;
+
+// `get_all_facts` returns both facts; the superseded `old` is flagged
+// `archived` (and linked behind the SUPERSEDES edge), so callers filter it out.
+let facts = cog.get_all_facts(50);
+assert!(facts.iter().any(|f| f.node_id == new && !f.archived));
+assert!(facts.iter().any(|f| f.node_id == old && f.archived));
+```
+
+---
+
+## Retention / Pruning
+
+### `RetentionPolicy`
+
+```rust
+pub struct RetentionPolicy {
+    pub max_facts_per_concept: Option<usize>,
+    pub ttl_seconds_by_concept: HashMap<String, i64>,
+    pub min_importance_to_keep: f64,
+    pub include_superseded: bool,
+    pub dry_run: bool,
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_facts_per_concept` | `Option<usize>` | `None` | Keep at most N active facts per concept; lowest-importance (tie-broken by oldest) beyond N become candidates. `None` = no cap. |
+| `ttl_seconds_by_concept` | `HashMap<String, i64>` | `{}` | Per-concept maximum age in seconds (measured from `created_at`). A concept with no entry has no TTL. |
+| `min_importance_to_keep` | `f64` | `0.0` | Facts with `importance >= this` are protected from deletion (but may still be archived). Clamped to `[0.0, 1.0]`. |
+| `include_superseded` | `bool` | `false` | When `true`, already-superseded (archived) facts are pruning candidates too. |
+| `dry_run` | `bool` | `false` | When `true`, compute and report counts but mutate nothing. |
+
+`RetentionPolicy::default()` is inert: no cap, no TTLs, importance floor `0.0`,
+superseded excluded, not a dry run — a default-constructed policy archives and
+deletes nothing.
+
+### `prune_semantic_memory`
+
+```rust
+pub fn prune_semantic_memory(
+    &mut self,
+    policy: &RetentionPolicy,
+) -> Result<PruneReport>
+```
+
+Apply the retention policy with **archive-before-delete** semantics so nothing
+is destroyed in a single irreversible step:
+
+* A **candidate** fact that is **not yet archived** is archived
+  (`archived = true`) — counted in `archived`.
+* A **candidate** fact that is **already archived** is deleted — counted in
+  `deleted`.
+
+Run the same policy twice and the first pass archives, the second deletes; this
+is intentional and gives operators a window to inspect or restore between
+passes.
+
+```rust
+pub struct PruneReport {
+    /// Facts archived this run (real run only).
+    pub archived: usize,
+    /// Facts deleted this run (real run only).
+    pub deleted: usize,
+    /// Facts that *would* be archived (dry run only).
+    pub would_archive: usize,
+    /// Facts that *would* be deleted (dry run only).
+    pub would_delete: usize,
+}
+```
+
+In a real run `would_archive`/`would_delete` are `0`; in a dry run
+`archived`/`deleted` are `0` and no data changes.
+
+#### Protection rules
+
+A candidate is **never deleted** when **both** hold:
+
+* it has provenance — at least one `DERIVES_FROM` edge, and
+* `importance >= policy.min_importance_to_keep`.
+
+The explicit override is the policy itself: lowering a fact's importance below
+`min_importance_to_keep` (or raising the floor above it) is the deliberate way
+to make a high-value, provenance-bearing fact eligible for deletion. This keeps
+durable, sourced knowledge from being silently swept away by an aggressive cap
+or TTL.
+
+#### Dry run vs. real run
+
+```rust
+use std::collections::HashMap;
+use amplihack_memory::{CognitiveMemory, RetentionPolicy};
+
+let mut cog = CognitiveMemory::new("agent")?;
+for i in 0..5 {
+    cog.store_fact("logs", &format!("log line {i}"), 0.2, "", None, None)?;
+}
+
+let policy = || RetentionPolicy {
+    max_facts_per_concept: Some(2),
+    ttl_seconds_by_concept: HashMap::new(),
+    min_importance_to_keep: 0.0,
+    include_superseded: false,
+    dry_run: true,
+};
+
+// Dry run: counts only, store unchanged.
+let preview = cog.prune_semantic_memory(&policy())?;
+assert_eq!(preview.would_archive, 3);
+assert_eq!(preview.archived, 0);
+assert_eq!(cog.get_all_facts(50).len(), 5);
+
+// Real run 1: archive the 3 over-cap facts. Archived facts are retained (still
+// returned by `get_all_facts`, flagged `archived = true`) until a later pass.
+let run1 = cog.prune_semantic_memory(&RetentionPolicy { dry_run: false, ..policy() })?;
+assert_eq!(run1.archived, 3);
+assert_eq!(run1.deleted, 0);
+assert_eq!(cog.get_all_facts(50).len(), 5); // archived, not yet deleted
+
+// Real run 2: the now-archived candidates are deleted.
+let run2 = cog.prune_semantic_memory(&RetentionPolicy { dry_run: false, ..policy() })?;
+assert_eq!(run2.deleted, 3);
+assert_eq!(cog.get_all_facts(50).len(), 2);
+```
+
+#### TTL example
+
+```rust
+use std::collections::HashMap;
+use amplihack_memory::RetentionPolicy;
+
+// Facts under concept "sensor-reading" older than 1 hour become candidates.
+let mut ttl = HashMap::new();
+ttl.insert("sensor-reading".to_string(), 3_600);
+
+let policy = RetentionPolicy {
+    ttl_seconds_by_concept: ttl,
+    min_importance_to_keep: 0.8, // protect high-importance + provenance-bearing facts
+    dry_run: false,
+    ..Default::default()
+};
+```
+
+---
+
+## Backward compatibility
+
+| Surface | Guarantee |
+|---------|-----------|
+| `store_fact`, `store_fact_with_provenance`, `store_fact_with_provenance_strict` | Unchanged signatures and behavior; delegate to the shared write path with new fields defaulted (`importance = confidence`, `usage_count = 0`, `archived = false`, etc.). |
+| `store_fact_with_options` | Unchanged signature and behavior. It reads **only** `options.similarity`; the new `options.provenance` and `options.dedup` fields are ignored on this path (they are honored exclusively by `upsert_fact`). Provenance still comes from its `source_episode_ids` argument, so existing calls behave identically. |
+| `get_all_facts`, `search_facts` | Unchanged signatures; still return all facts by confidence descending. Archived facts are included, each flagged `archived = true` so callers can filter them. |
+| Existing `SemanticFact` consumers | New fields are `#[serde(default)]`; deserializing an old fact yields the documented defaults. |
+| Stored graph nodes (both backends) | Missing properties are default-populated on read; `content_hash` is recomputed when absent. No migration required. |
+
+The one source-level change for callers that constructed `StoreFactOptions`
+literally is that it no longer derives `Copy` (it now owns a `Vec`/`String`).
+Use `..Default::default()` in the struct literal — a compile-time-visible,
+mechanical update.
+
+---
+
+## Python parity
+
+The Python `SemanticFact` dataclass (returned by `search_facts` and
+`get_all_facts` on the `amplihack_memory.CognitiveMemory` class) gains the new
+fields **additively** — existing attributes are unchanged, so code that reads
+`node_id`/`concept`/`content`/`confidence` continues to work:
+
+```python
+from amplihack_memory import CognitiveMemory
+
+cog = CognitiveMemory("agent", "/tmp/cog_db")
+cog.store_fact("ports", "staging uses 8080", confidence=0.9)
+
+fact = cog.get_all_facts(limit=1)[0]
+fact.importance        # 0.9    (defaults to confidence)
+fact.usage_count       # 0
+fact.last_accessed_at  # None   (datetime once reused via dedup)
+fact.expires_at        # None   (datetime | None)
+fact.archived          # False
+fact.superseded_by     # None   (str | None)
+fact.content_hash      # "…"    (hex SHA-256)
+fact.dedup_key         # None   (str | None)
+```
+
+The deduplication, supersession, and retention **operations** (`upsert_fact`,
+`supersede_fact`, `prune_semantic_memory`, `find_duplicate_facts`) are part of
+the Rust API in this iteration; the Python surface gains the read-only fields
+above so callers can observe lifecycle state.
+
+---
+
+## Configuration reference
+
+| Setting | Type | Default | Used by |
+|---------|------|---------|---------|
+| `DedupOptions.mode` | `DedupMode` | `None` | `upsert_fact`, `find_duplicate_facts` |
+| `DedupOptions.similarity_threshold` | `f64` | `0.60` | `SameConceptSimilarity` |
+| `DedupOptions.same_concept_only` | `bool` | `true` | dedup candidate scan |
+| `RetentionPolicy.max_facts_per_concept` | `Option<usize>` | `None` | `prune_semantic_memory` |
+| `RetentionPolicy.ttl_seconds_by_concept` | `HashMap<String, i64>` | `{}` | `prune_semantic_memory` |
+| `RetentionPolicy.min_importance_to_keep` | `f64` | `0.0` | prune protection |
+| `RetentionPolicy.include_superseded` | `bool` | `false` | prune candidacy |
+| `RetentionPolicy.dry_run` | `bool` | `false` | prune preview |
+
+---
+
+## See also
+
+* [Cognitive Memory](cognitive_memory.md) — the six memory types and the base
+  semantic-fact API.
+* [API Reference](api_reference.md) — full method and data-class tables.
+* [Architecture](architecture.md) — backends, edges, and data flow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ cog.store_prospective(
 | [Architecture](architecture.md) | Package structure, core components, design philosophy, data flow |
 | [Hierarchical Memory](hierarchical_memory.md) | Graph-based memory with 5 categories, SUPERSEDES/TRANSITIONED_TO edges, Graph RAG |
 | [Cognitive Memory](cognitive_memory.md) | Six-type cognitive memory system (sensory, working, episodic, semantic, procedural, prospective) |
+| [Fact Lifecycle](fact_lifecycle.md) | Semantic-fact deduplication, SUPERSEDES supersession, and retention/pruning |
 | [Kuzu Backend](kuzu_backend.md) | How the Kuzu graph database works, schema, query patterns |
 | [API Reference](api_reference.md) | Complete API reference for all public classes |
 | [Extending](extending.md) | Custom backends, new edge types, custom classifiers, integration patterns |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Architecture: architecture.md
   - Hierarchical Memory: hierarchical_memory.md
   - Cognitive Memory: cognitive_memory.md
+  - Fact Lifecycle (Dedup/Supersession/Retention): fact_lifecycle.md
   - Kuzu Backend: kuzu_backend.md
   - API Reference: api_reference.md
   - Extending: extending.md

--- a/rust/amplihack-memory/src/cognitive_memory/converters.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/converters.rs
@@ -37,6 +37,29 @@ pub(crate) fn prop_datetime(props: &HashMap<String, String>, key: &str) -> DateT
     ts_to_datetime(prop_i64(props, key))
 }
 
+/// Read an optional string prop: absent or empty maps to `None`.
+pub(crate) fn prop_opt_str(props: &HashMap<String, String>, key: &str) -> Option<String> {
+    props.get(key).filter(|v| !v.is_empty()).cloned()
+}
+
+/// Read an optional unix-timestamp prop as `DateTime<Utc>`: absent, empty, or
+/// unparseable maps to `None`.
+pub(crate) fn prop_opt_datetime(
+    props: &HashMap<String, String>,
+    key: &str,
+) -> Option<DateTime<Utc>> {
+    props
+        .get(key)
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(ts_to_datetime)
+}
+
+/// Read a boolean prop encoded as the string `"true"` (anything else is false).
+pub(crate) fn prop_bool(props: &HashMap<String, String>, key: &str) -> bool {
+    props.get(key).map(|v| v == "true").unwrap_or(false)
+}
+
 // ---------------------------------------------------------------------------
 // Node-to-struct converters
 // ---------------------------------------------------------------------------
@@ -88,15 +111,43 @@ pub(crate) fn node_to_fact(props: &HashMap<String, String>) -> SemanticFact {
     let metadata: HashMap<String, serde_json::Value> =
         serde_json::from_str(&meta_str).unwrap_or_default();
 
+    let concept = prop_str(props, "concept");
+    let content = prop_str(props, "content");
+    let confidence = prop_f64(props, "confidence");
+
+    // `importance` falls back to `confidence` when the prop is absent/empty so
+    // facts stored before the field existed keep a sensible value (rather than
+    // `prop_f64`'s `0.0`).
+    let importance = props
+        .get("importance")
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(confidence);
+
+    // `content_hash` is recomputed from concept + content when absent/empty so
+    // legacy facts participate in exact-content dedup without a migration.
+    let content_hash = match prop_opt_str(props, "content_hash") {
+        Some(h) => h,
+        None => super::dedup::compute_content_hash(&concept, &content),
+    };
+
     SemanticFact {
         node_id: prop_str(props, "node_id"),
-        concept: prop_str(props, "concept"),
-        content: prop_str(props, "content"),
-        confidence: prop_f64(props, "confidence"),
+        concept,
+        content,
+        confidence,
         source_id: prop_str(props, "source_id"),
         tags,
         metadata,
         created_at: prop_datetime(props, "created_at"),
+        importance,
+        usage_count: prop_i64(props, "usage_count"),
+        last_accessed_at: prop_opt_datetime(props, "last_accessed_at"),
+        expires_at: prop_opt_datetime(props, "expires_at"),
+        archived: prop_bool(props, "archived"),
+        superseded_by: prop_opt_str(props, "superseded_by"),
+        content_hash,
+        dedup_key: prop_opt_str(props, "dedup_key"),
     }
 }
 
@@ -253,6 +304,88 @@ mod tests {
         p.insert("tags".into(), "not json".into());
         let f = node_to_fact(&p);
         assert!(f.tags.is_empty());
+    }
+
+    #[test]
+    fn test_node_to_fact_new_lifecycle_fields() {
+        let mut p = HashMap::new();
+        p.insert("node_id".into(), "n1".into());
+        p.insert("concept".into(), "rust".into());
+        p.insert("content".into(), "safe".into());
+        p.insert("confidence".into(), "0.9".into());
+        p.insert("importance".into(), "0.42".into());
+        p.insert("usage_count".into(), "7".into());
+        p.insert("last_accessed_at".into(), "1700000500".into());
+        p.insert("expires_at".into(), "1800000000".into());
+        p.insert("archived".into(), "true".into());
+        p.insert("superseded_by".into(), "sem_newer".into());
+        p.insert("content_hash".into(), "deadbeef".into());
+        p.insert("dedup_key".into(), "caller-key".into());
+
+        let f = node_to_fact(&p);
+        assert!((f.importance - 0.42).abs() < 1e-9);
+        assert_eq!(f.usage_count, 7);
+        assert!(f.last_accessed_at.is_some());
+        assert!(f.expires_at.is_some());
+        assert!(f.archived);
+        assert_eq!(f.superseded_by.as_deref(), Some("sem_newer"));
+        assert_eq!(f.content_hash, "deadbeef");
+        assert_eq!(f.dedup_key.as_deref(), Some("caller-key"));
+    }
+
+    #[test]
+    fn test_node_to_fact_legacy_defaults() {
+        // A node persisted before the lifecycle fields existed: only the
+        // original props are present. The converter must default-populate the
+        // new fields without panicking and never break on missing data.
+        let mut p = HashMap::new();
+        p.insert("node_id".into(), "n1".into());
+        p.insert("concept".into(), "rust".into());
+        p.insert("content".into(), "memory safe".into());
+        p.insert("confidence".into(), "0.95".into());
+
+        let f = node_to_fact(&p);
+        assert!(
+            (f.importance - 0.95).abs() < 1e-9,
+            "importance falls back to confidence when absent"
+        );
+        assert_eq!(f.usage_count, 0);
+        assert!(f.last_accessed_at.is_none());
+        assert!(f.expires_at.is_none());
+        assert!(!f.archived);
+        assert!(f.superseded_by.is_none());
+        assert!(f.dedup_key.is_none());
+        assert!(
+            !f.content_hash.is_empty(),
+            "content_hash is recomputed when the stored prop is absent"
+        );
+    }
+
+    #[test]
+    fn test_node_to_fact_empty_options_are_none() {
+        // Empty-string props (lbug's DEFAULT '' for ALTER-added columns) map to
+        // None / defaults rather than Some("").
+        let mut p = HashMap::new();
+        p.insert("concept".into(), "c".into());
+        p.insert("content".into(), "x".into());
+        p.insert("confidence".into(), "0.5".into());
+        p.insert("superseded_by".into(), "".into());
+        p.insert("dedup_key".into(), "".into());
+        p.insert("last_accessed_at".into(), "".into());
+        p.insert("expires_at".into(), "".into());
+        p.insert("content_hash".into(), "".into());
+        p.insert("archived".into(), "".into());
+
+        let f = node_to_fact(&p);
+        assert!(f.superseded_by.is_none());
+        assert!(f.dedup_key.is_none());
+        assert!(f.last_accessed_at.is_none());
+        assert!(f.expires_at.is_none());
+        assert!(!f.archived);
+        assert!(
+            !f.content_hash.is_empty(),
+            "empty content_hash prop triggers a recompute"
+        );
     }
 
     #[test]

--- a/rust/amplihack-memory/src/cognitive_memory/dedup.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/dedup.rs
@@ -1,0 +1,790 @@
+//! Fact deduplication, supersession, and retention for [`CognitiveMemory`].
+//!
+//! This module adds three capabilities on top of the semantic-fact store so
+//! consumers can keep the fact graph from accumulating unbounded duplicate or
+//! stale knowledge:
+//!
+//! * **Dedup** — [`upsert_fact`](CognitiveMemory::upsert_fact) stores a fact
+//!   but first checks, per a [`DedupMode`], whether an equivalent live fact
+//!   already exists. A hit is either *reused* (confidence/usage refreshed) or
+//!   *superseded* (a new version replaces the old) instead of inserting a
+//!   duplicate. [`find_duplicate_facts`](CognitiveMemory::find_duplicate_facts)
+//!   reports existing duplicates without changing anything.
+//! * **Supersession** — [`supersede_fact`](CognitiveMemory::supersede_fact)
+//!   archives an old fact, records a `superseded_by` back-pointer, and links the
+//!   replacement to it with a `SUPERSEDES` edge.
+//! * **Retention** — [`prune_semantic_memory`](CognitiveMemory::prune_semantic_memory)
+//!   applies a [`RetentionPolicy`] using an archive-before-delete lifecycle:
+//!   the first pass archives candidates, a later pass deletes the now-archived
+//!   ones. High-importance, provenance-bearing facts are protected from
+//!   deletion.
+//!
+//! All entry points are additive; the legacy `store_fact*` / `get_all_facts`
+//! APIs keep their existing behaviour and the new fact fields default cleanly
+//! for facts written before this module existed.
+
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use crate::graph::types::Direction;
+use crate::memory_types::SemanticFact;
+use crate::similarity::compute_similarity;
+use crate::{MemoryError, Result};
+
+use super::similarity::SimilarityOptions;
+use super::types::{ts_now, ET_SUPERSEDES, NT_SEMANTIC};
+use super::CognitiveMemory;
+
+// ---------------------------------------------------------------------------
+// content hashing
+// ---------------------------------------------------------------------------
+
+/// Compute the deterministic content hash for a fact.
+///
+/// The hash is the lowercase hex SHA-256 of `concept`, a `0x1F` unit-separator
+/// byte, then `content`. The separator makes the concept/content boundary part
+/// of the hash so e.g. `("ab", "c")` and `("a", "bc")` do not collide. Content
+/// is hashed verbatim (no trimming or case-folding) so dedup is exact.
+pub fn compute_content_hash(concept: &str, content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(concept.as_bytes());
+    hasher.update([0x1f]);
+    hasher.update(content.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// option / input / outcome types
+// ---------------------------------------------------------------------------
+
+/// Strategy for detecting that a fact being stored duplicates an existing one.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum DedupMode {
+    /// No deduplication: every upsert inserts a fresh fact.
+    #[default]
+    None,
+    /// Treat facts with an identical `concept + content` hash as duplicates.
+    ExactContentHash,
+    /// Treat facts sharing the given caller-supplied key as the same logical
+    /// fact (a new version with changed content supersedes the old one).
+    CallerKey(String),
+    /// Treat a sufficiently similar fact (optionally restricted to the same
+    /// concept) as a duplicate, using the deterministic composite similarity.
+    SameConceptSimilarity,
+}
+
+/// Tuning knobs controlling dedup detection.
+///
+/// [`Default`] disables deduplication (`mode = None`) with a `0.60` similarity
+/// threshold and same-concept restriction, so it is a safe no-op default.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DedupOptions {
+    /// The duplicate-detection strategy.
+    pub mode: DedupMode,
+    /// Minimum composite similarity for `SameConceptSimilarity` to treat two
+    /// facts as duplicates (a pair matches when `score >= threshold`).
+    pub similarity_threshold: f64,
+    /// When `true`, only same-concept facts are similarity-dedup candidates.
+    pub same_concept_only: bool,
+}
+
+impl Default for DedupOptions {
+    fn default() -> Self {
+        Self {
+            mode: DedupMode::None,
+            similarity_threshold: 0.60,
+            same_concept_only: true,
+        }
+    }
+}
+
+/// Provenance inputs for an [`upsert_fact`](CognitiveMemory::upsert_fact) insert.
+///
+/// [`Default`] links no episodes and is lenient (`strict = false`).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProvenanceOptions {
+    /// Episode ids the new fact derives from (each gets a `DERIVES_FROM` edge).
+    pub source_episode_ids: Vec<String>,
+    /// When `true`, a missing source episode fails the whole insert atomically
+    /// (mirrors `store_fact_with_provenance_strict`).
+    pub strict: bool,
+}
+
+/// Options bundle for [`upsert_fact`](CognitiveMemory::upsert_fact) and
+/// [`store_fact_with_options`](CognitiveMemory::store_fact_with_options).
+///
+/// [`Default`] performs a plain insert: no similarity linking, no provenance
+/// edges, and no deduplication — observably identical to
+/// [`store_fact`](CognitiveMemory::store_fact).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct StoreFactOptions {
+    /// When `Some(opts)` (and `opts.enabled`), a freshly inserted fact is
+    /// auto-linked to its above-threshold neighbours.
+    pub similarity: Option<SimilarityOptions>,
+    /// Provenance edges to create for an inserted fact.
+    pub provenance: ProvenanceOptions,
+    /// Deduplication behaviour applied before insertion.
+    pub dedup: DedupOptions,
+}
+
+/// A fact to store via [`upsert_fact`](CognitiveMemory::upsert_fact).
+///
+/// Construct with [`FactInput::new`] and set the optional fields as needed.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct FactInput {
+    /// The concept / topic key.
+    pub concept: String,
+    /// The factual content.
+    pub content: String,
+    /// Confidence in `[0.0, 1.0]`.
+    pub confidence: f64,
+    /// Opaque source identifier (stored as a string property).
+    pub source_id: String,
+    /// Categorical tags for similarity linking and filtering.
+    pub tags: Vec<String>,
+    /// Arbitrary metadata.
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Optional importance override; defaults to `confidence` when `None`.
+    pub importance: Option<f64>,
+    /// Optional expiry instant used by retention.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Optional caller dedup key (used/overwritten by `DedupMode::CallerKey`).
+    pub dedup_key: Option<String>,
+}
+
+impl FactInput {
+    /// Create a `FactInput` with the required fields; the rest default.
+    pub fn new(concept: impl Into<String>, content: impl Into<String>, confidence: f64) -> Self {
+        Self {
+            concept: concept.into(),
+            content: content.into(),
+            confidence,
+            ..Default::default()
+        }
+    }
+}
+
+/// What an [`upsert_fact`](CognitiveMemory::upsert_fact) call did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DedupAction {
+    /// A new fact node was created.
+    Inserted,
+    /// An existing live fact was reused (confidence/usage refreshed).
+    Reused {
+        /// The id of the reused fact.
+        existing_id: String,
+    },
+    /// A new fact superseded an existing one.
+    Superseded {
+        /// The archived, superseded fact.
+        old_id: String,
+        /// The new replacement fact.
+        new_id: String,
+    },
+}
+
+/// Result of an [`upsert_fact`](CognitiveMemory::upsert_fact) call.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoreFactOutcome {
+    /// The id of the live fact after the call (inserted/reused/new replacement).
+    pub node_id: String,
+    /// What happened.
+    pub dedup_action: DedupAction,
+    /// The content hash of the input fact.
+    pub content_hash: String,
+    /// How many `SIMILAR_TO` links were created (0 unless inserted with
+    /// similarity enabled).
+    pub similarity_links_created: usize,
+    /// How many `DERIVES_FROM` provenance edges were created.
+    pub provenance_edges_created: usize,
+}
+
+/// A group of facts detected as duplicates of one another.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateFactGroup {
+    /// The grouping key (content hash, caller key, or representative id).
+    pub key: String,
+    /// The member fact ids, oldest first.
+    pub fact_ids: Vec<String>,
+    /// The representative (oldest) fact id.
+    pub representative_id: String,
+}
+
+/// Policy controlling [`prune_semantic_memory`](CognitiveMemory::prune_semantic_memory).
+///
+/// [`Default`] is a no-op-ish policy: no per-concept cap, no TTLs, keep
+/// everything with importance `>= 0.0`, ignore superseded facts, and actually
+/// mutate (`dry_run = false`).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct RetentionPolicy {
+    /// Keep at most this many live facts per concept (highest importance wins).
+    pub max_facts_per_concept: Option<usize>,
+    /// Per-concept max age in seconds; a fact older than its concept's TTL is a
+    /// prune candidate.
+    pub ttl_seconds_by_concept: HashMap<String, i64>,
+    /// Facts with importance below this threshold are prune candidates.
+    pub min_importance_to_keep: f64,
+    /// When `true`, superseded (archived) facts are also prune candidates.
+    pub include_superseded: bool,
+    /// When `true`, only report counts; make no changes.
+    pub dry_run: bool,
+}
+
+/// Summary of a [`prune_semantic_memory`](CognitiveMemory::prune_semantic_memory)
+/// pass. For a real run the `would_*` counts are zero; for a `dry_run` the
+/// `archived` / `deleted` counts are zero.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PruneReport {
+    /// Facts archived this pass.
+    pub archived: usize,
+    /// Facts deleted this pass.
+    pub deleted: usize,
+    /// Facts that would be archived (dry run).
+    pub would_archive: usize,
+    /// Facts that would be deleted (dry run).
+    pub would_delete: usize,
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/// Build the property map [`compute_similarity`] expects from raw fields.
+fn sim_map(concept: &str, content: &str, tags: &[String]) -> HashMap<String, serde_json::Value> {
+    let mut m = HashMap::with_capacity(3);
+    m.insert(
+        "content".to_string(),
+        serde_json::Value::String(content.to_string()),
+    );
+    m.insert(
+        "concept".to_string(),
+        serde_json::Value::String(concept.to_string()),
+    );
+    m.insert("tags".to_string(), serde_json::json!(tags));
+    m
+}
+
+/// Age basis for retention: the last access time, falling back to creation.
+fn age_basis_ts(f: &SemanticFact) -> i64 {
+    f.last_accessed_at.unwrap_or(f.created_at).timestamp()
+}
+
+/// Build a [`DuplicateFactGroup`] from members, ordered oldest-first.
+fn make_group(key: String, mut members: Vec<SemanticFact>) -> DuplicateFactGroup {
+    members.sort_by(|a, b| {
+        a.created_at
+            .cmp(&b.created_at)
+            .then_with(|| a.node_id.cmp(&b.node_id))
+    });
+    let representative_id = members
+        .first()
+        .map(|f| f.node_id.clone())
+        .unwrap_or_default();
+    let fact_ids = members.into_iter().map(|f| f.node_id).collect();
+    DuplicateFactGroup {
+        key,
+        fact_ids,
+        representative_id,
+    }
+}
+
+/// Group facts by a derived key, dropping facts whose key is `None`.
+fn group_by_key(
+    facts: &[SemanticFact],
+    key_of: impl Fn(&SemanticFact) -> Option<String>,
+) -> Vec<DuplicateFactGroup> {
+    let mut map: HashMap<String, Vec<SemanticFact>> = HashMap::new();
+    for f in facts {
+        if let Some(k) = key_of(f) {
+            map.entry(k).or_default().push(f.clone());
+        }
+    }
+    map.into_iter()
+        .map(|(key, members)| make_group(key, members))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// CognitiveMemory methods
+// ---------------------------------------------------------------------------
+
+impl CognitiveMemory {
+    /// Store a fact, deduplicating against existing live facts per `options.dedup`.
+    ///
+    /// Depending on the [`DedupMode`] and whether a matching live fact exists,
+    /// this either **inserts** a new fact (creating any provenance / similarity
+    /// edges from `options`), **reuses** an existing fact (bumping its usage
+    /// count, refreshing `last_accessed_at`, and updating its confidence while
+    /// leaving importance untouched), or **supersedes** an existing fact with a
+    /// new version. Only non-archived facts are dedup candidates.
+    ///
+    /// With the default `options.dedup.mode = None` every call inserts, making
+    /// this a backward-compatible superset of
+    /// [`store_fact`](Self::store_fact).
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::InvalidInput` if `confidence` is out of range (or,
+    /// in strict provenance mode, a source episode is missing), or
+    /// `MemoryError::Storage` if a node or edge cannot be persisted.
+    pub fn upsert_fact(
+        &mut self,
+        input: FactInput,
+        options: &StoreFactOptions,
+    ) -> Result<StoreFactOutcome> {
+        if input.confidence.is_nan() || !(0.0..=1.0).contains(&input.confidence) {
+            return Err(MemoryError::InvalidInput(
+                "confidence must be between 0.0 and 1.0".into(),
+            ));
+        }
+
+        let content_hash = compute_content_hash(&input.concept, &input.content);
+        let hit = self.find_dedup_hit(&input, &content_hash, &options.dedup);
+
+        match (&options.dedup.mode, hit) {
+            (DedupMode::CallerKey(k), Some(existing)) => {
+                if existing.content_hash == content_hash {
+                    self.reuse_fact(existing, &input, content_hash)
+                } else {
+                    let key = k.clone();
+                    self.supersede_with_new(existing, input, options, content_hash, key)
+                }
+            }
+            (DedupMode::CallerKey(k), None) => {
+                let mut input = input;
+                input.dedup_key = Some(k.clone());
+                self.insert_fact(input, options, content_hash)
+            }
+            (DedupMode::ExactContentHash, Some(existing))
+            | (DedupMode::SameConceptSimilarity, Some(existing)) => {
+                self.reuse_fact(existing, &input, content_hash)
+            }
+            _ => self.insert_fact(input, options, content_hash),
+        }
+    }
+
+    /// Archive `old_id`, point it at its replacement `new_id`, and link the two
+    /// with a `SUPERSEDES` edge (`new -> old`) carrying `reason`.
+    ///
+    /// The old fact's `superseded_by` is set and `archived` becomes `true`. The
+    /// `SUPERSEDES` edge is created once: a repeat call is idempotent on the
+    /// edge. Both ids must resolve to existing semantic-fact nodes and must
+    /// differ.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MemoryError::InvalidInput` if either id is missing or they are
+    /// equal, or `MemoryError::Storage` if the archive update or edge write
+    /// fails.
+    pub fn supersede_fact(&mut self, old_id: &str, new_id: &str, reason: &str) -> Result<()> {
+        if old_id == new_id {
+            return Err(MemoryError::InvalidInput(
+                "a fact cannot supersede itself".into(),
+            ));
+        }
+        if !self.is_semantic_fact(old_id) {
+            return Err(MemoryError::InvalidInput(format!(
+                "fact {old_id} not found"
+            )));
+        }
+        if !self.is_semantic_fact(new_id) {
+            return Err(MemoryError::InvalidInput(format!(
+                "fact {new_id} not found"
+            )));
+        }
+
+        let mut props = HashMap::new();
+        props.insert("superseded_by".to_string(), new_id.to_string());
+        props.insert("archived".to_string(), "true".to_string());
+        if !self.graph.update_node(old_id, props) {
+            return Err(MemoryError::Storage(format!(
+                "failed to archive superseded fact {old_id}"
+            )));
+        }
+
+        let already = self
+            .graph
+            .query_neighbors(new_id, Some(ET_SUPERSEDES), Direction::Outgoing, usize::MAX)
+            .iter()
+            .any(|(_, n)| n.node_id == old_id);
+        if !already {
+            let mut eprops = HashMap::new();
+            eprops.insert("reason".to_string(), reason.to_string());
+            eprops.insert("superseded_at".to_string(), ts_now().to_string());
+            self.graph
+                .add_edge(new_id, old_id, ET_SUPERSEDES, Some(eprops))
+                .map_err(|e| MemoryError::Storage(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    /// Report groups of live facts that duplicate one another under `options`.
+    ///
+    /// Grouping key depends on the [`DedupMode`]: `ExactContentHash` groups by
+    /// content hash, `CallerKey` groups by non-empty dedup key, and
+    /// `SameConceptSimilarity` clusters above-threshold pairs (optionally
+    /// same-concept). `None` returns no groups. Only groups with at least two
+    /// members are returned, sorted by size descending; `limit` (when non-zero)
+    /// caps the number of groups. This is read-only: nothing is mutated.
+    pub fn find_duplicate_facts(
+        &self,
+        options: &DedupOptions,
+        limit: usize,
+    ) -> Vec<DuplicateFactGroup> {
+        let live: Vec<SemanticFact> = self
+            .get_all_facts(usize::MAX)
+            .into_iter()
+            .filter(|f| !f.archived)
+            .collect();
+
+        let mut groups = match &options.mode {
+            DedupMode::None => return Vec::new(),
+            DedupMode::ExactContentHash => group_by_key(&live, |f| Some(f.content_hash.clone())),
+            DedupMode::CallerKey(_) => {
+                group_by_key(&live, |f| f.dedup_key.clone().filter(|k| !k.is_empty()))
+            }
+            DedupMode::SameConceptSimilarity => self.group_by_similarity(&live, options),
+        };
+
+        groups.retain(|g| g.fact_ids.len() >= 2);
+        groups.sort_by(|a, b| {
+            b.fact_ids
+                .len()
+                .cmp(&a.fact_ids.len())
+                .then_with(|| a.key.cmp(&b.key))
+        });
+        if limit > 0 {
+            groups.truncate(limit);
+        }
+        groups
+    }
+
+    /// Apply a [`RetentionPolicy`] to this agent's facts, archive-before-delete.
+    ///
+    /// A fact is a prune *candidate* if any policy trigger fires: importance
+    /// below `min_importance_to_keep`, a past `expires_at`, an exceeded
+    /// per-concept TTL, being over the per-concept cap (lowest-importance
+    /// excess), or — with `include_superseded` — being superseded.
+    ///
+    /// Each candidate is handled in two tiers: a not-yet-archived candidate is
+    /// archived; an already-archived candidate is deleted. Thus one pass
+    /// archives fresh candidates and a later pass deletes them. A fact with at
+    /// least one `DERIVES_FROM` edge **and** importance at or above the keep
+    /// threshold is protected from deletion (it may still be archived). With
+    /// `dry_run`, only the `would_*` counts are populated and nothing changes.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible, but returns `Result` for forward compatibility
+    /// with backends that report storage errors.
+    pub fn prune_semantic_memory(&mut self, policy: &RetentionPolicy) -> Result<PruneReport> {
+        let facts = self.get_all_facts(usize::MAX);
+        let now = ts_now();
+        let excess = self.compute_excess(&facts, policy);
+        let mut report = PruneReport::default();
+
+        for f in &facts {
+            if !self.prune_candidate(f, policy, now, &excess) {
+                continue;
+            }
+            if !f.archived {
+                if policy.dry_run {
+                    report.would_archive += 1;
+                } else {
+                    let mut props = HashMap::new();
+                    props.insert("archived".to_string(), "true".to_string());
+                    if self.graph.update_node(&f.node_id, props) {
+                        report.archived += 1;
+                    }
+                }
+            } else if !self.protected_from_delete(f, policy) {
+                if policy.dry_run {
+                    report.would_delete += 1;
+                } else if self.graph.delete_node(&f.node_id) {
+                    report.deleted += 1;
+                }
+            }
+        }
+
+        Ok(report)
+    }
+
+    // -- internals --
+
+    fn is_semantic_fact(&self, id: &str) -> bool {
+        self.graph
+            .get_node(id)
+            .is_some_and(|n| n.node_type == NT_SEMANTIC)
+    }
+
+    /// Find a live fact this input duplicates, per the dedup mode.
+    fn find_dedup_hit(
+        &self,
+        input: &FactInput,
+        content_hash: &str,
+        dedup: &DedupOptions,
+    ) -> Option<SemanticFact> {
+        let live = self
+            .get_all_facts(usize::MAX)
+            .into_iter()
+            .filter(|f| !f.archived);
+
+        match &dedup.mode {
+            DedupMode::None => None,
+            DedupMode::ExactContentHash => {
+                live.into_iter().find(|f| f.content_hash == content_hash)
+            }
+            DedupMode::CallerKey(k) => live
+                .into_iter()
+                .find(|f| f.dedup_key.as_deref() == Some(k.as_str())),
+            DedupMode::SameConceptSimilarity => {
+                let src = sim_map(&input.concept, &input.content, &input.tags);
+                live.into_iter().find(|f| {
+                    if dedup.same_concept_only && f.concept != input.concept {
+                        return false;
+                    }
+                    compute_similarity(&src, &sim_map(&f.concept, &f.content, &f.tags))
+                        >= dedup.similarity_threshold
+                })
+            }
+        }
+    }
+
+    fn insert_fact(
+        &mut self,
+        input: FactInput,
+        options: &StoreFactOptions,
+        content_hash: String,
+    ) -> Result<StoreFactOutcome> {
+        let node_id = self.store_fact_with_provenance_inner(
+            &input.concept,
+            &input.content,
+            input.confidence,
+            &input.source_id,
+            Some(input.tags.as_slice()),
+            Some(&input.metadata),
+            &options.provenance.source_episode_ids,
+            options.provenance.strict,
+            input.importance,
+            input.expires_at,
+            input.dedup_key.clone(),
+        )?;
+
+        let provenance_edges_created = self.fact_provenance(&node_id).len();
+        let similarity_links_created = self.auto_link_on_insert(&node_id, options)?;
+
+        Ok(StoreFactOutcome {
+            node_id,
+            dedup_action: DedupAction::Inserted,
+            content_hash,
+            similarity_links_created,
+            provenance_edges_created,
+        })
+    }
+
+    fn reuse_fact(
+        &mut self,
+        existing: SemanticFact,
+        input: &FactInput,
+        content_hash: String,
+    ) -> Result<StoreFactOutcome> {
+        let mut props = HashMap::new();
+        props.insert(
+            "usage_count".to_string(),
+            (existing.usage_count + 1).to_string(),
+        );
+        props.insert("last_accessed_at".to_string(), ts_now().to_string());
+        props.insert("confidence".to_string(), input.confidence.to_string());
+        if !self.graph.update_node(&existing.node_id, props) {
+            return Err(MemoryError::Storage(format!(
+                "failed to update reused fact {}",
+                existing.node_id
+            )));
+        }
+
+        Ok(StoreFactOutcome {
+            node_id: existing.node_id.clone(),
+            dedup_action: DedupAction::Reused {
+                existing_id: existing.node_id,
+            },
+            content_hash,
+            similarity_links_created: 0,
+            provenance_edges_created: 0,
+        })
+    }
+
+    fn supersede_with_new(
+        &mut self,
+        old: SemanticFact,
+        mut input: FactInput,
+        options: &StoreFactOptions,
+        content_hash: String,
+        key: String,
+    ) -> Result<StoreFactOutcome> {
+        input.dedup_key = Some(key);
+        let node_id = self.store_fact_with_provenance_inner(
+            &input.concept,
+            &input.content,
+            input.confidence,
+            &input.source_id,
+            Some(input.tags.as_slice()),
+            Some(&input.metadata),
+            &options.provenance.source_episode_ids,
+            options.provenance.strict,
+            input.importance,
+            input.expires_at,
+            input.dedup_key.clone(),
+        )?;
+
+        let provenance_edges_created = self.fact_provenance(&node_id).len();
+        self.supersede_fact(&old.node_id, &node_id, "callerkey")?;
+        let similarity_links_created = self.auto_link_on_insert(&node_id, options)?;
+
+        Ok(StoreFactOutcome {
+            node_id: node_id.clone(),
+            dedup_action: DedupAction::Superseded {
+                old_id: old.node_id,
+                new_id: node_id,
+            },
+            content_hash,
+            similarity_links_created,
+            provenance_edges_created,
+        })
+    }
+
+    fn auto_link_on_insert(&mut self, node_id: &str, options: &StoreFactOptions) -> Result<usize> {
+        if let Some(sim) = &options.similarity {
+            if sim.enabled {
+                return self.auto_link_similar_facts(node_id, sim);
+            }
+        }
+        Ok(0)
+    }
+
+    fn group_by_similarity(
+        &self,
+        facts: &[SemanticFact],
+        options: &DedupOptions,
+    ) -> Vec<DuplicateFactGroup> {
+        let mut used = vec![false; facts.len()];
+        let mut groups = Vec::new();
+
+        for i in 0..facts.len() {
+            if used[i] {
+                continue;
+            }
+            used[i] = true;
+            let mut members = vec![facts[i].clone()];
+            let src = sim_map(&facts[i].concept, &facts[i].content, &facts[i].tags);
+
+            for (j, used_j) in used.iter_mut().enumerate().skip(i + 1) {
+                if *used_j {
+                    continue;
+                }
+                if options.same_concept_only && facts[j].concept != facts[i].concept {
+                    continue;
+                }
+                let score = compute_similarity(
+                    &src,
+                    &sim_map(&facts[j].concept, &facts[j].content, &facts[j].tags),
+                );
+                if score >= options.similarity_threshold {
+                    *used_j = true;
+                    members.push(facts[j].clone());
+                }
+            }
+
+            if members.len() >= 2 {
+                groups.push(make_group(facts[i].node_id.clone(), members));
+            }
+        }
+
+        groups
+    }
+
+    /// Compute the set of fact ids that exceed `max_facts_per_concept`.
+    ///
+    /// Facts are ranked per concept with live facts before archived ones, then
+    /// by importance descending (newer wins on ties); everything past the cap is
+    /// excess. Sorting archived facts last means the cap first archives the
+    /// lowest-importance live facts, then — on a subsequent pass — the
+    /// now-archived excess becomes deletable (archive-before-delete) instead of
+    /// accumulating forever.
+    fn compute_excess(&self, facts: &[SemanticFact], policy: &RetentionPolicy) -> HashSet<String> {
+        let mut excess = HashSet::new();
+        let Some(max) = policy.max_facts_per_concept else {
+            return excess;
+        };
+
+        let mut by_concept: HashMap<&str, Vec<&SemanticFact>> = HashMap::new();
+        for f in facts {
+            by_concept.entry(f.concept.as_str()).or_default().push(f);
+        }
+
+        for (_concept, mut group) in by_concept {
+            if group.len() <= max {
+                continue;
+            }
+            group.sort_by(|a, b| {
+                a.archived
+                    .cmp(&b.archived)
+                    .then_with(|| {
+                        b.importance
+                            .partial_cmp(&a.importance)
+                            .unwrap_or(Ordering::Equal)
+                    })
+                    .then_with(|| age_basis_ts(b).cmp(&age_basis_ts(a)))
+            });
+            for f in group.iter().skip(max) {
+                excess.insert(f.node_id.clone());
+            }
+        }
+
+        excess
+    }
+
+    fn prune_candidate(
+        &self,
+        f: &SemanticFact,
+        policy: &RetentionPolicy,
+        now: i64,
+        excess: &HashSet<String>,
+    ) -> bool {
+        if f.importance < policy.min_importance_to_keep {
+            return true;
+        }
+        if let Some(exp) = f.expires_at {
+            if now >= exp.timestamp() {
+                return true;
+            }
+        }
+        if let Some(ttl) = policy.ttl_seconds_by_concept.get(&f.concept) {
+            if now - age_basis_ts(f) >= *ttl {
+                return true;
+            }
+        }
+        if excess.contains(&f.node_id) {
+            return true;
+        }
+        if policy.include_superseded && f.superseded_by.is_some() {
+            return true;
+        }
+        false
+    }
+
+    /// A fact is protected from deletion when it carries provenance and its
+    /// importance is at or above the keep threshold.
+    fn protected_from_delete(&self, f: &SemanticFact, policy: &RetentionPolicy) -> bool {
+        f.importance >= policy.min_importance_to_keep
+            && !self.fact_provenance(&f.node_id).is_empty()
+    }
+}

--- a/rust/amplihack-memory/src/cognitive_memory/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/mod.rs
@@ -13,6 +13,7 @@
 //! graph node.
 
 mod converters;
+mod dedup;
 mod episodic;
 mod procedural;
 mod prospective;
@@ -22,7 +23,11 @@ mod similarity;
 mod types;
 mod working;
 
-pub use similarity::{SimilarityOptions, SimilarityReport, StoreFactOptions};
+pub use dedup::{
+    compute_content_hash, DedupAction, DedupMode, DedupOptions, DuplicateFactGroup, FactInput,
+    ProvenanceOptions, PruneReport, RetentionPolicy, StoreFactOptions, StoreFactOutcome,
+};
+pub use similarity::{SimilarityOptions, SimilarityReport};
 pub use types::WORKING_MEMORY_CAPACITY;
 
 use std::collections::HashMap;

--- a/rust/amplihack-memory/src/cognitive_memory/semantic.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/semantic.rs
@@ -2,12 +2,15 @@
 
 use std::collections::HashMap;
 
+use chrono::{DateTime, Utc};
+
 use crate::memory_types::SemanticFact;
 use crate::{MemoryError, Result};
 
 use tracing::warn;
 
 use super::converters::node_to_fact;
+use super::dedup::compute_content_hash;
 use super::types::{agent_filter, new_id, ts_now, ET_DERIVES_FROM, ET_SIMILAR_TO, NT_SEMANTIC};
 use super::CognitiveMemory;
 
@@ -79,6 +82,9 @@ impl CognitiveMemory {
             metadata,
             source_episode_ids,
             false,
+            None,
+            None,
+            None,
         )
     }
 
@@ -113,11 +119,14 @@ impl CognitiveMemory {
             metadata,
             source_episode_ids,
             true,
+            None,
+            None,
+            None,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn store_fact_with_provenance_inner(
+    pub(super) fn store_fact_with_provenance_inner(
         &mut self,
         concept: &str,
         content: &str,
@@ -127,6 +136,9 @@ impl CognitiveMemory {
         metadata: Option<&HashMap<String, serde_json::Value>>,
         source_episode_ids: &[String],
         strict: bool,
+        importance: Option<f64>,
+        expires_at: Option<DateTime<Utc>>,
+        dedup_key: Option<String>,
     ) -> Result<String> {
         if confidence.is_nan() || !(0.0..=1.0).contains(&confidence) {
             return Err(MemoryError::InvalidInput(
@@ -175,6 +187,29 @@ impl CognitiveMemory {
         props.insert("tags".to_string(), tags_json);
         props.insert("metadata".to_string(), meta_json);
         props.insert("created_at".to_string(), now.to_string());
+
+        // Lifecycle / dedup props. Written on every store so the columns exist
+        // from the first write (the persistent backend creates them lazily) and
+        // legacy readers see explicit defaults.
+        props.insert(
+            "importance".to_string(),
+            importance.unwrap_or(confidence).to_string(),
+        );
+        props.insert("usage_count".to_string(), "0".to_string());
+        props.insert("archived".to_string(), "false".to_string());
+        props.insert(
+            "content_hash".to_string(),
+            compute_content_hash(concept, content),
+        );
+        props.insert("last_accessed_at".to_string(), String::new());
+        props.insert(
+            "expires_at".to_string(),
+            expires_at
+                .map(|d| d.timestamp().to_string())
+                .unwrap_or_default(),
+        );
+        props.insert("superseded_by".to_string(), String::new());
+        props.insert("dedup_key".to_string(), dedup_key.unwrap_or_default());
 
         self.graph
             .add_node(NT_SEMANTIC, props, Some(&node_id))

--- a/rust/amplihack-memory/src/cognitive_memory/similarity.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/similarity.rs
@@ -73,17 +73,7 @@ pub struct SimilarityReport {
     pub links_created: usize,
 }
 
-/// Options for [`store_fact_with_options`](CognitiveMemory::store_fact_with_options).
-///
-/// [`Default`] (`similarity: None`) makes the call behave exactly like
-/// [`store_fact`](CognitiveMemory::store_fact): no `SIMILAR_TO` edges are
-/// created, preserving backward compatibility.
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub struct StoreFactOptions {
-    /// When `Some(opts)` (and `opts.enabled`), the freshly stored fact is
-    /// auto-linked to its above-threshold neighbours after storage.
-    pub similarity: Option<SimilarityOptions>,
-}
+use super::dedup::StoreFactOptions;
 
 /// Build the property map [`compute_similarity`] expects from a fact.
 fn fact_to_sim_map(fact: &SemanticFact) -> HashMap<String, serde_json::Value> {

--- a/rust/amplihack-memory/src/cognitive_memory/tests/dedup_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/dedup_tests.rs
@@ -1,0 +1,909 @@
+//! File: rust/amplihack-memory/src/cognitive_memory/tests/dedup_tests.rs
+//!
+//! Failing-first TDD tests for fact DEDUP, SUPERSESSION, and RETENTION
+//! (issue #90). These bind to the not-yet-implemented public contract:
+//!   - new `SemanticFact` fields (importance, usage_count, last_accessed_at,
+//!     expires_at, archived, superseded_by, content_hash, dedup_key)
+//!   - types  `DedupMode`, `DedupOptions`, `ProvenanceOptions`, `FactInput`,
+//!     `DedupAction`, `StoreFactOutcome`, `DuplicateFactGroup`,
+//!     `RetentionPolicy`, `PruneReport`, and `compute_content_hash`
+//!   - methods `CognitiveMemory::upsert_fact`,
+//!     `CognitiveMemory::supersede_fact`,
+//!     `CognitiveMemory::find_duplicate_facts`,
+//!     `CognitiveMemory::prune_semantic_memory`
+//!
+//! They are backend-agnostic (default in-memory gate); durability of the new
+//! fields + `SUPERSEDES` edge is re-proven under `--features persistent` in
+//! `persistent_tests.rs`.
+
+use super::super::types::ET_SUPERSEDES;
+use super::super::*;
+use crate::graph::Direction;
+use crate::memory_types::SemanticFact;
+use crate::MemoryError;
+use chrono::{DateTime, Duration, Utc};
+
+fn make_cm() -> CognitiveMemory {
+    CognitiveMemory::new(&format!("test-agent-{}", uuid::Uuid::new_v4())).unwrap()
+}
+
+fn tags(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
+}
+
+/// Store a fact via the legacy (non-dedup) path and return its id.
+fn store(cm: &mut CognitiveMemory, concept: &str, content: &str, conf: f64, t: &[&str]) -> String {
+    let tg = tags(t);
+    cm.store_fact(concept, content, conf, "", Some(&tg), None)
+        .unwrap()
+}
+
+/// Fetch a single fact by id (including archived facts).
+fn fact(cm: &CognitiveMemory, id: &str) -> SemanticFact {
+    cm.get_all_facts(10_000)
+        .into_iter()
+        .find(|f| f.node_id == id)
+        .expect("fact should exist")
+}
+
+fn exists(cm: &CognitiveMemory, id: &str) -> bool {
+    cm.get_all_facts(10_000).iter().any(|f| f.node_id == id)
+}
+
+/// `StoreFactOptions` selecting just a dedup mode (everything else default).
+fn dedup_opts(mode: DedupMode) -> StoreFactOptions {
+    StoreFactOptions {
+        dedup: DedupOptions {
+            mode,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn upsert_imp(
+    cm: &mut CognitiveMemory,
+    concept: &str,
+    content: &str,
+    conf: f64,
+    imp: f64,
+) -> String {
+    let mut fi = FactInput::new(concept, content, conf);
+    fi.importance = Some(imp);
+    cm.upsert_fact(fi, &dedup_opts(DedupMode::None))
+        .unwrap()
+        .node_id
+}
+
+#[allow(clippy::too_many_arguments)]
+fn upsert_full(
+    cm: &mut CognitiveMemory,
+    concept: &str,
+    content: &str,
+    conf: f64,
+    imp: Option<f64>,
+    expires: Option<DateTime<Utc>>,
+    episodes: Vec<String>,
+) -> String {
+    let mut fi = FactInput::new(concept, content, conf);
+    fi.importance = imp;
+    fi.expires_at = expires;
+    let opts = StoreFactOptions {
+        provenance: ProvenanceOptions {
+            source_episode_ids: episodes,
+            strict: false,
+        },
+        ..Default::default()
+    };
+    cm.upsert_fact(fi, &opts).unwrap().node_id
+}
+
+fn has_similar_edge(cm: &CognitiveMemory, from: &str, to: &str) -> bool {
+    use super::super::types::ET_SIMILAR_TO;
+    cm.graph
+        .query_neighbors(from, Some(ET_SIMILAR_TO), Direction::Outgoing, 100)
+        .iter()
+        .any(|(e, _)| e.target_id == to)
+}
+
+fn supersedes_targets(cm: &CognitiveMemory, new_id: &str) -> Vec<String> {
+    cm.graph
+        .query_neighbors(new_id, Some(ET_SUPERSEDES), Direction::Outgoing, 100)
+        .into_iter()
+        .map(|(_, n)| n.node_id)
+        .collect()
+}
+
+// ===========================================================================
+// New SemanticFact fields: defaults via the legacy store path
+// ===========================================================================
+
+/// A plain `store_fact` populates the new lifecycle fields with their defaults:
+/// importance defaults to the confidence, counters/flags are zero/false, the
+/// content_hash is computed, and the optional fields are `None`. (Backward
+/// compatibility of the storage layer.)
+#[test]
+fn store_fact_populates_new_fields_with_defaults() {
+    let mut cm = make_cm();
+    let id = store(&mut cm, "rust", "rust is memory safe", 0.8, &["lang"]);
+
+    let f = fact(&cm, &id);
+    assert!(
+        (f.importance - 0.8).abs() < 1e-9,
+        "importance defaults to confidence"
+    );
+    assert_eq!(f.usage_count, 0, "usage_count defaults to 0");
+    assert!(
+        f.last_accessed_at.is_none(),
+        "last_accessed_at defaults None"
+    );
+    assert!(f.expires_at.is_none(), "expires_at defaults None");
+    assert!(!f.archived, "archived defaults false");
+    assert!(f.superseded_by.is_none(), "superseded_by defaults None");
+    assert!(f.dedup_key.is_none(), "dedup_key defaults None");
+    assert_eq!(
+        f.content_hash,
+        compute_content_hash("rust", "rust is memory safe"),
+        "content_hash is computed from concept + content"
+    );
+    assert!(!f.content_hash.is_empty());
+}
+
+/// `compute_content_hash` is order-sensitive across the concept/content
+/// boundary: it must not collide when the split between concept and content
+/// shifts (the unit-separator delimiter prevents concatenation collisions).
+#[test]
+fn content_hash_is_deterministic_and_collision_resistant() {
+    assert_eq!(
+        compute_content_hash("ab", "c"),
+        compute_content_hash("ab", "c"),
+        "same inputs -> same hash"
+    );
+    assert_ne!(
+        compute_content_hash("ab", "c"),
+        compute_content_hash("a", "bc"),
+        "the concept/content boundary must be part of the hash"
+    );
+    assert_ne!(
+        compute_content_hash("rust", "safe"),
+        compute_content_hash("rust", "fast"),
+        "different content -> different hash"
+    );
+}
+
+// ===========================================================================
+// supersede_fact + ET_SUPERSEDES
+// ===========================================================================
+
+/// `supersede_fact(old, new, reason)` archives the old fact, records the
+/// pointer to its replacement, and adds exactly one `SUPERSEDES` edge
+/// new -> old carrying the reason. (Requirement 2.)
+#[test]
+fn supersede_fact_archives_old_and_adds_edge() {
+    let mut cm = make_cm();
+    let a = store(&mut cm, "c", "v1", 0.9, &[]);
+    let b = store(&mut cm, "c", "v2", 0.9, &[]);
+
+    cm.supersede_fact(&a, &b, "newer version").unwrap();
+
+    let fa = fact(&cm, &a);
+    assert!(fa.archived, "the superseded fact is archived");
+    assert_eq!(
+        fa.superseded_by.as_deref(),
+        Some(b.as_str()),
+        "superseded_by points at the replacement"
+    );
+
+    // The replacement is untouched.
+    let fb = fact(&cm, &b);
+    assert!(!fb.archived);
+    assert!(fb.superseded_by.is_none());
+
+    // Exactly one SUPERSEDES edge new -> old, carrying the reason.
+    assert_eq!(supersedes_targets(&cm, &b), vec![a.clone()]);
+    let edges = cm
+        .graph
+        .query_neighbors(&b, Some(ET_SUPERSEDES), Direction::Outgoing, 10);
+    assert_eq!(edges.len(), 1);
+    assert_eq!(
+        edges[0].0.properties.get("reason").map(String::as_str),
+        Some("newer version")
+    );
+}
+
+/// `supersede_fact` is idempotent on the edge: a repeat does not duplicate the
+/// `SUPERSEDES` edge.
+#[test]
+fn supersede_fact_does_not_duplicate_edge() {
+    let mut cm = make_cm();
+    let a = store(&mut cm, "c", "v1", 0.9, &[]);
+    let b = store(&mut cm, "c", "v2", 0.9, &[]);
+
+    cm.supersede_fact(&a, &b, "r1").unwrap();
+    cm.supersede_fact(&a, &b, "r2").unwrap();
+
+    assert_eq!(
+        supersedes_targets(&cm, &b),
+        vec![a],
+        "no duplicate SUPERSEDES edge on repeat"
+    );
+}
+
+/// `supersede_fact` validates its inputs: unknown ids and self-supersession
+/// are rejected with `InvalidInput` and write nothing.
+#[test]
+fn supersede_fact_rejects_invalid_input() {
+    let mut cm = make_cm();
+    let a = store(&mut cm, "c", "v1", 0.9, &[]);
+
+    assert!(matches!(
+        cm.supersede_fact(&a, "sem_missing", "r"),
+        Err(MemoryError::InvalidInput(_))
+    ));
+    assert!(matches!(
+        cm.supersede_fact("sem_missing", &a, "r"),
+        Err(MemoryError::InvalidInput(_))
+    ));
+    assert!(
+        matches!(
+            cm.supersede_fact(&a, &a, "r"),
+            Err(MemoryError::InvalidInput(_))
+        ),
+        "a fact cannot supersede itself"
+    );
+
+    // Nothing was archived by the failed calls.
+    assert!(!fact(&cm, &a).archived);
+}
+
+// ===========================================================================
+// upsert_fact: dedup modes
+// ===========================================================================
+
+/// `DedupMode::None` always inserts a fresh node. (Requirement 3, test 9.)
+#[test]
+fn upsert_none_always_inserts() {
+    let mut cm = make_cm();
+    let o1 = cm
+        .upsert_fact(FactInput::new("c", "v", 0.8), &dedup_opts(DedupMode::None))
+        .unwrap();
+    let o2 = cm
+        .upsert_fact(FactInput::new("c", "v", 0.8), &dedup_opts(DedupMode::None))
+        .unwrap();
+
+    assert!(matches!(o1.dedup_action, DedupAction::Inserted));
+    assert!(matches!(o2.dedup_action, DedupAction::Inserted));
+    assert_ne!(o1.node_id, o2.node_id);
+    assert_eq!(cm.get_all_facts(100).len(), 2, "two distinct nodes");
+    assert!(!o1.content_hash.is_empty());
+}
+
+/// `ExactContentHash`: a second upsert of the same concept+content reuses the
+/// existing node (no new node), bumps usage_count, refreshes last_accessed_at,
+/// and updates confidence while leaving importance untouched.
+/// (Requirement 3, test 1.)
+#[test]
+fn upsert_exact_content_hash_reuses_existing() {
+    let mut cm = make_cm();
+    let o1 = cm
+        .upsert_fact(
+            FactInput::new("rust", "safe", 0.8),
+            &dedup_opts(DedupMode::ExactContentHash),
+        )
+        .unwrap();
+    assert!(matches!(o1.dedup_action, DedupAction::Inserted));
+    let imp_before = fact(&cm, &o1.node_id).importance;
+
+    let o2 = cm
+        .upsert_fact(
+            FactInput::new("rust", "safe", 0.95),
+            &dedup_opts(DedupMode::ExactContentHash),
+        )
+        .unwrap();
+
+    match &o2.dedup_action {
+        DedupAction::Reused { existing_id } => assert_eq!(*existing_id, o1.node_id),
+        other => panic!("expected Reused, got {other:?}"),
+    }
+    assert_eq!(o2.node_id, o1.node_id, "outcome points at the reused node");
+    assert_eq!(
+        cm.get_all_facts(100).len(),
+        1,
+        "reuse must not create a second node"
+    );
+
+    let f = fact(&cm, &o1.node_id);
+    assert_eq!(f.usage_count, 1, "reuse bumps usage_count");
+    assert!(
+        (f.confidence - 0.95).abs() < 1e-9,
+        "reuse updates confidence"
+    );
+    assert!(f.last_accessed_at.is_some(), "reuse sets last_accessed_at");
+    assert!(
+        (f.importance - imp_before).abs() < 1e-9,
+        "reuse leaves importance untouched"
+    );
+}
+
+/// `ExactContentHash` only treats identical concept+content as a duplicate:
+/// different content, or the same content under a different concept, inserts a
+/// new node.
+#[test]
+fn upsert_exact_content_hash_distinguishes_concept_and_content() {
+    let mut cm = make_cm();
+    cm.upsert_fact(
+        FactInput::new("rust", "safe", 0.8),
+        &dedup_opts(DedupMode::ExactContentHash),
+    )
+    .unwrap();
+    // Different content -> insert.
+    let diff_content = cm
+        .upsert_fact(
+            FactInput::new("rust", "fast", 0.8),
+            &dedup_opts(DedupMode::ExactContentHash),
+        )
+        .unwrap();
+    // Same content, different concept -> insert.
+    let diff_concept = cm
+        .upsert_fact(
+            FactInput::new("python", "safe", 0.8),
+            &dedup_opts(DedupMode::ExactContentHash),
+        )
+        .unwrap();
+
+    assert!(matches!(diff_content.dedup_action, DedupAction::Inserted));
+    assert!(matches!(diff_concept.dedup_action, DedupAction::Inserted));
+    assert_eq!(cm.get_all_facts(100).len(), 3);
+}
+
+/// `CallerKey`: a same-key upsert with *changed* content supersedes the prior
+/// fact (keeping the latest live + a `SUPERSEDES` edge), while a same-key
+/// upsert with *identical* content reuses without churn. (Requirement 3,
+/// test 2.)
+#[test]
+fn upsert_caller_key_supersedes_on_change_and_reuses_on_match() {
+    let mut cm = make_cm();
+    let key = || DedupMode::CallerKey("k1".to_string());
+
+    let o1 = cm
+        .upsert_fact(FactInput::new("c", "v1", 0.8), &dedup_opts(key()))
+        .unwrap();
+    assert!(matches!(o1.dedup_action, DedupAction::Inserted));
+    assert_eq!(
+        fact(&cm, &o1.node_id).dedup_key.as_deref(),
+        Some("k1"),
+        "the caller key is stored on the fact"
+    );
+
+    // Changed content under the same key -> supersession.
+    let o2 = cm
+        .upsert_fact(FactInput::new("c", "v2", 0.9), &dedup_opts(key()))
+        .unwrap();
+    let (old_id, new_id) = match &o2.dedup_action {
+        DedupAction::Superseded { old_id, new_id } => (old_id.clone(), new_id.clone()),
+        other => panic!("expected Superseded, got {other:?}"),
+    };
+    assert_eq!(old_id, o1.node_id);
+    assert_eq!(new_id, o2.node_id);
+    assert_ne!(new_id, o1.node_id);
+
+    let old = fact(&cm, &o1.node_id);
+    assert!(old.archived, "superseded fact archived");
+    assert_eq!(old.superseded_by.as_deref(), Some(new_id.as_str()));
+    assert_eq!(supersedes_targets(&cm, &new_id), vec![o1.node_id.clone()]);
+    assert_eq!(
+        fact(&cm, &new_id).dedup_key.as_deref(),
+        Some("k1"),
+        "the replacement keeps the caller key"
+    );
+
+    // Exactly one live (non-archived) fact under the key.
+    let live = cm
+        .get_all_facts(100)
+        .into_iter()
+        .filter(|f| !f.archived)
+        .count();
+    assert_eq!(live, 1);
+
+    // Same key, identical content -> reuse, no new node, no new edge.
+    let o3 = cm
+        .upsert_fact(FactInput::new("c", "v2", 0.7), &dedup_opts(key()))
+        .unwrap();
+    match &o3.dedup_action {
+        DedupAction::Reused { existing_id } => assert_eq!(*existing_id, new_id),
+        other => panic!("expected Reused on identical content, got {other:?}"),
+    }
+    assert_eq!(
+        supersedes_targets(&cm, &new_id),
+        vec![o1.node_id],
+        "no churn: identical content does not supersede again"
+    );
+}
+
+/// `SameConceptSimilarity`: an upsert whose content is similar enough (same
+/// concept) to an existing fact reuses it; a different concept (with
+/// `same_concept_only`) is never a duplicate and inserts. (Requirement 3.)
+#[test]
+fn upsert_same_concept_similarity_reuses_close_match() {
+    let mut cm = make_cm();
+    let opts = StoreFactOptions {
+        dedup: DedupOptions {
+            mode: DedupMode::SameConceptSimilarity,
+            similarity_threshold: 0.6,
+            same_concept_only: true,
+        },
+        ..Default::default()
+    };
+
+    let o1 = cm
+        .upsert_fact(
+            FactInput::new(
+                "memory-safety",
+                "rust borrow checker prevents memory bugs",
+                0.9,
+            ),
+            &opts,
+        )
+        .unwrap();
+    assert!(matches!(o1.dedup_action, DedupAction::Inserted));
+
+    // Near-identical content, same concept -> reuse.
+    let o2 = cm
+        .upsert_fact(
+            FactInput::new(
+                "memory-safety",
+                "rust borrow checker prevents memory leaks",
+                0.85,
+            ),
+            &opts,
+        )
+        .unwrap();
+    match &o2.dedup_action {
+        DedupAction::Reused { existing_id } => assert_eq!(*existing_id, o1.node_id),
+        other => panic!("expected Reused, got {other:?}"),
+    }
+    assert_eq!(cm.get_all_facts(100).len(), 1);
+
+    // Different concept is not a candidate under same_concept_only -> insert.
+    let o3 = cm
+        .upsert_fact(
+            FactInput::new(
+                "web-frontend",
+                "javascript renders the browser interface",
+                0.7,
+            ),
+            &opts,
+        )
+        .unwrap();
+    assert!(matches!(o3.dedup_action, DedupAction::Inserted));
+    assert_eq!(cm.get_all_facts(100).len(), 2);
+}
+
+/// Dedup only considers *live* (non-archived) facts: once a fact is superseded
+/// (archived), an `ExactContentHash` upsert of the same content inserts a fresh
+/// node rather than resurrecting the archived one.
+#[test]
+fn upsert_dedup_ignores_archived_facts() {
+    let mut cm = make_cm();
+    let a = store(&mut cm, "rust", "safe", 0.8, &[]);
+    let b = store(&mut cm, "rust", "safe-v2", 0.8, &[]);
+    cm.supersede_fact(&a, &b, "newer").unwrap(); // a archived
+
+    // Same content as the archived `a` -> must NOT reuse the archived node.
+    let o = cm
+        .upsert_fact(
+            FactInput::new("rust", "safe", 0.9),
+            &dedup_opts(DedupMode::ExactContentHash),
+        )
+        .unwrap();
+    assert!(
+        matches!(o.dedup_action, DedupAction::Inserted),
+        "archived facts are not dedup candidates"
+    );
+    assert_ne!(o.node_id, a);
+}
+
+/// On insert, `upsert_fact` composes the existing provenance + similarity
+/// machinery and reports accurate edge counts. (Requirement 3 + backward-compat
+/// with #91/#92.)
+#[test]
+fn upsert_insert_creates_provenance_and_similarity_edges() {
+    let mut cm = make_cm();
+    let ep = cm
+        .store_episode("observed safety", "src", None, None)
+        .unwrap();
+    let a = store(
+        &mut cm,
+        "memory-safety",
+        "rust borrow checker prevents memory bugs",
+        0.95,
+        &["rust", "systems"],
+    );
+
+    let mut fi = FactInput::new(
+        "memory-safety",
+        "rust borrow checker prevents memory leaks",
+        0.9,
+    );
+    fi.tags = tags(&["rust", "systems"]);
+    let opts = StoreFactOptions {
+        similarity: Some(SimilarityOptions::default()),
+        provenance: ProvenanceOptions {
+            source_episode_ids: vec![ep.clone()],
+            strict: false,
+        },
+        dedup: DedupOptions::default(),
+    };
+
+    let outcome = cm.upsert_fact(fi, &opts).unwrap();
+    assert!(matches!(outcome.dedup_action, DedupAction::Inserted));
+    assert_eq!(outcome.provenance_edges_created, 1);
+    assert_eq!(outcome.similarity_links_created, 1);
+    assert_eq!(cm.fact_provenance(&outcome.node_id), vec![ep]);
+    assert!(has_similar_edge(&cm, &outcome.node_id, &a));
+}
+
+/// `upsert_fact` validates confidence exactly like `store_fact`.
+#[test]
+fn upsert_fact_validates_confidence() {
+    let mut cm = make_cm();
+    assert!(cm
+        .upsert_fact(FactInput::new("c", "x", 1.5), &dedup_opts(DedupMode::None))
+        .is_err());
+    assert!(cm
+        .upsert_fact(
+            FactInput::new("c", "x", f64::NAN),
+            &dedup_opts(DedupMode::None)
+        )
+        .is_err());
+}
+
+// ===========================================================================
+// find_duplicate_facts
+// ===========================================================================
+
+/// `ExactContentHash` grouping collects facts sharing a content_hash into one
+/// group keyed by that hash, with a representative drawn from the group.
+/// (Requirement 4.)
+#[test]
+fn find_duplicates_groups_by_content_hash() {
+    let mut cm = make_cm();
+    let a = store(&mut cm, "rust", "safe", 0.9, &[]);
+    let b = store(&mut cm, "rust", "safe", 0.8, &[]);
+    let _c = store(&mut cm, "python", "fast", 0.7, &[]);
+
+    let groups = cm.find_duplicate_facts(
+        &DedupOptions {
+            mode: DedupMode::ExactContentHash,
+            ..Default::default()
+        },
+        10,
+    );
+
+    assert_eq!(groups.len(), 1, "only the duplicated pair forms a group");
+    let g = &groups[0];
+    assert_eq!(g.key, compute_content_hash("rust", "safe"));
+    assert_eq!(g.fact_ids.len(), 2);
+    assert!(g.fact_ids.contains(&a) && g.fact_ids.contains(&b));
+    assert!(
+        g.fact_ids.contains(&g.representative_id),
+        "representative is a member of the group"
+    );
+}
+
+/// `CallerKey` grouping collects facts sharing a non-empty dedup_key.
+/// (Requirement 4.) Facts are seeded with `DedupMode::None` so two live facts
+/// can carry the same key.
+#[test]
+fn find_duplicates_groups_by_caller_key() {
+    let mut cm = make_cm();
+    let mut k1a = FactInput::new("c", "v1", 0.8);
+    k1a.dedup_key = Some("k1".to_string());
+    let a = cm
+        .upsert_fact(k1a, &dedup_opts(DedupMode::None))
+        .unwrap()
+        .node_id;
+
+    let mut k1b = FactInput::new("c", "v2", 0.8);
+    k1b.dedup_key = Some("k1".to_string());
+    let b = cm
+        .upsert_fact(k1b, &dedup_opts(DedupMode::None))
+        .unwrap()
+        .node_id;
+
+    let mut k2 = FactInput::new("c", "v3", 0.8);
+    k2.dedup_key = Some("k2".to_string());
+    cm.upsert_fact(k2, &dedup_opts(DedupMode::None)).unwrap();
+
+    let groups = cm.find_duplicate_facts(
+        &DedupOptions {
+            mode: DedupMode::CallerKey("ignored".to_string()),
+            ..Default::default()
+        },
+        10,
+    );
+
+    assert_eq!(groups.len(), 1, "only k1 has >= 2 members");
+    assert_eq!(groups[0].key, "k1");
+    assert_eq!(groups[0].fact_ids.len(), 2);
+    assert!(groups[0].fact_ids.contains(&a) && groups[0].fact_ids.contains(&b));
+}
+
+/// `DedupMode::None` reports no duplicate groups. (Requirement 4.)
+#[test]
+fn find_duplicates_none_mode_is_empty() {
+    let mut cm = make_cm();
+    store(&mut cm, "rust", "safe", 0.9, &[]);
+    store(&mut cm, "rust", "safe", 0.8, &[]);
+
+    let groups = cm.find_duplicate_facts(
+        &DedupOptions {
+            mode: DedupMode::None,
+            ..Default::default()
+        },
+        10,
+    );
+    assert!(groups.is_empty());
+}
+
+// ===========================================================================
+// prune_semantic_memory
+// ===========================================================================
+
+/// `dry_run` reports the would-be archive/delete counts and mutates nothing.
+/// (Requirement 5, test 3.)
+#[test]
+fn prune_dry_run_reports_without_mutating() {
+    let mut cm = make_cm();
+    let low = upsert_imp(&mut cm, "c", "low imp", 0.5, 0.1);
+    let high = upsert_imp(&mut cm, "c", "high imp", 0.5, 0.9);
+
+    let policy = RetentionPolicy {
+        min_importance_to_keep: 0.5,
+        dry_run: true,
+        ..Default::default()
+    };
+    let r = cm.prune_semantic_memory(&policy).unwrap();
+
+    assert_eq!(r.would_archive, 1);
+    assert_eq!(r.would_delete, 0);
+    assert_eq!(r.archived, 0);
+    assert_eq!(r.deleted, 0);
+
+    // Nothing changed on disk.
+    assert!(!fact(&cm, &low).archived, "dry_run must not archive");
+    assert_eq!(cm.get_all_facts(100).len(), 2);
+    let _ = high;
+}
+
+/// A real prune is a two-tier lifecycle: the first pass archives candidates,
+/// the second pass deletes the now-archived candidates (archive-before-delete).
+/// (Requirement 5, test 3 + importance retention test 5.)
+#[test]
+fn prune_archives_then_deletes_low_importance_facts() {
+    let mut cm = make_cm();
+    let low = upsert_imp(&mut cm, "c", "low imp", 0.5, 0.1);
+    let high = upsert_imp(&mut cm, "c", "high imp", 0.5, 0.9);
+
+    let policy = RetentionPolicy {
+        min_importance_to_keep: 0.5,
+        ..Default::default()
+    };
+
+    // Pass 1: archive only.
+    let r1 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!((r1.archived, r1.deleted), (1, 0));
+    assert!(fact(&cm, &low).archived);
+    assert!(!fact(&cm, &high).archived);
+    assert_eq!(cm.get_all_facts(100).len(), 2, "archive does not delete");
+
+    // Pass 2: delete the archived candidate.
+    let r2 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!((r2.archived, r2.deleted), (0, 1));
+    assert!(!exists(&cm, &low), "archived low-importance fact deleted");
+    assert!(exists(&cm, &high), "high-importance fact retained");
+}
+
+/// TTL retention: a fact whose concept has an expired TTL is pruned, while a
+/// fact of an unconfigured concept is retained. (Requirement 5, test 4.)
+#[test]
+fn prune_ttl_expires_stale_concept() {
+    let mut cm = make_cm();
+    let keep = store(&mut cm, "durable", "long lived", 0.9, &[]);
+    let expire = store(&mut cm, "ephemeral", "short lived", 0.9, &[]);
+
+    let mut ttl = HashMap::new();
+    ttl.insert("ephemeral".to_string(), 0i64); // age >= 0 -> immediately expired
+    let policy = RetentionPolicy {
+        ttl_seconds_by_concept: ttl,
+        ..Default::default()
+    };
+
+    let r1 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!((r1.archived, r1.deleted), (1, 0));
+    assert!(fact(&cm, &expire).archived);
+    assert!(!fact(&cm, &keep).archived);
+
+    let r2 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!(r2.deleted, 1);
+    assert!(!exists(&cm, &expire));
+    assert!(
+        exists(&cm, &keep),
+        "unconfigured concept is never TTL-pruned"
+    );
+}
+
+/// `expires_at` retention: a fact whose explicit expiry is in the past is a
+/// prune candidate. (Requirement 5.)
+#[test]
+fn prune_expires_at_in_the_past() {
+    let mut cm = make_cm();
+    let past = Utc::now() - Duration::seconds(3600);
+    let expired = upsert_full(&mut cm, "c", "stale", 0.9, Some(0.9), Some(past), vec![]);
+
+    let r1 = cm
+        .prune_semantic_memory(&RetentionPolicy::default())
+        .unwrap();
+    assert_eq!(r1.archived, 1);
+    assert!(fact(&cm, &expired).archived);
+}
+
+/// `max_facts_per_concept` keeps the highest-importance facts and prunes the
+/// lowest-ranked excess. (Requirement 5.)
+#[test]
+fn prune_enforces_max_facts_per_concept() {
+    let mut cm = make_cm();
+    let hi = upsert_imp(&mut cm, "topic", "a", 0.5, 0.9);
+    let mid = upsert_imp(&mut cm, "topic", "b", 0.5, 0.5);
+    let lo = upsert_imp(&mut cm, "topic", "c", 0.5, 0.1);
+
+    let policy = RetentionPolicy {
+        max_facts_per_concept: Some(2),
+        ..Default::default()
+    };
+    let r1 = cm.prune_semantic_memory(&policy).unwrap();
+
+    assert_eq!(r1.archived, 1, "only the single excess fact is a candidate");
+    assert!(
+        fact(&cm, &lo).archived,
+        "lowest-importance fact is the excess"
+    );
+    assert!(!fact(&cm, &hi).archived);
+    assert!(!fact(&cm, &mid).archived);
+}
+
+/// Over-cap facts are archived first, then deleted on a later pass, so the
+/// archived excess does not accumulate forever (archive-before-delete).
+#[test]
+fn prune_max_facts_archives_then_deletes_excess() {
+    let mut cm = make_cm();
+    let f0 = upsert_imp(&mut cm, "topic", "a", 0.5, 0.9);
+    let f1 = upsert_imp(&mut cm, "topic", "b", 0.5, 0.7);
+    let f2 = upsert_imp(&mut cm, "topic", "c", 0.5, 0.3);
+    let f3 = upsert_imp(&mut cm, "topic", "d", 0.5, 0.1);
+
+    let policy = RetentionPolicy {
+        max_facts_per_concept: Some(2),
+        ..Default::default()
+    };
+
+    // Pass 1: archive the two lowest-importance excess facts.
+    let r1 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!((r1.archived, r1.deleted), (2, 0));
+    assert!(fact(&cm, &f2).archived && fact(&cm, &f3).archived);
+    assert!(!fact(&cm, &f0).archived && !fact(&cm, &f1).archived);
+
+    // Pass 2: the now-archived excess is deleted; the kept facts remain.
+    let r2 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!((r2.archived, r2.deleted), (0, 2));
+    assert!(!exists(&cm, &f2) && !exists(&cm, &f3));
+    assert!(exists(&cm, &f0) && exists(&cm, &f1));
+
+    // Pass 3: stable — nothing left to prune.
+    let r3 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!((r3.archived, r3.deleted), (0, 0));
+}
+
+/// Provenance protection: a fact with a `DERIVES_FROM` edge AND importance at
+/// or above the keep threshold is never deleted (it may still be archived). A
+/// provenance fact below the threshold loses that protection. (Requirement 5,
+/// test 6.)
+#[test]
+fn prune_protects_high_importance_provenance_facts() {
+    let mut cm = make_cm();
+    let ep = cm.store_episode("obs", "src", None, None).unwrap();
+    let past = Utc::now() - Duration::seconds(3600);
+
+    // provenance + high importance -> protected from deletion.
+    let prov_hi = upsert_full(
+        &mut cm,
+        "c",
+        "prov high",
+        0.9,
+        Some(0.9),
+        Some(past),
+        vec![ep.clone()],
+    );
+    // no provenance + high importance -> deletable.
+    let plain_hi = upsert_full(
+        &mut cm,
+        "c",
+        "plain high",
+        0.9,
+        Some(0.9),
+        Some(past),
+        vec![],
+    );
+    // provenance + LOW importance -> protection lifted, deletable.
+    let prov_lo = upsert_full(
+        &mut cm,
+        "c",
+        "prov low",
+        0.9,
+        Some(0.1),
+        Some(past),
+        vec![ep.clone()],
+    );
+
+    let policy = RetentionPolicy {
+        min_importance_to_keep: 0.5,
+        ..Default::default()
+    };
+
+    // Pass 1: all three are expired -> all archived (protection allows archiving).
+    let r1 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!(r1.archived, 3);
+
+    // Pass 2: delete archived candidates except the protected one.
+    let r2 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!((r2.archived, r2.deleted), (0, 2));
+    assert!(exists(&cm, &prov_hi), "protected provenance fact survives");
+    assert!(
+        !exists(&cm, &plain_hi),
+        "unprotected high-importance fact deleted"
+    );
+    assert!(
+        !exists(&cm, &prov_lo),
+        "below-threshold provenance fact deleted"
+    );
+}
+
+/// `include_superseded` makes superseded facts prune candidates. Since
+/// supersession already archives them, a single pass deletes. (Requirement 5.)
+#[test]
+fn prune_include_superseded_deletes_superseded_facts() {
+    let mut cm = make_cm();
+    let a = store(&mut cm, "c", "v1", 0.9, &[]);
+    let b = store(&mut cm, "c", "v2", 0.9, &[]);
+    cm.supersede_fact(&a, &b, "newer").unwrap();
+    assert!(fact(&cm, &a).archived);
+
+    let policy = RetentionPolicy {
+        include_superseded: true,
+        ..Default::default()
+    };
+    let r = cm.prune_semantic_memory(&policy).unwrap();
+
+    assert_eq!(r.deleted, 1, "the archived, superseded fact is deleted");
+    assert!(!exists(&cm, &a));
+    assert!(exists(&cm, &b), "the live replacement is retained");
+}
+
+/// Without `include_superseded`, a merely-superseded fact (high importance, no
+/// other trigger) is not a prune candidate.
+#[test]
+fn prune_leaves_superseded_facts_when_not_included() {
+    let mut cm = make_cm();
+    let a = store(&mut cm, "c", "v1", 0.9, &[]);
+    let b = store(&mut cm, "c", "v2", 0.9, &[]);
+    cm.supersede_fact(&a, &b, "newer").unwrap();
+
+    let r = cm
+        .prune_semantic_memory(&RetentionPolicy::default())
+        .unwrap();
+    assert_eq!((r.archived, r.deleted), (0, 0));
+    assert!(
+        exists(&cm, &a),
+        "superseded fact retained without include_superseded"
+    );
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "persistent")]
 mod conformance_tests;
+mod dedup_tests;
 mod episodic_tests;
 mod integration_tests;
 #[cfg(feature = "persistent")]

--- a/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
@@ -1047,3 +1047,164 @@ fn similar_to_edge_survives_reopen() {
         "no duplicate SIMILAR_TO edge after reopen + re-link"
     );
 }
+
+// ===========================================================================
+// Fact dedup / SUPERSEDES / retention (issue #90): durability across reopen
+//
+// File: rust/amplihack-memory/src/cognitive_memory/tests/persistent_tests.rs
+//
+// Failing-first TDD tests proving the new SemanticFact lifecycle fields and
+// the SUPERSEDES edge survive a drop + reopen on the LadybugDB persistent
+// backend (which also proves the new STRING columns + rel table are
+// reintrospected on reopen). Gated by the `persistent` feature.
+// ===========================================================================
+
+#[test]
+fn semantic_fact_lifecycle_fields_survive_reopen() {
+    use crate::cognitive_memory::{
+        DedupAction, DedupMode, DedupOptions, FactInput, StoreFactOptions,
+    };
+
+    let (_tmp, path) = temp_db();
+    let id;
+    let expires = chrono::Utc::now() + chrono::Duration::seconds(7200);
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        let opts = StoreFactOptions {
+            dedup: DedupOptions {
+                mode: DedupMode::ExactContentHash,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut fi = FactInput::new("rust", "memory safe", 0.8);
+        fi.importance = Some(0.7);
+        fi.dedup_key = Some("k1".to_string());
+        fi.expires_at = Some(expires);
+        id = cm.upsert_fact(fi, &opts).unwrap().node_id;
+
+        // Reuse the same content to bump usage_count to 1 and confidence to 0.95.
+        let out = cm
+            .upsert_fact(FactInput::new("rust", "memory safe", 0.95), &opts)
+            .unwrap();
+        assert!(matches!(out.dedup_action, DedupAction::Reused { .. }));
+        assert_eq!(out.node_id, id);
+
+        cm.close();
+    } // dropped -> LadybugDB flushed to disk
+
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    let f = cm
+        .get_all_facts(10)
+        .into_iter()
+        .find(|f| f.node_id == id)
+        .expect("fact survives reopen");
+
+    assert!((f.importance - 0.7).abs() < 1e-9, "importance persists");
+    assert_eq!(f.dedup_key.as_deref(), Some("k1"), "dedup_key persists");
+    assert_eq!(f.usage_count, 1, "usage_count persists");
+    assert!(
+        (f.confidence - 0.95).abs() < 1e-9,
+        "reused confidence persists"
+    );
+    assert!(f.last_accessed_at.is_some(), "last_accessed_at persists");
+    assert!(f.expires_at.is_some(), "expires_at persists");
+    assert!(!f.content_hash.is_empty(), "content_hash persists");
+    assert!(!f.archived, "archived flag persists (false)");
+    assert!(f.superseded_by.is_none());
+}
+
+#[test]
+fn supersedes_edge_and_archived_flag_survive_reopen() {
+    use crate::cognitive_memory::types::ET_SUPERSEDES;
+    use crate::graph::Direction;
+
+    let (_tmp, path) = temp_db();
+    let a;
+    let b;
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        a = cm.store_fact("c", "v1", 0.9, "", None, None).unwrap();
+        b = cm.store_fact("c", "v2", 0.9, "", None, None).unwrap();
+        cm.supersede_fact(&a, &b, "newer version").unwrap();
+        cm.close();
+    } // dropped -> LadybugDB flushed to disk
+
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+
+    let fa = cm
+        .get_all_facts(10)
+        .into_iter()
+        .find(|f| f.node_id == a)
+        .expect("superseded fact survives reopen");
+    assert!(fa.archived, "archived flag persists across reopen");
+    assert_eq!(
+        fa.superseded_by.as_deref(),
+        Some(b.as_str()),
+        "superseded_by persists across reopen"
+    );
+
+    let edges = cm
+        .graph
+        .query_neighbors(&b, Some(ET_SUPERSEDES), Direction::Outgoing, 10);
+    assert_eq!(edges.len(), 1, "SUPERSEDES edge persists across reopen");
+    assert_eq!(edges[0].1.node_id, a);
+    assert_eq!(
+        edges[0].0.properties.get("reason").map(String::as_str),
+        Some("newer version")
+    );
+}
+
+#[test]
+fn prune_archive_then_delete_persists_across_reopen() {
+    use crate::cognitive_memory::RetentionPolicy;
+
+    let (_tmp, path) = temp_db();
+    let low;
+    let high;
+    {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        low = cm.store_fact("c", "low", 0.1, "", None, None).unwrap();
+        high = cm.store_fact("c", "high", 0.9, "", None, None).unwrap();
+
+        let policy = RetentionPolicy {
+            min_importance_to_keep: 0.5,
+            ..Default::default()
+        };
+        // Pass 1: archive the low-importance fact.
+        let r1 = cm.prune_semantic_memory(&policy).unwrap();
+        assert_eq!((r1.archived, r1.deleted), (1, 0));
+        cm.close();
+    }
+
+    // The archived flag survived; a second prune pass now deletes it durably.
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    let fa = cm
+        .get_all_facts(10)
+        .into_iter()
+        .find(|f| f.node_id == low)
+        .expect("archived fact still present after reopen");
+    assert!(fa.archived, "archive survived reopen");
+
+    let policy = RetentionPolicy {
+        min_importance_to_keep: 0.5,
+        ..Default::default()
+    };
+    let r2 = cm.prune_semantic_memory(&policy).unwrap();
+    assert_eq!(
+        r2.deleted, 1,
+        "previously-archived fact deleted after reopen"
+    );
+    cm.close();
+
+    let cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    assert!(
+        !cm.get_all_facts(10).iter().any(|f| f.node_id == low),
+        "deletion persists across reopen"
+    );
+    assert!(
+        cm.get_all_facts(10).iter().any(|f| f.node_id == high),
+        "retained fact persists across reopen"
+    );
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/similarity_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/similarity_tests.rs
@@ -486,7 +486,10 @@ fn store_fact_with_options_none_does_not_link() {
     );
 
     let tg = tags(&["rust", "systems"]);
-    let opts = StoreFactOptions { similarity: None };
+    let opts = StoreFactOptions {
+        similarity: None,
+        ..Default::default()
+    };
     let b = cm
         .store_fact_with_options(
             "memory-safety",
@@ -521,6 +524,7 @@ fn store_fact_with_options_some_auto_links() {
     let tg = tags(&["rust", "systems"]);
     let opts = StoreFactOptions {
         similarity: Some(SimilarityOptions::default()),
+        ..Default::default()
     };
     let b = cm
         .store_fact_with_options(

--- a/rust/amplihack-memory/src/cognitive_memory/types.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/types.rs
@@ -79,3 +79,9 @@ pub(crate) const ET_DERIVES_FROM: &str = "DERIVES_FROM";
 /// edge type (rather than reusing [`ET_DERIVES_FROM`]) keeps fact and procedure
 /// provenance independently queryable.
 pub(crate) const ET_PROCEDURE_DERIVES_FROM: &str = "PROCEDURE_DERIVES_FROM";
+/// Edge-type label indicating one fact supersedes (replaces) another.
+///
+/// Used for fact lifecycle/versioning: the newer fact points at the one it
+/// replaces — `SemanticMemory(new) --SUPERSEDES--> SemanticMemory(old)`. The
+/// superseded (old) fact is archived and carries a `superseded_by` back-pointer.
+pub(crate) const ET_SUPERSEDES: &str = "SUPERSEDES";

--- a/rust/amplihack-memory/src/lib.rs
+++ b/rust/amplihack-memory/src/lib.rs
@@ -147,6 +147,11 @@ pub use backends::LadybugBackend;
 pub use backends::{ExperienceBackend, MemoryBackend, SqliteBackend};
 /// Unified cognitive memory interface over the graph layer.
 pub use cognitive_memory::CognitiveMemory;
+/// Fact dedup, supersession, and retention types.
+pub use cognitive_memory::{
+    compute_content_hash, DedupAction, DedupMode, DedupOptions, DuplicateFactGroup, FactInput,
+    ProvenanceOptions, PruneReport, RetentionPolicy, StoreFactOutcome,
+};
 /// Automatic `SIMILAR_TO` linking options and report types.
 pub use cognitive_memory::{SimilarityOptions, SimilarityReport, StoreFactOptions};
 /// Backend selector and memory connector entry point.

--- a/rust/amplihack-memory/src/memory_types.rs
+++ b/rust/amplihack-memory/src/memory_types.rs
@@ -180,6 +180,36 @@ pub struct SemanticFact {
     pub metadata: HashMap<String, serde_json::Value>,
     /// When this fact was recorded.
     pub created_at: DateTime<Utc>,
+    /// Relative importance in `[0.0, 1.0]` used by retention/pruning to decide
+    /// what to keep. Defaults to the fact's `confidence` when not set explicitly.
+    #[serde(default)]
+    pub importance: f64,
+    /// Number of times this fact has been reused (incremented on a dedup hit).
+    #[serde(default)]
+    pub usage_count: i64,
+    /// When this fact was last accessed via a dedup-reuse. `None` until reused.
+    #[serde(default)]
+    pub last_accessed_at: Option<DateTime<Utc>>,
+    /// Optional expiry instant; once past, the fact becomes a retention
+    /// candidate. `None` means the fact never expires on its own.
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Whether this fact has been archived (soft-deleted) by supersession or a
+    /// retention pass. Archived facts are excluded from dedup candidates.
+    #[serde(default)]
+    pub archived: bool,
+    /// Id of the fact that superseded this one, if any. Set together with
+    /// `archived = true` by [`supersede_fact`](crate::CognitiveMemory::supersede_fact).
+    #[serde(default)]
+    pub superseded_by: Option<String>,
+    /// Deterministic hash of `concept + content`, used by exact-content dedup.
+    /// Recomputed on read for facts stored before this field existed.
+    #[serde(default)]
+    pub content_hash: String,
+    /// Optional caller-supplied dedup key (e.g. an external record id) used by
+    /// `DedupMode::CallerKey`.
+    #[serde(default)]
+    pub dedup_key: Option<String>,
 }
 
 /// Reusable step-by-step procedure (how-to knowledge).

--- a/rust/amplihack-memory/src/python/converters.rs
+++ b/rust/amplihack-memory/src/python/converters.rs
@@ -60,6 +60,19 @@ pub(crate) fn fact_to_dict(py: Python<'_>, f: &SemanticFact) -> PyResult<PyObjec
     d.set_item("tags", f.tags.to_object(py))?;
     d.set_item("created_at", f.created_at.to_rfc3339())?;
     d.set_item("metadata", hashmap_to_pydict(py, &f.metadata)?)?;
+    // Fact-lifecycle fields (dedup / supersession / retention). Read-only on the
+    // Python surface; additive so existing keys are unaffected.
+    d.set_item("importance", f.importance)?;
+    d.set_item("usage_count", f.usage_count)?;
+    d.set_item(
+        "last_accessed_at",
+        f.last_accessed_at.map(|t| t.to_rfc3339()),
+    )?;
+    d.set_item("expires_at", f.expires_at.map(|t| t.to_rfc3339()))?;
+    d.set_item("archived", f.archived)?;
+    d.set_item("superseded_by", f.superseded_by.as_deref())?;
+    d.set_item("content_hash", &f.content_hash)?;
+    d.set_item("dedup_key", f.dedup_key.as_deref())?;
     Ok(d.to_object(py))
 }
 


### PR DESCRIPTION
## Summary

Adds fact **deduplication**, **supersession**, and **retention/pruning** to `CognitiveMemory` (issue #90) so consumers can prevent unbounded accumulation of duplicate and stale semantic facts. Fully **additive and backward compatible** across the in-memory (default) and lbug **persistent** (`--features persistent`) backends — no migration required.

Builds on provenance (DERIVES_FROM, #91) and SIMILAR_TO auto-linking (#92).

## What's new

**`SemanticFact` lifecycle fields** (all `#[serde(default)]`): `importance`, `usage_count`, `last_accessed_at`, `expires_at`, `archived`, `superseded_by`, `content_hash`, `dedup_key`. Persisted and survive reopen on both backends; legacy nodes default-populate on read (importance falls back to `confidence`, `content_hash` is recomputed) so there is no schema break.

**Supersession** — `ET_SUPERSEDES` edge + `supersede_fact(old, new, reason)`: archives the old fact, sets `superseded_by`, and links `new --SUPERSEDES--> old`.

**Dedup / retention API** (new `cognitive_memory/dedup.rs`):
- Types: `DedupMode`, `DedupOptions`, `ProvenanceOptions`, `FactInput`, `DedupAction`, `StoreFactOutcome`, `DuplicateFactGroup`, `RetentionPolicy`, `PruneReport`, and `compute_content_hash`.
- `upsert_fact(FactInput, &StoreFactOptions) -> StoreFactOutcome`: dedups per mode —
  - `ExactContentHash` / `SameConceptSimilarity` hit ⇒ **reuse** (bump `usage_count`, refresh `last_accessed_at`, update `confidence`; `importance` untouched),
  - `CallerKey` with changed content ⇒ **supersede**,
  - `None` (default) ⇒ always insert.
  Inserts compose the existing provenance + `SIMILAR_TO` machinery and report edge counts.
- `find_duplicate_facts(&DedupOptions, limit) -> Vec<DuplicateFactGroup>`.
- `prune_semantic_memory(&RetentionPolicy) -> PruneReport`: **archive-before-delete** two-tier lifecycle (pass 1 archives candidates, a later pass deletes the now-archived ones). Triggers: per-concept cap, per-concept TTL, importance floor, `expires_at`, and optionally superseded facts. `dry_run` reports `would_*` counts and mutates nothing. High-importance, provenance-bearing facts are protected from deletion.

**Backward compatibility:** `store_fact`, `store_fact_with_provenance(/_strict)`, `store_fact_with_options`, and `get_all_facts` keep their signatures and behaviour (new props written with defaults). `StoreFactOptions` is extended to `{ similarity, provenance, dedup }` (it no longer derives `Copy`; use `..Default::default()`). The Python read path additively exposes the new fields.

## Tests (strict TDD — written first)

New `dedup_tests.rs` (default backend) + reopen tests in `persistent_tests.rs` + converter default tests:
- ExactContentHash reuse keeps a single node, bumps usage/confidence.
- CallerKey supersession keeps the latest live fact + exactly one `SUPERSEDES` edge.
- prune dry-run vs real (archive then delete), TTL and importance retention, provenance protection.
- Legacy-node defaulting (importance ⇐ confidence, content_hash recompute).
- Persistent reopen round-trips all 8 new fields, the archived flag, and the `SUPERSEDES` edge.

**Results:** default `cargo test` **511 passed**; `--features persistent` **553 passed**; `cargo clippy` clean (no new warnings); `--features python` compiles. All pre-existing tests stay green.

Docs: new `docs/fact_lifecycle.md` plus `cognitive_memory.md` / `api_reference.md` / nav updates.

Closes #90