### PR TITLE
feat(cognitive-memory): ranked recall (importance/recency/usage/graph) + access tracking

### DIFF
--- a/rust/amplihack-memory/README.md
+++ b/rust/amplihack-memory/README.md
@@ -356,6 +356,93 @@ See [`docs/similarity_linking.md`](docs/similarity_linking.md) for the full
 reference, threshold-tuning guidance, directionality semantics, and a worked
 tutorial.
 
+### Ranked recall (importance / recency / usage / graph)
+
+Alongside the keyword-only `search_facts` / `search_episodes_by_keyword`,
+`CognitiveMemory` can **rank** recalled memories by a blend of six deterministic
+signals — text relevance, confidence, importance, recency, usage, and graph
+proximity — so a recent, high-importance, frequently-used fact outranks an old
+low-confidence keyword match. Scoring is plain arithmetic over fields the crate
+already stores: Jaccard keyword overlap, a half-life recency decay, a logarithmic
+usage boost, and neighbour overlap over existing `DERIVES_FROM` / `SIMILAR_TO`
+edges. No embeddings, no network calls.
+
+```text
+score(x) = w_text       · keyword_jaccard(q, text(x))
+         + w_confidence  · confidence(x)            // facts only; 0 for episodes
+         + w_importance  · importance(x)            // facts only; 0 for episodes
+         + w_recency     · exp_decay(age(x), half_life)
+         + w_usage       · usage_boost(usage_count(x))
+         + w_graph       · best_edge_score(x, q, max_graph_hops)
+```
+
+Recall is **additive and backward compatible** (the existing keyword search is
+unchanged), **same-agent only**, and **lifecycle-aware** — archived and
+superseded facts and compressed episodes are excluded by default. It is also
+**access-tracking**: ranked recall (and the explicit `record_access`) bump a
+memory's `usage_count` and `last_accessed_at`, persisted across reopen, so
+frequently- and recently-used memories float to the top over time.
+
+`RecallOptions` (build with `..Default::default()`) controls a call:
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `limit` | `10` | Max items returned (`0` ⇒ empty). |
+| `min_confidence` | `0.0` | Drop facts below this confidence (no-op for episodes). |
+| `include_archived` | `false` | Surface archived facts when `true`. |
+| `include_superseded` | `false` | Surface superseded facts when `true`. |
+| `max_graph_hops` | `1` | Neighbour traversal depth (`0` disables; clamped ≤ 3). |
+| `recency_half_life_seconds` | `604_800.0` | Recency half-life (7 days; `≤ 0` disables recency). |
+| `record_access` | `true` | Bump usage for returned items; `false` for a pure read. |
+| `weights` | `RecallWeights::default()` | The six weights (`text 1.0, confidence 0.7, importance 0.5, recency 0.4, usage 0.3, graph 0.6`). |
+
+> Note: a fact's `importance` defaults to its `confidence` on the `store_fact`
+> path, so the default `confidence` + `importance` weights act on the same value
+> (≈ `1.2 · confidence`) unless you set importance independently via `upsert_fact`.
+
+```rust
+use amplihack_memory::{CognitiveMemory, RecallOptions, RecallWeights, Scored, AccessKind};
+
+let mut mem = CognitiveMemory::new("research-agent")?;
+let rust = ["rust".to_string()];
+let _old   = mem.store_fact("rust-async", "early notes on rust async runtimes",
+                            0.2, "s-old", Some(&rust), None)?;
+let fresh  = mem.store_fact("rust-async", "tokio is the de-facto rust async runtime",
+                            0.9, "s-fresh", Some(&rust), None)?;
+for _ in 0..5 { mem.record_access(&fresh, AccessKind::Read)?; }
+
+// Ranked by the combined score: the fresh/important/used fact ranks first.
+let hits = mem.recall_facts_ranked("rust async runtime", RecallOptions::default())?;
+assert_eq!(hits[0].item.content, "tokio is the de-facto rust async runtime");
+for Scored { item, score, reasons } in &hits {
+    println!("{score:.3}  {}  {:?}", item.content, reasons);
+}
+
+// Tune weights and take a side-effect-free read of the top 3.
+let opts = RecallOptions {
+    limit: 3,
+    record_access: false,
+    weights: RecallWeights { recency: 2.0, graph: 0.0, ..RecallWeights::default() },
+    ..RecallOptions::default()
+};
+let _top3 = mem.recall_facts_ranked("rust async", opts)?;
+```
+
+Each result is a `Scored<T> { item, score, reasons }`; `reasons` is a
+numeric/label-only explanation (e.g. `"recency 0.40 (age=120s)"`,
+`"graph 0.30 (SIMILAR_TO hop1)"`) that never leaks content or the query.
+`recall_episodes_ranked` is the episode analogue (episodes carry no
+confidence/importance, so those terms are `0`). The pure scoring primitives
+`keyword_jaccard`, `exp_decay`, and `usage_boost` are public and re-exported for
+independent use. Recall is **same-agent isolated**, **NaN-safe** (sorts with
+`f64::total_cmp`, never panics on hostile floats), and one implementation serves
+both the in-memory and `--features persistent` backends — no schema migration,
+no `GraphStore` change.
+
+See [`docs/ranked_recall.md`](docs/ranked_recall.md) for the full reference —
+the scoring model, the graph term, weight tuning, access tracking, the security
+model, and a worked tutorial.
+
 ### Pattern detection
 
 ```rust
@@ -467,7 +554,7 @@ contradiction = detect_contradiction("sky is blue", "sky is green", "sky", "sky"
 | Module                 | Description                                                      |
 |------------------------|------------------------------------------------------------------|
 | `backends`             | `MemoryBackend` / `ExperienceBackend` traits and implementations (SQLite, Kuzu, LadybugDB) |
-| `cognitive_memory`     | Six-type cognitive memory over a pluggable `GraphStore` (in-memory by default; durable LadybugDB via the `persistent` feature); optional automatic `SIMILAR_TO` linking between related facts |
+| `cognitive_memory`     | Six-type cognitive memory over a pluggable `GraphStore` (in-memory by default; durable LadybugDB via the `persistent` feature); optional automatic `SIMILAR_TO` linking between related facts; ranked recall (importance/recency/usage/graph scoring) with access tracking |
 | `connector`            | `MemoryConnector` — factory for backend lifecycle management     |
 | `contradiction`        | Contradiction detection between semantic facts                   |
 | `entity_extraction`    | Entity-name extraction from free text                            |

--- a/rust/amplihack-memory/docs/ranked_recall.md
+++ b/rust/amplihack-memory/docs/ranked_recall.md
@@ -1,0 +1,612 @@
+# Ranked Recall — scored retrieval over `CognitiveMemory`
+
+`CognitiveMemory` can rank recalled memories by a blend of six signals —
+**text relevance, confidence, importance, recency, usage, and graph proximity** —
+instead of returning only keyword matches sorted by confidence. This page is the
+complete reference for the feature: the scoring model, configuration, the public
+API, access tracking, the security model, and an end-to-end tutorial.
+
+- **Deterministic.** Scoring is plain arithmetic over fields the crate already
+  stores — Jaccard keyword overlap, exponential recency decay, a logarithmic
+  usage boost, and neighbour overlap over existing `DERIVES_FROM` / `SIMILAR_TO`
+  edges. No embeddings, no model downloads, no network calls.
+- **Additive and backward compatible.** `search_facts`, `get_all_facts`, and
+  `search_episodes_by_keyword` are unchanged in signature, ordering, and serde
+  shape. Ranked recall is a *new* path you opt into; nothing about the existing
+  keyword path moves.
+- **Same-agent only.** A `CognitiveMemory` instance is scoped to one agent.
+  Candidates and graph neighbours that belong to other agents are never scored,
+  never returned, and never contribute to the graph term.
+- **Lifecycle-aware.** Archived and superseded facts (and compressed episodes)
+  are excluded by default; you opt back in per call.
+- **Access-tracking.** Ranked recall (and the explicit `record_access`) bump a
+  memory's `usage_count` and `last_accessed_at`, persisted across reopen, so
+  frequently-used and recently-used memories naturally float to the top over
+  time.
+
+---
+
+## Table of contents
+
+1. [When to use it](#when-to-use-it)
+2. [How the score is computed](#how-the-score-is-computed)
+   - [The six signals](#the-six-signals)
+   - [The graph term (neighbour boost)](#the-graph-term-neighbour-boost)
+   - [`reasons` — why an item ranked where it did](#reasons--why-an-item-ranked-where-it-did)
+3. [Configuration](#configuration)
+   - [`RecallWeights`](#recallweights)
+   - [`RecallOptions`](#recalloptions)
+4. [API reference](#api-reference)
+   - [`recall_facts_ranked`](#recall_facts_rankedquery-options---resultvecscoredsemanticfact)
+   - [`recall_episodes_ranked`](#recall_episodes_rankedquery-options---resultvecscoredepisodicmemory)
+   - [`record_access`](#record_accessnode_id-kind---result)
+   - [`Scored<T>`](#scoredt)
+   - [`AccessKind`](#accesskind)
+   - [Pure scoring primitives](#pure-scoring-primitives)
+5. [Candidate gathering, filtering, and ordering](#candidate-gathering-filtering-and-ordering)
+6. [Access tracking and persistence](#access-tracking-and-persistence)
+7. [Security and tenant isolation](#security-and-tenant-isolation)
+8. [Errors](#errors)
+9. [Tutorial: ranking a knowledge base](#tutorial-ranking-a-knowledge-base)
+10. [Compatibility and guarantees](#compatibility-and-guarantees)
+
+---
+
+## When to use it
+
+| You want to… | Use |
+|--------------|-----|
+| Retrieve the *most relevant* facts for a query, blending freshness, importance, and usage | [`recall_facts_ranked`](#recall_facts_rankedquery-options---resultvecscoredsemanticfact) |
+| Retrieve the most relevant episodes for a query | [`recall_episodes_ranked`](#recall_episodes_rankedquery-options---resultvecscoredepisodicmemory) |
+| Have retrieval *learn* over time (used memories rank higher next time) | either ranked method with `record_access: true` (the default) |
+| Manually mark a memory as used (e.g. after a non-recall read) | [`record_access`](#record_accessnode_id-kind---result) |
+| Plain keyword lookup, confidence-sorted, no side effects | the existing `search_facts` / `search_episodes_by_keyword` (unchanged) |
+
+If you only need exact keyword matches and never care about freshness, usage, or
+graph proximity, you do not need ranked recall — the existing keyword search is
+still there and still behaves identically.
+
+---
+
+## How the score is computed
+
+For a candidate memory `x` and query `q`, the score is a single **un-normalized**
+weighted sum. Higher is better; the absolute value is meaningless — only the
+relative ordering matters. The weights (and only the weights) are the tuning
+knob.
+
+```text
+score(x) = w_text       · keyword_jaccard(q, text(x))
+         + w_confidence  · confidence(x)                  // facts only; 0 for episodes
+         + w_importance  · importance(x)                  // facts only; 0 for episodes
+         + w_recency     · exp_decay(age(x), half_life)
+         + w_usage       · usage_boost(usage_count(x))
+         + w_graph       · best_edge_score(x, q, max_graph_hops)
+```
+
+Because the sum is un-normalized, a strong showing on several signals can
+outrank a perfect keyword match that is otherwise stale, low-confidence, and
+unused. That is the entire point: a recent, high-importance, frequently-used
+fact should beat an old throwaway that merely happens to share a word.
+
+### The six signals
+
+| Signal | Term | Range | Source |
+|--------|------|-------|--------|
+| Text relevance | `keyword_jaccard(q, text(x))` | `[0, 1]` | `concept + " " + content` for facts; `content` for episodes |
+| Confidence | `confidence(x)` | `[0, 1]` | `SemanticFact.confidence` (episodes contribute `0`) |
+| Importance | `importance(x)` | `[0, 1]` | `SemanticFact.importance` (episodes contribute `0`) |
+| Recency | `exp_decay(age(x), half_life)` | `(0, 1]` | `now − reference_time(x)` |
+| Usage | `usage_boost(usage_count(x))` | `[0, ∞)` | `usage_count` property |
+| Graph | `best_edge_score(x, q, hops)` | `[0, 1]` | best agent-owned neighbour overlap |
+
+Precise definitions:
+
+- **`keyword_jaccard(q, t)`** — the [Jaccard index](https://en.wikipedia.org/wiki/Jaccard_index)
+  of the lower-cased, whitespace-tokenized **word sets** of `q` and `t`:
+  `|A ∩ B| / |A ∪ B|`. An empty query or empty text yields `0.0` (empty union ⇒
+  `0.0`, never a divide-by-zero). Ranked recall does **not** special-case an
+  empty query by delegating to `get_all_*`; it ranks every non-excluded
+  candidate by the remaining signals.
+
+- **`reference_time(x) = last_accessed_at.unwrap_or(created_at)`**, and
+  `age(x) = max(0, now − reference_time(x))` in seconds. Because access updates
+  `last_accessed_at`, *using* a memory also refreshes its recency. (To measure
+  pure stored-age decay in tests or analytics, recall with
+  `record_access: false`.)
+
+- **`exp_decay(age, hl) = 2^(−age / hl)`** — a half-life decay in `(0, 1]`:
+  `age = 0 ⇒ 1.0`, `age = hl ⇒ 0.5`, `age = 2·hl ⇒ 0.25`. A non-positive
+  half-life (`hl ≤ 0`) is guarded to yield `0.0` (the recency term is switched
+  off, never `NaN`).
+
+- **`usage_boost(n) = ln(1 + max(0, n))`** — logarithmic, so the first few uses
+  matter a lot and later uses add progressively less (`n ≤ 0 ⇒ 0.0`). Sub-linear
+  growth deliberately damps runaway inflation from hot memories.
+
+> **`confidence` vs `importance`.** These are scored as two independent signals,
+> but a fact's stored `importance` *defaults to its `confidence`* when not set
+> explicitly (`store_fact` / `store_fact_with_provenance` always do this). For
+> facts stored that way the two signals move together, so their combined effect is
+> roughly `(w_confidence + w_importance)·confidence`. To make `importance` an
+> independent dial, store the fact via `upsert_fact` with an explicit
+> `FactInput { importance: Some(_), .. }`. Episodes carry neither field and
+> contribute `0` to both terms.
+
+### The graph term (neighbour boost)
+
+The graph term pulls a candidate up when it sits next to *other* memories that
+match the query, following the edges the crate already maintains:
+
+```text
+best_edge_score(x, q, hops) =
+    max over agent-owned neighbours n reachable within min(hops, 3) of
+        keyword_jaccard(q, text(n)) / hop_distance(n)
+    or 0.0 if there are none
+```
+
+Traversal direction depends on what you are recalling and which edge type is
+followed (`DERIVES_FROM` points fact → episode):
+
+| Recalling | `DERIVES_FROM` | `SIMILAR_TO` |
+|-----------|----------------|--------------|
+| Facts (`recall_facts_ranked`) | `Outgoing` | `Both` |
+| Episodes (`recall_episodes_ranked`) | `Incoming` | `Both` |
+
+- Hop-1 neighbours are gathered directly; `max_graph_hops > 1` runs a bounded
+  breadth-first traversal with a visited-set cycle guard. The default is
+  **1 hop**, and the effective hop count is always clamped to **≤ 3** to bound
+  fan-out (a `max_graph_hops` of `0` disables the graph term entirely).
+- Each additional hop divides a neighbour's contribution by its hop distance, so
+  closer neighbours dominate.
+- **Tenant safety:** any neighbour whose `agent_id` differs from the current
+  agent is dropped *before* it can contribute to the score or appear in
+  `reasons`. Another agent's graph can never leak in, even via a shared edge.
+
+### `reasons` — why an item ranked where it did
+
+Every `Scored<T>` carries a `reasons: Vec<String>` explaining its score. There is
+one entry per **positive** weighted term, for example:
+
+```text
+["text 0.40 (jaccard=0.50)",
+ "confidence 0.63",
+ "importance 0.35",
+ "recency 0.40 (age=120s)",
+ "usage 0.21 (n=3)",
+ "graph 0.30 (SIMILAR_TO hop1)"]
+```
+
+If every term is zero, a single baseline entry is emitted
+(`"baseline (no positive signals)"`), so `reasons` is **never empty**. Reasons
+are intentionally **numeric/label-only**: they may include the weighted term
+value, the contributing edge type and hop, and the opaque neighbour `node_id` as
+a label, but they **never** embed raw fact/episode content, neighbour body text,
+or the query string.
+
+---
+
+## Configuration
+
+### `RecallWeights`
+
+`RecallWeights` is `Copy` and `Serialize`/`Deserialize`. Every weight is an
+independent `f64`; set one to `0.0` to switch a signal off, or raise it to make
+that signal dominate. Weights are not required to sum to anything.
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RecallWeights {
+    pub text_relevance: f64,
+    pub confidence: f64,
+    pub importance: f64,
+    pub recency: f64,
+    pub usage: f64,
+    pub graph: f64,
+}
+```
+
+| Field | Default | Effect |
+|-------|---------|--------|
+| `text_relevance` | `1.0` | Weight on keyword Jaccard overlap with the query. |
+| `confidence` | `0.7` | Weight on a fact's stored confidence (no effect on episodes). |
+| `importance` | `0.5` | Weight on a fact's stored importance (no effect on episodes). |
+| `recency` | `0.4` | Weight on exponential recency decay. |
+| `usage` | `0.3` | Weight on the logarithmic usage boost. |
+| `graph` | `0.6` | Weight on the best neighbour overlap. |
+
+```rust
+// Defaults
+RecallWeights {
+    text_relevance: 1.0,
+    confidence: 0.7,
+    importance: 0.5,
+    recency: 0.4,
+    usage: 0.3,
+    graph: 0.6,
+}
+
+// Example: rank almost purely by freshness + usage, ignore the graph.
+let weights = RecallWeights {
+    recency: 2.0,
+    usage: 1.0,
+    graph: 0.0,
+    ..RecallWeights::default()
+};
+```
+
+> **Default weighting note.** With the defaults, `confidence` (`0.7`) and
+> `importance` (`0.5`) *both* act on a fact's confidence for the common
+> `store_fact` path, because stored `importance` defaults to `confidence` there
+> (see the [`confidence` vs `importance` note](#the-six-signals)). So those two
+> weights together contribute ≈ `1.2 · confidence` unless you set `importance`
+> independently via `upsert_fact`. Tune `importance` *and* store with an explicit
+> importance if you want that dial to move on its own.
+
+### `RecallOptions`
+
+`RecallOptions` is `Clone` and `Serialize`/`Deserialize`. Construct it with
+`..Default::default()` so future additive fields don't break your call sites.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecallOptions {
+    pub limit: usize,
+    pub min_confidence: f64,
+    pub include_archived: bool,
+    pub include_superseded: bool,
+    pub max_graph_hops: usize,
+    pub recency_half_life_seconds: f64,
+    pub record_access: bool,
+    pub weights: RecallWeights,
+}
+```
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `limit` | `10` | Max items returned (after scoring + sorting). `0` ⇒ `Ok(vec![])`. |
+| `min_confidence` | `0.0` | Drop facts below this confidence. **Facts only** — a no-op for episodes. |
+| `include_archived` | `false` | When `false`, archived facts are excluded. |
+| `include_superseded` | `false` | When `false`, superseded facts (`superseded_by.is_some()`) are excluded. |
+| `max_graph_hops` | `1` | Neighbour traversal depth. `0` disables the graph term; clamped to `≤ 3`. |
+| `recency_half_life_seconds` | `604_800.0` | Recency half-life (7 days). `≤ 0` switches the recency term off. |
+| `record_access` | `true` | When `true`, each returned item gets a `record_access(_, Recall)` bump. Set `false` for a pure, side-effect-free read. |
+| `weights` | `RecallWeights::default()` | The six weights above. |
+
+```rust
+// Top 5 high-confidence facts, no graph traversal, no side effects.
+let opts = RecallOptions {
+    limit: 5,
+    min_confidence: 0.5,
+    max_graph_hops: 0,
+    record_access: false,
+    ..RecallOptions::default()
+};
+```
+
+---
+
+## API reference
+
+All three methods take `&mut self` because the default path records access
+(writes `usage_count` / `last_accessed_at`). The existing read-only `search_*` /
+`get_all_*` methods keep `&self` and are untouched.
+
+### `recall_facts_ranked(query, options) -> Result<Vec<Scored<SemanticFact>>>`
+
+```rust
+pub fn recall_facts_ranked(
+    &mut self,
+    query: &str,
+    options: RecallOptions,
+) -> Result<Vec<Scored<SemanticFact>>>;
+```
+
+Scores every agent-owned semantic fact against `query` using all six signals,
+excludes archived/superseded facts and those below `min_confidence` (unless opted
+in), sorts by descending score, truncates to `limit`, and — unless
+`record_access` is `false` — records a `Recall` access for each returned fact.
+Returns a `Vec<Scored<SemanticFact>>` already in rank order.
+
+```rust
+use amplihack_memory::{CognitiveMemory, RecallOptions};
+
+let mut mem = CognitiveMemory::new("research-agent")?;
+let hits = mem.recall_facts_ranked("rust memory safety", RecallOptions::default())?;
+for Scored { item, score, reasons } in &hits {
+    println!("{score:.3}  {}  {:?}", item.content, reasons);
+}
+```
+
+### `recall_episodes_ranked(query, options) -> Result<Vec<Scored<EpisodicMemory>>>`
+
+```rust
+pub fn recall_episodes_ranked(
+    &mut self,
+    query: &str,
+    options: RecallOptions,
+) -> Result<Vec<Scored<EpisodicMemory>>>;
+```
+
+The episode analogue. Episodes carry no confidence or importance, so those terms
+contribute `0` and `min_confidence` is a no-op; text relevance, recency, usage,
+and the graph term still apply. Compressed episodes are excluded (parity with
+`search_episodes_by_keyword`). `usage_count` and `last_accessed_at` are read
+directly from the episode's graph node — `EpisodicMemory` has **no field for
+either**, so a recorded access persists on the node and shapes the recency/usage
+terms of *future* recalls, but is never surfaced on the returned
+`Scored<EpisodicMemory>.item`. (`SemanticFact` does carry both fields; see
+[access tracking](#access-tracking-and-persistence) for why a recall still returns
+the pre-bump value.)
+
+```rust
+let hits = mem.recall_episodes_ranked("deployment incident", RecallOptions::default())?;
+```
+
+### `record_access(node_id, kind) -> Result<()>`
+
+```rust
+pub fn record_access(&mut self, node_id: &str, kind: AccessKind) -> Result<()>;
+```
+
+Increments a node's `usage_count` (saturating) and sets `last_accessed_at` to the
+current time, persisting both. Works for any node owned by the current agent —
+fact or episode. Call it yourself when a memory is consumed outside of ranked
+recall (e.g. surfaced through your own UI), so future ranked recalls reflect that
+use.
+
+```rust
+use amplihack_memory::AccessKind;
+
+mem.record_access(&fact_id, AccessKind::Read)?;
+```
+
+Failure modes:
+
+- the node does not exist ⇒ `MemoryError::Storage`;
+- the node belongs to a different agent ⇒ `MemoryError::SecurityViolation`
+  (**no write happens** — it fails closed);
+- the underlying store update fails ⇒ `MemoryError::Storage`.
+
+### `Scored<T>`
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Scored<T> {
+    pub item: T,
+    pub score: f64,
+    pub reasons: Vec<String>,
+}
+```
+
+The ranked wrapper returned by both recall methods. `item` is the unmodified
+`SemanticFact` / `EpisodicMemory`; `score` is the un-normalized combined score;
+`reasons` explains the score (see [`reasons`](#reasons--why-an-item-ranked-where-it-did)).
+
+### `AccessKind`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AccessKind { Read, Recall }
+```
+
+Serialized as `"Read"` / `"Recall"`. Both variants increment `usage_count`
+identically today; the distinction is informational and reserved for future
+differential weighting. Ranked recall records `Recall`; use `Read` for manual
+non-recall reads.
+
+### Pure scoring primitives
+
+The three building blocks are public and re-exported from the crate root, so you
+can reproduce or unit-test the scoring math independently of any store. They are
+pure functions — no `self`, no clock, fully deterministic.
+
+```rust
+/// Jaccard overlap of lower-cased whitespace word sets. 0.0 on an empty union.
+pub fn keyword_jaccard(query: &str, text: &str) -> f64;
+
+/// 2^(-age/half_life), in (0, 1]. 1.0 at age 0; 0.0 when half_life <= 0.
+pub fn exp_decay(age_seconds: f64, half_life_seconds: f64) -> f64;
+
+/// ln(1 + max(0, usage_count)). 0.0 at n <= 0; monotonic, sub-linear.
+pub fn usage_boost(usage_count: i64) -> f64;
+```
+
+```rust
+use amplihack_memory::{keyword_jaccard, exp_decay, usage_boost};
+
+assert_eq!(keyword_jaccard("rust async", "rust async runtime"), 2.0 / 3.0);
+assert_eq!(exp_decay(0.0, 604_800.0), 1.0);
+assert_eq!(exp_decay(604_800.0, 604_800.0), 0.5);
+assert_eq!(usage_boost(0), 0.0);
+assert!(usage_boost(10) > usage_boost(1));
+```
+
+---
+
+## Candidate gathering, filtering, and ordering
+
+A single `recall_*_ranked` call runs these steps:
+
+1. **Gather** all nodes of the requested type (`SemanticMemory` /
+   `EpisodicMemory`) **owned by the current agent** — the same agent-scoped query
+   path `search_facts` uses. Other agents' nodes are never fetched.
+2. **Convert** graph nodes to `SemanticFact` / `EpisodicMemory` via the crate's
+   existing converters.
+3. **Filter by lifecycle:**
+   - *Facts:* drop `archived` unless `include_archived`; drop superseded
+     (`superseded_by.is_some()`) unless `include_superseded`; drop
+     `confidence < min_confidence`.
+   - *Episodes:* archived / superseded / `min_confidence` are no-ops; `compressed`
+     episodes are excluded (matching `search_episodes_by_keyword`).
+4. **Score** the survivors and **sort by descending score** using a NaN-safe
+   total order (`f64::total_cmp`). Ties break by `confidence` descending, then
+   `node_id` ascending (for episodes, by `temporal_index` descending then
+   `node_id`, since confidence is uniformly `0`). Then `truncate(limit)`.
+5. **Record access** (only if `record_access`): for each *returned* (post-truncation)
+   item, after scoring, record a `Recall` access. This affects the *next* recall,
+   not the current result — the `Scored` items in *this* result carry each memory's
+   state **before** its bump. The writes are best-effort and **non-transactional**:
+   items are bumped one at a time and the first write failure aborts the loop and
+   returns that `Err`. There is no rollback, so a mid-loop failure can leave the
+   earlier items already bumped (a partial write) while the caller receives the
+   `Err` instead of the ranked `Vec`.
+
+---
+
+## Access tracking and persistence
+
+`record_access` (and the recall side-effect) write exactly two properties on the
+target node:
+
+| Property | Type | Written value |
+|----------|------|---------------|
+| `usage_count` | integer | previous value `saturating_add(1)` (a missing/unparseable value reads as `0`) |
+| `last_accessed_at` | unix seconds | current time |
+
+Nothing else is touched — the query and content are never copied into the graph.
+Both property keys are static literals. On the in-memory backend the updates live
+for the lifetime of the process; on the `persistent` (LadybugDB) backend they are
+durable — the two columns are created lazily on first write (**no migration, no
+DDL**) and survive `checkpoint()`, `drop`, and reopen. A fact accessed, then
+checkpointed, then reopened, comes back with the incremented `usage_count` and
+the recorded `last_accessed_at` intact.
+
+A recall's own access writes run **after** scoring and conversion, so the items a
+recall returns carry their **pre-bump** values: for a `SemanticFact` the
+`usage_count` / `last_accessed_at` you read on a result reflect the state *before*
+this call, and the increment first becomes visible on the *next* recall. Episodes
+never expose these values on the struct at all (see
+[`recall_episodes_ranked`](#recall_episodes_rankedquery-options---resultvecscoredepisodicmemory)),
+so for episodes the access is observable only as changed ranking on later recalls.
+
+---
+
+## Security and tenant isolation
+
+Ranked recall is built to be safe under hostile input and multi-agent stores:
+
+- **Agent-scoped candidates.** Recall only ever queries nodes owned by the
+  current agent. Agent A's recall can never return agent B's memory.
+- **Agent-scoped neighbours.** The graph term filters neighbours by `agent_id`;
+  a cross-agent neighbour contributes `0` and never appears in `reasons`.
+- **`record_access` fails closed.** Writing to a node owned by another agent is
+  refused with `MemoryError::SecurityViolation` and performs no write.
+- **Query is data, never code.** The query is only ever tokenized for Jaccard
+  comparison. It is never interpolated into Cypher/SQL, an identifier, or a
+  filter key.
+- **No panics on hostile floats.** `NaN`/`inf` weights or half-lives still
+  produce a sorted result — sorting uses `f64::total_cmp`, decay guards
+  non-positive half-lives, and parsing failures degrade to `0`. No
+  `unwrap`/`expect`/`panic` is reachable from untrusted input.
+- **Bounded fan-out.** Graph traversal is capped at 3 effective hops with a
+  visited-set, so a densely linked store cannot blow up traversal cost.
+- **Leak-free explanations.** `reasons` are numeric/label-only and never log
+  payloads.
+
+---
+
+## Errors
+
+| Method | Variant | Trigger |
+|--------|---------|---------|
+| `record_access` | `MemoryError::Storage` | node id not found |
+| `record_access` | `MemoryError::SecurityViolation` | node owned by another agent (no write) |
+| `record_access` | `MemoryError::Storage` | underlying store update failed |
+| `recall_*_ranked` | *(none)* | normal results, empty store, or `limit = 0` ⇒ `Ok` |
+| `recall_*_ranked` | propagated | only when `record_access == true` and a post-rank access write fails (non-transactional — earlier items may already be bumped) |
+
+Degenerate options never error and never panic: a non-positive half-life,
+`max_graph_hops = 0`, `limit = 0`, or a negative usage count simply become
+zero-contribution terms.
+
+---
+
+## Tutorial: ranking a knowledge base
+
+```rust
+use amplihack_memory::{
+    CognitiveMemory, RecallOptions, RecallWeights, Scored, AccessKind,
+};
+
+fn main() -> amplihack_memory::Result<()> {
+    let mut mem = CognitiveMemory::new("research-agent")?;
+
+    // 1. Store a few facts. An old, low-confidence keyword match…
+    let rust = ["rust".to_string()];
+    let old = mem.store_fact(
+        "rust-async",
+        "early notes on rust async runtimes",
+        0.2, "s-old", Some(&rust), None,
+    )?;
+
+    // …and a recent, high-importance, frequently-used fact on the same topic.
+    let fresh = mem.store_fact(
+        "rust-async",
+        "tokio is the de-facto rust async runtime",
+        0.9, "s-fresh", Some(&rust), None,
+    )?;
+    // Bump usage so the fresh fact has a usage history.
+    for _ in 0..5 { mem.record_access(&fresh, AccessKind::Read)?; }
+
+    // 2. Rank by the combined score. Despite both matching "rust async",
+    //    the fresh/important/used fact ranks first.
+    let hits = mem.recall_facts_ranked("rust async runtime", RecallOptions::default())?;
+    assert_eq!(hits[0].item.content, "tokio is the de-facto rust async runtime");
+    for Scored { item, score, reasons } in &hits {
+        println!("{score:.3}  {}\n      {:?}", item.content, reasons);
+    }
+    let _ = (old,); // `old` still appears, just lower.
+
+    // 3. Tune the weights: ignore the graph, weight freshness heavily,
+    //    and take a side-effect-free read of the top 3.
+    let opts = RecallOptions {
+        limit: 3,
+        record_access: false,
+        weights: RecallWeights { recency: 2.0, graph: 0.0, ..RecallWeights::default() },
+        ..RecallOptions::default()
+    };
+    let _fresh_first = mem.recall_facts_ranked("rust async", opts)?;
+
+    // 4. Graph boost: a weak fact linked SIMILAR_TO a strong match is pulled up.
+    let weak = mem.store_fact(
+        "rust-tooling", "cargo is rust's build tool", 0.5, "s-weak", Some(&rust), None,
+    )?;
+    mem.link_similar_facts(&weak, &fresh, 0.8)?;
+    let boosted = mem.recall_facts_ranked(
+        "tokio runtime",
+        RecallOptions { max_graph_hops: 1, ..RecallOptions::default() },
+    )?;
+    // `weak` now carries a positive "graph (...)" reason.
+    assert!(boosted.iter().any(|s| s.item.content.contains("cargo")
+        && s.reasons.iter().any(|r| r.starts_with("graph"))));
+
+    Ok(())
+}
+```
+
+---
+
+## Compatibility and guarantees
+
+- **Backward compatible.** `search_facts`, `get_all_facts`, and
+  `search_episodes_by_keyword` keep their exact signatures, ordering, and serde
+  shapes. Ranked recall is purely additive.
+- **Both backends, one implementation.** All logic sits behind the existing
+  `GraphStore` seam, so behaviour is identical on the default in-memory backend
+  and the `--features persistent` (LadybugDB) backend. No new edge types, no
+  schema migration, no `GraphStore` trait change, no new dependencies.
+- **Deterministic.** For a fixed store, query, options, and clock, the result —
+  scores, order, and `reasons` — is fully deterministic.
+- **Monotonic in each signal.** With non-negative weights, increasing any single
+  signal (importance, usage, fact confidence, keyword overlap, recency, or best
+  neighbour overlap) never lowers an item's score.
+- **`reasons` is never empty.** Every returned item carries at least one reason.
+- **SemVer-additive evolution.** New `RecallOptions` / `RecallWeights` fields are
+  introduced via `Default`, so `..Default::default()` call sites keep compiling.
+  serde keys are snake_case; `AccessKind` wire values `"Read"` / `"Recall"` are
+  stable.
+
+See the crate [`README`](../README.md) for the quick-start summary, and
+[`docs/similarity_linking.md`](similarity_linking.md) for the `SIMILAR_TO` edges
+that feed the graph term.

--- a/rust/amplihack-memory/src/cognitive_memory/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/mod.rs
@@ -17,6 +17,7 @@ mod dedup;
 mod episodic;
 mod procedural;
 mod prospective;
+mod ranked;
 mod semantic;
 mod sensory;
 mod similarity;
@@ -26,6 +27,9 @@ mod working;
 pub use dedup::{
     compute_content_hash, DedupAction, DedupMode, DedupOptions, DuplicateFactGroup, FactInput,
     ProvenanceOptions, PruneReport, RetentionPolicy, StoreFactOptions, StoreFactOutcome,
+};
+pub use ranked::{
+    exp_decay, keyword_jaccard, usage_boost, AccessKind, RecallOptions, RecallWeights, Scored,
 };
 pub use similarity::{SimilarityOptions, SimilarityReport};
 pub use types::WORKING_MEMORY_CAPACITY;

--- a/rust/amplihack-memory/src/cognitive_memory/ranked.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/ranked.rs
@@ -1,0 +1,587 @@
+//! Ranked (scored) recall over [`CognitiveMemory`].
+//!
+//! Adds a scored recall path alongside the existing keyword-only
+//! `search_facts` / `search_episodes_by_keyword`. Ranking combines six signals
+//! — text relevance, confidence, importance, recency, usage, and graph
+//! proximity — into a single un-normalized score, with documented defaults,
+//! lifecycle filtering (archived / superseded / compressed excluded by
+//! default), and optional access tracking (`usage_count` + `last_accessed_at`)
+//! that persists across reopen.
+//!
+//! This module is purely additive and backward compatible: no existing public
+//! signature, sort order, or serde shape changes. All logic lives behind the
+//! existing [`GraphStore`](crate::graph::GraphStore) seam, so behavior is
+//! identical on the in-memory and `--features persistent` (LadybugDB) backends.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::graph::types::{Direction, GraphNode};
+use crate::memory_types::{EpisodicMemory, SemanticFact};
+use crate::{MemoryError, Result};
+
+use super::converters::{node_to_episodic, node_to_fact, prop_bool, prop_i64, prop_opt_datetime};
+use super::types::{
+    agent_filter, ts_now, ET_DERIVES_FROM, ET_SIMILAR_TO, NT_EPISODIC, NT_SEMANTIC,
+};
+use super::CognitiveMemory;
+
+/// Upper bound on graph-traversal depth, regardless of `max_graph_hops`.
+///
+/// Caps neighbor fan-out (security R6/D5): a caller-supplied
+/// `RecallOptions::max_graph_hops` is clamped to this value before traversal.
+const MAX_GRAPH_HOPS: usize = 3;
+
+// ---------------------------------------------------------------------------
+// Public value types
+// ---------------------------------------------------------------------------
+
+/// Per-signal weights for [`recall_facts_ranked`](CognitiveMemory::recall_facts_ranked)
+/// and [`recall_episodes_ranked`](CognitiveMemory::recall_episodes_ranked).
+///
+/// Each field scales one scoring term. Weights are un-normalized — only their
+/// relative magnitudes matter. The [`Default`] reflects the tuned baseline:
+/// text relevance dominates, with confidence and graph proximity as the next
+/// strongest signals.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RecallWeights {
+    /// Weight on keyword Jaccard overlap between the query and the item text.
+    pub text_relevance: f64,
+    /// Weight on the fact's confidence (no-op for episodes; treated as 0).
+    pub confidence: f64,
+    /// Weight on the fact's importance (no-op for episodes; treated as 0).
+    pub importance: f64,
+    /// Weight on exponential recency decay of the last access / creation time.
+    pub recency: f64,
+    /// Weight on the sub-linear usage boost (`ln(1 + usage_count)`).
+    pub usage: f64,
+    /// Weight on the best graph-neighbor relevance within `max_graph_hops`.
+    pub graph: f64,
+}
+
+impl Default for RecallWeights {
+    fn default() -> Self {
+        Self {
+            text_relevance: 1.0,
+            confidence: 0.7,
+            importance: 0.5,
+            recency: 0.4,
+            usage: 0.3,
+            graph: 0.6,
+        }
+    }
+}
+
+/// How a node was accessed. Recorded by
+/// [`record_access`](CognitiveMemory::record_access); both variants currently
+/// increment `usage_count` identically (reserved for future differential
+/// weighting). The serde wire form is the variant name (`"Read"` / `"Recall"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AccessKind {
+    /// A direct read of a single node.
+    Read,
+    /// An access made while recalling/ranking results.
+    Recall,
+}
+
+/// Tunable options for ranked recall.
+///
+/// Construct via [`Default`] and struct-update so new fields stay
+/// source-compatible:
+///
+/// ```
+/// use amplihack_memory::RecallOptions;
+/// let opts = RecallOptions { limit: 25, ..Default::default() };
+/// assert_eq!(opts.limit, 25);
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecallOptions {
+    /// Maximum number of results to return. `0` yields an empty result.
+    pub limit: usize,
+    /// Minimum confidence floor (facts only; no-op for episodes).
+    pub min_confidence: f64,
+    /// Include archived facts. Defaults to `false`.
+    pub include_archived: bool,
+    /// Include superseded facts. Defaults to `false`.
+    pub include_superseded: bool,
+    /// Maximum graph-traversal hops for the graph term. `0` disables the graph
+    /// term; values above [`MAX_GRAPH_HOPS`] are clamped.
+    pub max_graph_hops: usize,
+    /// Recency half-life in seconds. `<= 0` makes the recency term `0`.
+    pub recency_half_life_seconds: f64,
+    /// Record access (bump `usage_count` + `last_accessed_at`) for every
+    /// returned item. Defaults to `true`; set `false` for a pure read.
+    pub record_access: bool,
+    /// Per-signal weights.
+    pub weights: RecallWeights,
+}
+
+impl Default for RecallOptions {
+    fn default() -> Self {
+        Self {
+            limit: 10,
+            min_confidence: 0.0,
+            include_archived: false,
+            include_superseded: false,
+            max_graph_hops: 1,
+            recency_half_life_seconds: 604_800.0,
+            record_access: true,
+            weights: RecallWeights::default(),
+        }
+    }
+}
+
+/// A scored recall result: the recalled item, its combined score, and a list of
+/// human-readable, numeric/label-only `reasons` explaining the score.
+///
+/// `reasons` never embeds raw content, neighbor body text, or the query — each
+/// entry is one positive scoring term (or a single baseline marker when every
+/// term is zero), so the vector is always non-empty.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Scored<T> {
+    /// The recalled item (a [`SemanticFact`] or [`EpisodicMemory`]).
+    pub item: T,
+    /// The combined, un-normalized relevance score (higher is better).
+    pub score: f64,
+    /// One short, payload-free explanation per positive scoring term.
+    pub reasons: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Pure scoring primitives (no `self`, no clock — deterministic & unit-testable)
+// ---------------------------------------------------------------------------
+
+/// Jaccard similarity of the lowercased whitespace-token *sets* of `query` and
+/// `text`: `|A ∩ B| / |A ∪ B|`. Returns `0.0` when either side is empty (so an
+/// empty union never divides by zero).
+pub fn keyword_jaccard(query: &str, text: &str) -> f64 {
+    let a: HashSet<String> = query.split_whitespace().map(str::to_lowercase).collect();
+    let b: HashSet<String> = text.split_whitespace().map(str::to_lowercase).collect();
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let inter = a.intersection(&b).count() as f64;
+    let union = a.union(&b).count() as f64;
+    if union == 0.0 {
+        0.0
+    } else {
+        inter / union
+    }
+}
+
+/// Exponential recency decay: `2^(-age / half_life)` in `(0, 1]`.
+///
+/// `age = 0` yields `1.0`; `age = half_life` yields `0.5`. Guarded so a
+/// non-positive `half_life_seconds` returns `0.0` (no division by zero / NaN).
+pub fn exp_decay(age_seconds: f64, half_life_seconds: f64) -> f64 {
+    if half_life_seconds <= 0.0 {
+        return 0.0;
+    }
+    2f64.powf(-age_seconds / half_life_seconds)
+}
+
+/// Sub-linear usage boost: `ln(1 + max(0, usage_count))`.
+///
+/// `0` at `usage_count <= 0`, monotonically increasing, and sub-linear so a
+/// large usage count cannot dominate the combined score.
+pub fn usage_boost(usage_count: i64) -> f64 {
+    (1.0 + usage_count.max(0) as f64).ln()
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Build the scoring text for a neighbor node: `concept + " " + content` when a
+/// concept is present (facts), else `content` (episodes).
+fn node_text(node: &GraphNode) -> String {
+    let concept = node
+        .properties
+        .get("concept")
+        .map(String::as_str)
+        .unwrap_or("");
+    let content = node
+        .properties
+        .get("content")
+        .map(String::as_str)
+        .unwrap_or("");
+    match (concept.is_empty(), content.is_empty()) {
+        (true, _) => content.to_string(),
+        (false, true) => concept.to_string(),
+        (false, false) => format!("{concept} {content}"),
+    }
+}
+
+impl CognitiveMemory {
+    // ======================================================================
+    // RANKED RECALL
+    // ======================================================================
+
+    /// Ranked recall over this agent's semantic facts.
+    ///
+    /// Scores every non-excluded fact by the weighted combination of text
+    /// relevance, confidence, importance, recency, usage, and graph proximity
+    /// (see module docs), returns them sorted by descending score (NaN-safe,
+    /// deterministic tie-break), and — when `options.record_access` is `true`
+    /// (the default) — records a [`Recall`](AccessKind::Recall) access for each
+    /// returned item (affecting subsequent calls, not the returned values).
+    ///
+    /// Archived and superseded facts are excluded unless opted in via
+    /// `options`; facts below `options.min_confidence` are dropped. The existing
+    /// [`search_facts`](Self::search_facts) / [`get_all_facts`](Self::get_all_facts)
+    /// remain unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Only when `options.record_access` is `true` and a post-rank access write
+    /// fails: the first failure returns that `MemoryError`.
+    pub fn recall_facts_ranked(
+        &mut self,
+        query: &str,
+        options: RecallOptions,
+    ) -> Result<Vec<Scored<SemanticFact>>> {
+        let filter = agent_filter(&self.agent_name);
+        let nodes = self
+            .graph
+            .query_nodes(NT_SEMANTIC, Some(&filter), usize::MAX);
+        let now = ts_now();
+        let traversals = [
+            (ET_DERIVES_FROM, Direction::Outgoing),
+            (ET_SIMILAR_TO, Direction::Both),
+        ];
+
+        let mut scored: Vec<Scored<SemanticFact>> = Vec::new();
+        for node in &nodes {
+            let fact = node_to_fact(&node.properties);
+
+            if fact.archived && !options.include_archived {
+                continue;
+            }
+            if fact.superseded_by.is_some() && !options.include_superseded {
+                continue;
+            }
+            if fact.confidence < options.min_confidence {
+                continue;
+            }
+
+            let text = format!("{} {}", fact.concept, fact.content);
+            let reference_time = fact
+                .last_accessed_at
+                .map(|d| d.timestamp())
+                .unwrap_or_else(|| fact.created_at.timestamp());
+
+            let (score, reasons) = self.score_signals(
+                query,
+                &text,
+                fact.confidence,
+                fact.importance,
+                fact.usage_count,
+                reference_time,
+                now,
+                &fact.node_id,
+                &traversals,
+                &options,
+            );
+            scored.push(Scored {
+                item: fact,
+                score,
+                reasons,
+            });
+        }
+
+        scored.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then(b.item.confidence.total_cmp(&a.item.confidence))
+                .then(a.item.node_id.cmp(&b.item.node_id))
+        });
+        scored.truncate(options.limit);
+
+        if options.record_access {
+            let ids: Vec<String> = scored.iter().map(|s| s.item.node_id.clone()).collect();
+            for id in ids {
+                self.record_access(&id, AccessKind::Recall)?;
+            }
+        }
+
+        Ok(scored)
+    }
+
+    /// Ranked recall over this agent's episodic memories.
+    ///
+    /// Mirrors [`recall_facts_ranked`](Self::recall_facts_ranked) for episodes.
+    /// Confidence, importance, archived, superseded, and `min_confidence` are
+    /// no-ops for episodes; compressed episodes are always excluded (parity with
+    /// [`search_episodes_by_keyword`](Self::search_episodes_by_keyword)). The
+    /// graph term follows `DERIVES_FROM` incoming (toward the source fact) and
+    /// `SIMILAR_TO` in both directions.
+    ///
+    /// # Errors
+    ///
+    /// Only when `options.record_access` is `true` and a post-rank access write
+    /// fails: the first failure returns that `MemoryError`.
+    pub fn recall_episodes_ranked(
+        &mut self,
+        query: &str,
+        options: RecallOptions,
+    ) -> Result<Vec<Scored<EpisodicMemory>>> {
+        let filter = agent_filter(&self.agent_name);
+        let nodes = self
+            .graph
+            .query_nodes(NT_EPISODIC, Some(&filter), usize::MAX);
+        let now = ts_now();
+        let traversals = [
+            (ET_DERIVES_FROM, Direction::Incoming),
+            (ET_SIMILAR_TO, Direction::Both),
+        ];
+
+        let mut scored: Vec<Scored<EpisodicMemory>> = Vec::new();
+        for node in &nodes {
+            if prop_bool(&node.properties, "compressed") {
+                continue;
+            }
+
+            let usage_count = prop_i64(&node.properties, "usage_count");
+            let reference_time = prop_opt_datetime(&node.properties, "last_accessed_at")
+                .map(|d| d.timestamp())
+                .unwrap_or_else(|| prop_i64(&node.properties, "created_at"));
+
+            let episode = node_to_episodic(&node.properties);
+            let text = episode.content.clone();
+
+            let (score, reasons) = self.score_signals(
+                query,
+                &text,
+                0.0,
+                0.0,
+                usage_count,
+                reference_time,
+                now,
+                &episode.node_id,
+                &traversals,
+                &options,
+            );
+            scored.push(Scored {
+                item: episode,
+                score,
+                reasons,
+            });
+        }
+
+        scored.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then(b.item.temporal_index.cmp(&a.item.temporal_index))
+                .then(a.item.node_id.cmp(&b.item.node_id))
+        });
+        scored.truncate(options.limit);
+
+        if options.record_access {
+            let ids: Vec<String> = scored.iter().map(|s| s.item.node_id.clone()).collect();
+            for id in ids {
+                self.record_access(&id, AccessKind::Recall)?;
+            }
+        }
+
+        Ok(scored)
+    }
+
+    /// Record an access to a node: increment its `usage_count` (saturating) and
+    /// set `last_accessed_at` to now. Persisted, so the bump survives reopen.
+    ///
+    /// Works for any node type owned by this agent. Writes only the two static
+    /// counter properties — never the query or any content.
+    ///
+    /// # Errors
+    ///
+    /// - [`MemoryError::Storage`] if `node_id` does not exist.
+    /// - [`MemoryError::SecurityViolation`] if the node is owned by a different
+    ///   agent (no write is performed).
+    /// - [`MemoryError::Storage`] if the backend update fails.
+    pub fn record_access(&mut self, node_id: &str, kind: AccessKind) -> Result<()> {
+        let _ = kind; // Read and Recall increment identically (reserved).
+
+        let node = self.graph.get_node(node_id).ok_or_else(|| {
+            MemoryError::Storage(format!("record_access: node {node_id} not found"))
+        })?;
+
+        if node.properties.get("agent_id").map(String::as_str) != Some(self.agent_name.as_str()) {
+            return Err(MemoryError::SecurityViolation(
+                "record_access: node not owned by current agent".into(),
+            ));
+        }
+
+        let prev = prop_i64(&node.properties, "usage_count");
+        let mut props = HashMap::new();
+        props.insert(
+            "usage_count".to_string(),
+            prev.saturating_add(1).to_string(),
+        );
+        props.insert("last_accessed_at".to_string(), ts_now().to_string());
+
+        if !self.graph.update_node(node_id, props) {
+            return Err(MemoryError::Storage(format!(
+                "record_access: update failed for {node_id}"
+            )));
+        }
+        Ok(())
+    }
+
+    // ======================================================================
+    // SCORING (internal)
+    // ======================================================================
+
+    /// Compute the combined score and `reasons` for one candidate.
+    ///
+    /// `confidence` / `importance` are passed as `0.0` for episodes so their
+    /// terms vanish. Every positive weighted term contributes one numeric /
+    /// label-only `reasons` entry; if all terms are zero a single baseline
+    /// marker is emitted so the vector is never empty.
+    #[allow(clippy::too_many_arguments)]
+    fn score_signals(
+        &self,
+        query: &str,
+        text: &str,
+        confidence: f64,
+        importance: f64,
+        usage_count: i64,
+        reference_time: i64,
+        now: i64,
+        node_id: &str,
+        traversals: &[(&str, Direction)],
+        options: &RecallOptions,
+    ) -> (f64, Vec<String>) {
+        let w = &options.weights;
+        let mut score = 0.0;
+        let mut reasons: Vec<String> = Vec::new();
+
+        // Text relevance.
+        let jaccard = keyword_jaccard(query, text);
+        let text_term = w.text_relevance * jaccard;
+        if text_term > 0.0 {
+            reasons.push(format!("text {text_term:.4} (jaccard={jaccard:.4})"));
+        }
+        score += text_term;
+
+        // Confidence (facts only; 0 for episodes).
+        let conf_term = w.confidence * confidence;
+        if conf_term > 0.0 {
+            reasons.push(format!("confidence {conf_term:.4}"));
+        }
+        score += conf_term;
+
+        // Importance (facts only; 0 for episodes).
+        let imp_term = w.importance * importance;
+        if imp_term > 0.0 {
+            reasons.push(format!("importance {imp_term:.4}"));
+        }
+        score += imp_term;
+
+        // Recency.
+        let age = (now - reference_time).max(0) as f64;
+        let recency_term = w.recency * exp_decay(age, options.recency_half_life_seconds);
+        if recency_term > 0.0 {
+            reasons.push(format!("recency {recency_term:.4} (age={}s)", age as i64));
+        }
+        score += recency_term;
+
+        // Usage.
+        let usage_term = w.usage * usage_boost(usage_count);
+        if usage_term > 0.0 {
+            reasons.push(format!("usage {usage_term:.4} (n={usage_count})"));
+        }
+        score += usage_term;
+
+        // Graph proximity.
+        if options.max_graph_hops > 0 {
+            let (best, meta) =
+                self.best_edge_score(node_id, query, traversals, options.max_graph_hops);
+            let graph_term = w.graph * best;
+            if graph_term > 0.0 {
+                if let Some((label, hop)) = meta {
+                    reasons.push(format!("graph {graph_term:.4} ({label} hop{hop})"));
+                }
+            }
+            score += graph_term;
+        }
+
+        if reasons.is_empty() {
+            reasons.push("baseline (no positive signals)".to_string());
+        }
+
+        (score, reasons)
+    }
+
+    /// Best graph-neighbor relevance reachable from `start_id` within
+    /// `min(max_hops, MAX_GRAPH_HOPS)`.
+    ///
+    /// Runs a bounded BFS over the supplied `(edge_type, direction)` pairs,
+    /// scoring each agent-owned neighbor by `keyword_jaccard(query, text) / hop`
+    /// and returning the maximum (with the edge label + hop of the winner for
+    /// the reason string). Foreign-tenant neighbors are pruned entirely — they
+    /// neither contribute a score nor are traversed through (security A3).
+    fn best_edge_score(
+        &self,
+        start_id: &str,
+        query: &str,
+        traversals: &[(&str, Direction)],
+        max_hops: usize,
+    ) -> (f64, Option<(String, usize)>) {
+        let hops = max_hops.min(MAX_GRAPH_HOPS);
+        if hops == 0 {
+            return (0.0, None);
+        }
+
+        let mut visited: HashSet<String> = HashSet::new();
+        visited.insert(start_id.to_string());
+        let mut frontier: Vec<String> = vec![start_id.to_string()];
+        let mut best = 0.0_f64;
+        let mut best_meta: Option<(String, usize)> = None;
+
+        for hop in 1..=hops {
+            let mut next: Vec<String> = Vec::new();
+            for nid in &frontier {
+                for (edge_type, direction) in traversals {
+                    for (_, neighbor) in
+                        self.graph
+                            .query_neighbors(nid, Some(edge_type), *direction, usize::MAX)
+                    {
+                        if !visited.insert(neighbor.node_id.clone()) {
+                            continue;
+                        }
+                        // A3: drop foreign-tenant neighbors before they score or
+                        // expand the frontier.
+                        if neighbor.properties.get("agent_id").map(String::as_str)
+                            != Some(self.agent_name.as_str())
+                        {
+                            continue;
+                        }
+                        let s = keyword_jaccard(query, &node_text(&neighbor)) / hop as f64;
+                        if s > best {
+                            best = s;
+                            best_meta = Some(((*edge_type).to_string(), hop));
+                        }
+                        next.push(neighbor.node_id);
+                    }
+                }
+            }
+            frontier = next;
+        }
+
+        (best, best_meta)
+    }
+
+    /// Test-only seam: overwrite raw node properties through the backing
+    /// `GraphStore`, used to fabricate deterministic state (old timestamps,
+    /// foreign `agent_id`, lifecycle flags) the public API can't construct
+    /// directly. Returns `true` on success.
+    #[cfg(test)]
+    pub(crate) fn set_node_props_for_test(
+        &mut self,
+        node_id: &str,
+        props: HashMap<String, String>,
+    ) -> bool {
+        self.graph.update_node(node_id, props)
+    }
+}

--- a/rust/amplihack-memory/src/cognitive_memory/tests/mod.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/mod.rs
@@ -7,6 +7,7 @@ mod integration_tests;
 mod persistent_tests;
 mod procedural_tests;
 mod prospective_tests;
+mod ranked_tests;
 mod semantic_tests;
 mod sensory_tests;
 mod similarity_tests;

--- a/rust/amplihack-memory/src/cognitive_memory/tests/ranked_tests.rs
+++ b/rust/amplihack-memory/src/cognitive_memory/tests/ranked_tests.rs
@@ -1,0 +1,928 @@
+//! TDD specification tests for **ranked recall** over [`CognitiveMemory`]
+//! (issue #90).
+//!
+//! These tests are written *before* the implementation and define the
+//! behavioral contract for:
+//!   * [`CognitiveMemory::recall_facts_ranked`]
+//!   * [`CognitiveMemory::recall_episodes_ranked`]
+//!   * [`CognitiveMemory::record_access`]
+//!   * the value types `RecallWeights`, `RecallOptions`, `AccessKind`, `Scored<T>`
+//!   * the pure scoring primitives `keyword_jaccard`, `exp_decay`, `usage_boost`
+//!
+//! They are derived from the consolidated design (Step 5e) and its Gherkin
+//! scenarios / formal invariants (I1–I13).
+//!
+//! ## Required test-only seam
+//!
+//! Several scenarios (recency decay, usage isolation, lifecycle flags, tenant
+//! isolation) need to construct deterministic node state that the public API
+//! does not let a test fabricate directly (e.g. an *old* `last_accessed_at`, a
+//! foreign `agent_id`). The implementation MUST therefore expose a
+//! `#[cfg(test)] pub(crate)` helper on `CognitiveMemory` that writes raw node
+//! properties through the backing `GraphStore`:
+//!
+//! ```ignore
+//! #[cfg(test)]
+//! pub(crate) fn set_node_props_for_test(
+//!     &mut self,
+//!     node_id: &str,
+//!     props: std::collections::HashMap<String, String>,
+//! ) -> bool {
+//!     self.graph.update_node(node_id, props)
+//! }
+//! ```
+//!
+//! This is the only non-public surface these tests rely on; everything else is
+//! the real public ranked-recall API. Until that API exists this module fails
+//! to compile — the expected TDD "red" state.
+
+use std::collections::HashMap;
+
+// Brings `CognitiveMemory` plus the ranked-recall re-exports
+// (`RecallWeights`, `RecallOptions`, `AccessKind`, `Scored`, `keyword_jaccard`,
+// `exp_decay`, `usage_boost`) into scope from `cognitive_memory::mod`.
+use super::super::*;
+
+use crate::memory_types::{EpisodicMemory, SemanticFact};
+use crate::MemoryError;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Fresh in-memory `CognitiveMemory` with a unique agent name per test.
+fn make_cm() -> CognitiveMemory {
+    CognitiveMemory::new(&format!("ranked-agent-{}", uuid::Uuid::new_v4())).unwrap()
+}
+
+/// Seconds since the Unix epoch, computed the same way the implementation's
+/// internal `ts_now()` does, so test-constructed ages line up with scoring.
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+/// Overwrite a single raw property on a node (see module docs for the required
+/// `set_node_props_for_test` seam).
+fn set_prop(cm: &mut CognitiveMemory, node_id: &str, key: &str, value: &str) {
+    let mut props = HashMap::new();
+    props.insert(key.to_string(), value.to_string());
+    assert!(
+        cm.set_node_props_for_test(node_id, props),
+        "set_node_props_for_test failed for node {node_id}"
+    );
+}
+
+/// Default `RecallOptions` that never mutates the store, so scoring assertions
+/// stay isolated from the access-tracking side effect.
+fn read_only_opts() -> RecallOptions {
+    RecallOptions {
+        record_access: false,
+        ..RecallOptions::default()
+    }
+}
+
+fn find_fact<'a>(
+    scored: &'a [Scored<SemanticFact>],
+    node_id: &str,
+) -> Option<&'a Scored<SemanticFact>> {
+    scored.iter().find(|s| s.item.node_id == node_id)
+}
+
+fn rank_of_fact(scored: &[Scored<SemanticFact>], node_id: &str) -> Option<usize> {
+    scored.iter().position(|s| s.item.node_id == node_id)
+}
+
+fn find_episode<'a>(
+    scored: &'a [Scored<EpisodicMemory>],
+    node_id: &str,
+) -> Option<&'a Scored<EpisodicMemory>> {
+    scored.iter().find(|s| s.item.node_id == node_id)
+}
+
+fn get_fact(cm: &CognitiveMemory, node_id: &str) -> SemanticFact {
+    cm.get_all_facts(10_000)
+        .into_iter()
+        .find(|f| f.node_id == node_id)
+        .unwrap_or_else(|| panic!("fact {node_id} not found"))
+}
+
+/// Case-insensitive substring search across a `Scored` item's reasons.
+fn has_reason(reasons: &[String], needle: &str) -> bool {
+    let needle = needle.to_lowercase();
+    reasons.iter().any(|r| r.to_lowercase().contains(&needle))
+}
+
+// ===========================================================================
+// 1. Pure scoring primitives (deterministic, no clock, no store)
+// ===========================================================================
+
+#[test]
+fn keyword_jaccard_partial_overlap() {
+    // {rust, async} ∩ {rust, async, programming, tokio} = 2; ∪ = 4 -> 0.5
+    let j = keyword_jaccard("rust async", "rust async programming tokio");
+    assert!((j - 0.5).abs() < 1e-9, "expected 0.5, got {j}");
+}
+
+#[test]
+fn keyword_jaccard_identical_is_one() {
+    assert!((keyword_jaccard("alpha beta", "beta alpha") - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn keyword_jaccard_is_case_insensitive() {
+    assert!((keyword_jaccard("Rust ASYNC", "rust async") - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn keyword_jaccard_empty_inputs_are_zero() {
+    assert_eq!(keyword_jaccard("", "anything"), 0.0);
+    assert_eq!(keyword_jaccard("anything", ""), 0.0);
+    assert_eq!(keyword_jaccard("", ""), 0.0);
+}
+
+#[test]
+fn keyword_jaccard_disjoint_is_zero() {
+    assert_eq!(keyword_jaccard("rust async", "banana smoothie"), 0.0);
+}
+
+#[test]
+fn exp_decay_at_zero_age_is_one() {
+    assert!((exp_decay(0.0, 100.0) - 1.0).abs() < 1e-12);
+}
+
+#[test]
+fn exp_decay_at_one_half_life_is_half() {
+    // Core recency property used in the Gherkin scenario.
+    assert!((exp_decay(100.0, 100.0) - 0.5).abs() < 1e-12);
+    assert!((exp_decay(200.0, 100.0) - 0.25).abs() < 1e-12);
+}
+
+#[test]
+fn exp_decay_nonpositive_half_life_guarded_to_zero() {
+    // No div-by-zero / NaN: hl <= 0 yields 0.0.
+    assert_eq!(exp_decay(50.0, 0.0), 0.0);
+    assert_eq!(exp_decay(50.0, -10.0), 0.0);
+}
+
+#[test]
+fn exp_decay_is_monotonic_decreasing_in_age() {
+    let hl = 7.0 * 86_400.0;
+    assert!(exp_decay(0.0, hl) > exp_decay(3600.0, hl));
+    assert!(exp_decay(3600.0, hl) > exp_decay(30.0 * 86_400.0, hl));
+}
+
+#[test]
+fn usage_boost_zero_and_negative_are_zero() {
+    assert_eq!(usage_boost(0), 0.0);
+    assert_eq!(usage_boost(-5), 0.0);
+}
+
+#[test]
+fn usage_boost_is_ln_one_plus_n_and_monotonic() {
+    assert!((usage_boost(1) - (2.0f64).ln()).abs() < 1e-12);
+    assert!(usage_boost(10) > usage_boost(3));
+    assert!(usage_boost(3) > usage_boost(1));
+    assert!(usage_boost(1) > usage_boost(0));
+}
+
+// ===========================================================================
+// 2. Defaults (the documented contract for the option/weight structs)
+// ===========================================================================
+
+#[test]
+fn recall_weights_defaults_match_design() {
+    let w = RecallWeights::default();
+    assert_eq!(w.text_relevance, 1.0);
+    assert_eq!(w.confidence, 0.7);
+    assert_eq!(w.importance, 0.5);
+    assert_eq!(w.recency, 0.4);
+    assert_eq!(w.usage, 0.3);
+    assert_eq!(w.graph, 0.6);
+}
+
+#[test]
+fn recall_options_defaults_match_design() {
+    let o = RecallOptions::default();
+    assert_eq!(o.limit, 10);
+    assert_eq!(o.min_confidence, 0.0);
+    assert!(!o.include_archived);
+    assert!(!o.include_superseded);
+    assert_eq!(o.max_graph_hops, 1);
+    assert_eq!(o.recency_half_life_seconds, 604_800.0);
+    assert!(o.record_access);
+    assert_eq!(o.weights, RecallWeights::default());
+}
+
+// ===========================================================================
+// 3. Combined-score ranking (I4, I11)
+// ===========================================================================
+
+#[test]
+fn ranking_orders_by_combined_score() {
+    // A recent, high-importance, high-usage fact must outrank an old,
+    // low-confidence keyword match even though both mention the query terms.
+    let mut cm = make_cm();
+
+    let alpha = cm
+        .store_fact("alpha", "rust async notes", 0.2, "", None, None)
+        .unwrap();
+    let beta = cm
+        .store_fact("beta", "rust async deep dive", 0.9, "", None, None)
+        .unwrap();
+
+    // Make alpha stale and beta heavily used.
+    set_prop(
+        &mut cm,
+        &alpha,
+        "last_accessed_at",
+        &(now_secs() - 60 * 86_400).to_string(),
+    );
+    set_prop(&mut cm, &beta, "usage_count", "5");
+
+    let res = cm
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+
+    let ra = rank_of_fact(&res, &alpha).expect("alpha present");
+    let rb = rank_of_fact(&res, &beta).expect("beta present");
+    assert!(rb < ra, "beta (recent/important/used) should outrank alpha");
+    assert!(find_fact(&res, &beta).unwrap().score > find_fact(&res, &alpha).unwrap().score);
+}
+
+#[test]
+fn results_are_sorted_descending_by_score() {
+    // I4: i < j => R[i].score >= R[j].score.
+    let mut cm = make_cm();
+    cm.store_fact("a", "rust async one", 0.9, "", None, None)
+        .unwrap();
+    cm.store_fact("b", "rust tokio two", 0.5, "", None, None)
+        .unwrap();
+    cm.store_fact("c", "unrelated three", 0.1, "", None, None)
+        .unwrap();
+
+    let res = cm
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+    for w in res.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "scores must be non-increasing: {} then {}",
+            w[0].score,
+            w[1].score
+        );
+    }
+}
+
+#[test]
+fn reasons_are_never_empty() {
+    // I6: every returned item carries at least one reason string.
+    let mut cm = make_cm();
+    cm.store_fact("x", "rust async", 0.9, "", None, None)
+        .unwrap();
+    let res = cm
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+    assert!(!res.is_empty());
+    for s in &res {
+        assert!(!s.reasons.is_empty(), "reasons must not be empty");
+    }
+}
+
+#[test]
+fn limit_truncates_results() {
+    // I5: |R| <= limit.
+    let mut cm = make_cm();
+    for i in 0..5 {
+        cm.store_fact(&format!("c{i}"), "rust async item", 0.5, "", None, None)
+            .unwrap();
+    }
+    let opts = RecallOptions {
+        limit: 2,
+        ..read_only_opts()
+    };
+    let res = cm.recall_facts_ranked("rust async", opts).unwrap();
+    assert_eq!(res.len(), 2);
+}
+
+#[test]
+fn limit_zero_returns_empty() {
+    let mut cm = make_cm();
+    cm.store_fact("x", "rust async", 0.9, "", None, None)
+        .unwrap();
+    let opts = RecallOptions {
+        limit: 0,
+        ..read_only_opts()
+    };
+    let res = cm.recall_facts_ranked("rust async", opts).unwrap();
+    assert!(res.is_empty());
+}
+
+// ===========================================================================
+// 4. Recency decay (recency term, I7)
+// ===========================================================================
+
+#[test]
+fn recency_decay_lowers_old_facts() {
+    // Two facts equal in everything except last_accessed_at; the recent one
+    // must score higher. record_access=false keeps the comparison pure (I7).
+    let mut cm = make_cm();
+    let recent = cm
+        .store_fact("topic", "identical body text", 0.6, "", None, None)
+        .unwrap();
+    let old = cm
+        .store_fact("topic", "identical body text", 0.6, "", None, None)
+        .unwrap();
+
+    set_prop(
+        &mut cm,
+        &old,
+        "last_accessed_at",
+        &(now_secs() - 30 * 86_400).to_string(),
+    );
+
+    let res = cm
+        .recall_facts_ranked("identical body", read_only_opts())
+        .unwrap();
+    let recent_s = find_fact(&res, &recent).unwrap();
+    let old_s = find_fact(&res, &old).unwrap();
+
+    assert!(
+        recent_s.score > old_s.score,
+        "recent {} should beat old {}",
+        recent_s.score,
+        old_s.score
+    );
+    assert!(has_reason(&recent_s.reasons, "recency"));
+}
+
+// ===========================================================================
+// 5. Usage boost (usage term)
+// ===========================================================================
+
+#[test]
+fn usage_boost_orders_facts() {
+    // Two facts equal except usage_count; higher usage scores higher.
+    let mut cm = make_cm();
+    let low = cm
+        .store_fact("topic", "same content here", 0.6, "", None, None)
+        .unwrap();
+    let high = cm
+        .store_fact("topic", "same content here", 0.6, "", None, None)
+        .unwrap();
+
+    set_prop(&mut cm, &high, "usage_count", "10");
+
+    let res = cm
+        .recall_facts_ranked("same content", read_only_opts())
+        .unwrap();
+    let high_s = find_fact(&res, &high).unwrap();
+    let low_s = find_fact(&res, &low).unwrap();
+
+    assert!(
+        high_s.score > low_s.score,
+        "higher usage should score higher"
+    );
+    assert!(has_reason(&high_s.reasons, "usage"));
+    // The zero-usage fact contributes no usage term, hence no usage reason.
+    assert!(!has_reason(&low_s.reasons, "usage"));
+}
+
+// ===========================================================================
+// 6. Graph boost via DERIVES_FROM / SIMILAR_TO (graph term, A3)
+// ===========================================================================
+
+#[test]
+fn graph_boost_similar_neighbor_raises_score() {
+    // "core" matches the query strongly; "neighbor" has no textual overlap but
+    // is SIMILAR_TO "core", so a 1-hop graph term should lift it.
+    let mut cm = make_cm();
+    let core = cm
+        .store_fact("core", "rust async tokio runtime", 0.0, "", None, None)
+        .unwrap();
+    let neighbor = cm
+        .store_fact("cooking", "banana smoothie recipe", 0.0, "", None, None)
+        .unwrap();
+    cm.link_similar_facts(&neighbor, &core, 0.9).unwrap();
+
+    let with_graph = RecallOptions {
+        max_graph_hops: 1,
+        ..read_only_opts()
+    };
+    let no_graph = RecallOptions {
+        max_graph_hops: 0,
+        ..read_only_opts()
+    };
+
+    let res_g = cm.recall_facts_ranked("rust async", with_graph).unwrap();
+    let res_ng = cm.recall_facts_ranked("rust async", no_graph).unwrap();
+
+    let n_g = find_fact(&res_g, &neighbor).unwrap();
+    let n_ng = find_fact(&res_ng, &neighbor).unwrap();
+
+    assert!(
+        n_g.score > n_ng.score,
+        "graph hop should raise neighbor score: {} vs {}",
+        n_g.score,
+        n_ng.score
+    );
+    assert!(has_reason(&n_g.reasons, "graph"), "expected a graph reason");
+    assert!(
+        !has_reason(&n_ng.reasons, "graph"),
+        "hops=0 disables graph term"
+    );
+}
+
+#[test]
+fn graph_boost_derives_from_episode() {
+    // A fact "core" matches the query; an episode DERIVES_FROM "core" (edge
+    // core --DERIVES_FROM--> episode, i.e. Incoming from the episode's view)
+    // should be boosted above an unlinked episode with identical text.
+    let mut cm = make_cm();
+    let core = cm
+        .store_fact("core", "rust async tokio", 0.0, "", None, None)
+        .unwrap();
+    let linked = cm
+        .store_episode("did unrelated plumbing work", "ops", Some(1), None)
+        .unwrap();
+    let unlinked = cm
+        .store_episode("did unrelated plumbing work", "ops", Some(2), None)
+        .unwrap();
+    cm.link_fact_to_episode(&core, &linked).unwrap();
+
+    let opts = RecallOptions {
+        max_graph_hops: 1,
+        ..read_only_opts()
+    };
+    let res = cm.recall_episodes_ranked("rust async", opts).unwrap();
+
+    let linked_s = find_episode(&res, &linked).unwrap();
+    let unlinked_s = find_episode(&res, &unlinked).unwrap();
+    assert!(
+        linked_s.score > unlinked_s.score,
+        "DERIVES_FROM-linked episode should outrank the unlinked one"
+    );
+    assert!(has_reason(&linked_s.reasons, "graph"));
+}
+
+// ===========================================================================
+// 7. Lifecycle exclusion (I2)
+// ===========================================================================
+
+#[test]
+fn archived_facts_excluded_by_default_and_surfaced_on_opt_in() {
+    let mut cm = make_cm();
+    let normal = cm
+        .store_fact("normal", "rust async normal", 0.8, "", None, None)
+        .unwrap();
+    let archived = cm
+        .store_fact("archived", "rust async archived", 0.8, "", None, None)
+        .unwrap();
+    set_prop(&mut cm, &archived, "archived", "true");
+
+    let res = cm
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+    assert!(find_fact(&res, &normal).is_some());
+    assert!(
+        find_fact(&res, &archived).is_none(),
+        "archived fact must be excluded by default"
+    );
+
+    let opts = RecallOptions {
+        include_archived: true,
+        ..read_only_opts()
+    };
+    let res2 = cm.recall_facts_ranked("rust async", opts).unwrap();
+    assert!(
+        find_fact(&res2, &archived).is_some(),
+        "include_archived must surface the archived fact"
+    );
+}
+
+#[test]
+fn superseded_facts_excluded_by_default_and_surfaced_on_opt_in() {
+    let mut cm = make_cm();
+    let normal = cm
+        .store_fact("normal", "rust async normal", 0.8, "", None, None)
+        .unwrap();
+    let superseded = cm
+        .store_fact("old", "rust async superseded", 0.8, "", None, None)
+        .unwrap();
+    // Mark only superseded_by (independent of the archived flag) to isolate the
+    // superseded filter from the archived filter.
+    set_prop(&mut cm, &superseded, "superseded_by", "some-newer-id");
+
+    let res = cm
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+    assert!(find_fact(&res, &normal).is_some());
+    assert!(
+        find_fact(&res, &superseded).is_none(),
+        "superseded fact must be excluded by default"
+    );
+
+    let opts = RecallOptions {
+        include_superseded: true,
+        ..read_only_opts()
+    };
+    let res2 = cm.recall_facts_ranked("rust async", opts).unwrap();
+    assert!(
+        find_fact(&res2, &superseded).is_some(),
+        "include_superseded must surface the superseded fact"
+    );
+}
+
+#[test]
+fn supersede_fact_real_api_excludes_old_by_default() {
+    // Realistic path: supersede_fact archives + sets superseded_by on `old`.
+    let mut cm = make_cm();
+    let old = cm
+        .store_fact("topic", "rust async old fact", 0.8, "", None, None)
+        .unwrap();
+    let new = cm
+        .store_fact("topic", "rust async new fact", 0.9, "", None, None)
+        .unwrap();
+    cm.supersede_fact(&old, &new, "newer info").unwrap();
+
+    let res = cm
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+    assert!(
+        find_fact(&res, &old).is_none(),
+        "superseded old fact excluded"
+    );
+    assert!(find_fact(&res, &new).is_some(), "replacement fact retained");
+}
+
+#[test]
+fn compressed_episodes_excluded() {
+    let mut cm = make_cm();
+    let normal = cm
+        .store_episode("rust async episode normal", "ops", Some(1), None)
+        .unwrap();
+    let compressed = cm
+        .store_episode("rust async episode compressed", "ops", Some(2), None)
+        .unwrap();
+    set_prop(&mut cm, &compressed, "compressed", "true");
+
+    let res = cm
+        .recall_episodes_ranked("rust async", read_only_opts())
+        .unwrap();
+    assert!(find_episode(&res, &normal).is_some());
+    assert!(
+        find_episode(&res, &compressed).is_none(),
+        "compressed episodes are always excluded"
+    );
+}
+
+#[test]
+fn min_confidence_floor_excludes_low_confidence_facts() {
+    // I3: facts below min_confidence are dropped (facts only).
+    let mut cm = make_cm();
+    let low = cm
+        .store_fact("a", "rust async low", 0.2, "", None, None)
+        .unwrap();
+    let high = cm
+        .store_fact("b", "rust async high", 0.9, "", None, None)
+        .unwrap();
+
+    let opts = RecallOptions {
+        min_confidence: 0.5,
+        ..read_only_opts()
+    };
+    let res = cm.recall_facts_ranked("rust async", opts).unwrap();
+    assert!(find_fact(&res, &high).is_some());
+    assert!(find_fact(&res, &low).is_none());
+}
+
+// ===========================================================================
+// 8. Access tracking: record_access + recall side effect (I7, I8, I9)
+// ===========================================================================
+
+#[test]
+fn record_access_increments_usage_and_sets_last_accessed() {
+    // I8: single op bumps usage_count by one and sets last_accessed_at.
+    let mut cm = make_cm();
+    let id = cm
+        .store_fact("topic", "rust async fact", 0.7, "", None, None)
+        .unwrap();
+
+    let before = get_fact(&cm, &id);
+    assert_eq!(before.usage_count, 0);
+    assert!(before.last_accessed_at.is_none());
+
+    cm.record_access(&id, AccessKind::Recall).unwrap();
+
+    let after = get_fact(&cm, &id);
+    assert_eq!(after.usage_count, 1);
+    assert!(after.last_accessed_at.is_some());
+}
+
+#[test]
+fn record_access_read_kind_also_increments() {
+    let mut cm = make_cm();
+    let id = cm
+        .store_fact("topic", "rust async fact", 0.7, "", None, None)
+        .unwrap();
+    cm.record_access(&id, AccessKind::Read).unwrap();
+    assert_eq!(get_fact(&cm, &id).usage_count, 1);
+}
+
+#[test]
+fn record_access_missing_node_is_storage_error() {
+    let mut cm = make_cm();
+    let err = cm
+        .record_access("does-not-exist", AccessKind::Recall)
+        .unwrap_err();
+    assert!(
+        matches!(err, MemoryError::Storage(_)),
+        "missing node must yield Storage, got {err:?}"
+    );
+}
+
+#[test]
+fn recall_records_access_for_returned_items_when_enabled() {
+    // I9: with record_access=true, each returned item is bumped exactly once,
+    // and the *returned* item carries the pre-bump value.
+    let mut cm = make_cm();
+    let id = cm
+        .store_fact("topic", "rust async fact", 0.7, "", None, None)
+        .unwrap();
+
+    let opts = RecallOptions {
+        record_access: true,
+        ..RecallOptions::default()
+    };
+    let res = cm.recall_facts_ranked("rust async", opts).unwrap();
+    let returned = find_fact(&res, &id).expect("fact returned");
+    assert_eq!(returned.item.usage_count, 0, "returned item is pre-bump");
+
+    // The stored node, however, has been incremented.
+    assert_eq!(get_fact(&cm, &id).usage_count, 1);
+}
+
+#[test]
+fn recall_does_not_record_access_when_disabled() {
+    // I7: record_access=false is a pure read — no mutation.
+    let mut cm = make_cm();
+    let id = cm
+        .store_fact("topic", "rust async fact", 0.7, "", None, None)
+        .unwrap();
+
+    let _ = cm
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+    let after = get_fact(&cm, &id);
+    assert_eq!(after.usage_count, 0);
+    assert!(after.last_accessed_at.is_none());
+}
+
+// ===========================================================================
+// 9. Tenant isolation (I12, A2/A3/A4)
+// ===========================================================================
+
+#[test]
+fn cross_agent_recall_excludes_foreign_node() {
+    // A node carrying a different agent_id in the same store must never be
+    // returned by this agent's ranked recall (A2).
+    let mut cm = make_cm();
+    let foreign = cm
+        .store_fact("foreign", "rust async foreign secret", 0.9, "", None, None)
+        .unwrap();
+    set_prop(&mut cm, &foreign, "agent_id", "intruder");
+
+    let res = cm
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+    assert!(
+        find_fact(&res, &foreign).is_none(),
+        "foreign-agent node must be excluded"
+    );
+}
+
+#[test]
+fn cross_agent_record_access_denied_and_leaves_node_unchanged() {
+    // A4: record_access on a node owned by another agent returns
+    // SecurityViolation and performs no write.
+    let mut cm = make_cm();
+    let owner = cm.agent_name().to_string();
+    let foreign = cm
+        .store_fact("foreign", "rust async foreign", 0.9, "", None, None)
+        .unwrap();
+    set_prop(&mut cm, &foreign, "agent_id", "intruder");
+
+    let err = cm.record_access(&foreign, AccessKind::Recall).unwrap_err();
+    assert!(
+        matches!(err, MemoryError::SecurityViolation(_)),
+        "cross-agent access must be a SecurityViolation, got {err:?}"
+    );
+
+    // Reclaim ownership only to read state back and prove nothing was written.
+    set_prop(&mut cm, &foreign, "agent_id", &owner);
+    let after = get_fact(&cm, &foreign);
+    assert_eq!(after.usage_count, 0, "no usage bump on denied access");
+    assert!(after.last_accessed_at.is_none());
+}
+
+#[test]
+fn cross_agent_neighbor_contributes_zero_graph_score() {
+    // A3: a SIMILAR_TO neighbor owned by another agent must not contribute to
+    // the graph term, even though it matches the query.
+    let mut cm = make_cm();
+    // anchor has no textual overlap with the query.
+    let anchor = cm
+        .store_fact("anchor", "banana smoothie recipe", 0.0, "", None, None)
+        .unwrap();
+    // rich strongly matches the query.
+    let rich = cm
+        .store_fact("rich", "rust async rust async tokio", 0.0, "", None, None)
+        .unwrap();
+    cm.link_similar_facts(&anchor, &rich, 0.9).unwrap();
+
+    let opts = RecallOptions {
+        max_graph_hops: 1,
+        ..read_only_opts()
+    };
+
+    // Baseline: rich is owned by this agent -> anchor gets a graph boost.
+    let owned = cm.recall_facts_ranked("rust async", opts.clone()).unwrap();
+    let anchor_owned = find_fact(&owned, &anchor).unwrap();
+    assert!(
+        has_reason(&anchor_owned.reasons, "graph"),
+        "owned neighbor should produce a graph reason"
+    );
+    let owned_score = anchor_owned.score;
+
+    // Now make rich foreign: anchor's graph term must drop to zero.
+    set_prop(&mut cm, &rich, "agent_id", "intruder");
+    let foreign = cm.recall_facts_ranked("rust async", opts).unwrap();
+    let anchor_foreign = find_fact(&foreign, &anchor).unwrap();
+    assert!(
+        !has_reason(&anchor_foreign.reasons, "graph"),
+        "foreign neighbor must not contribute a graph reason"
+    );
+    assert!(
+        anchor_foreign.score < owned_score,
+        "foreign neighbor must lower anchor score: {} !< {}",
+        anchor_foreign.score,
+        owned_score
+    );
+}
+
+// ===========================================================================
+// 10. Hostile floats never panic (I13, V3)
+// ===========================================================================
+
+#[test]
+fn nan_weight_does_not_panic() {
+    let mut cm = make_cm();
+    cm.store_fact("a", "rust async one", 0.9, "", None, None)
+        .unwrap();
+    cm.store_fact("b", "rust async two", 0.5, "", None, None)
+        .unwrap();
+
+    let opts = RecallOptions {
+        weights: RecallWeights {
+            text_relevance: f64::NAN,
+            ..RecallWeights::default()
+        },
+        ..read_only_opts()
+    };
+    let res = cm.recall_facts_ranked("rust async", opts).unwrap();
+    assert!(res.len() <= RecallOptions::default().limit);
+}
+
+#[test]
+fn nan_half_life_does_not_panic() {
+    let mut cm = make_cm();
+    cm.store_fact("a", "rust async one", 0.9, "", None, None)
+        .unwrap();
+
+    let opts = RecallOptions {
+        recency_half_life_seconds: f64::NAN,
+        ..read_only_opts()
+    };
+    // Must return Ok without panicking.
+    let _ = cm.recall_facts_ranked("rust async", opts).unwrap();
+}
+
+// ===========================================================================
+// 11. Backward compatibility (I1) — existing keyword search unaffected
+// ===========================================================================
+
+#[test]
+fn search_facts_still_keyword_only_and_confidence_sorted() {
+    // Ranked recall is purely additive: search_facts keeps its old semantics.
+    let mut cm = make_cm();
+    cm.store_fact("rust", "rust systems language", 0.95, "", None, None)
+        .unwrap();
+    cm.store_fact("python", "python interpreted", 0.9, "", None, None)
+        .unwrap();
+
+    let hits = cm.search_facts("rust", 10, 0.0);
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].concept, "rust");
+}
+
+// ===========================================================================
+// 12. Persistent backend: durability across reopen (I8, I10)
+// ===========================================================================
+
+#[cfg(feature = "persistent")]
+fn temp_db_path() -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("ranked.ladybug");
+    (tmp, path)
+}
+
+#[cfg(feature = "persistent")]
+#[test]
+fn record_access_persists_across_reopen() {
+    let (_tmp, path) = temp_db_path();
+
+    let id = {
+        let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+        let id = cm
+            .store_fact("topic", "rust async durable", 0.8, "", None, None)
+            .unwrap();
+        cm.record_access(&id, AccessKind::Recall).unwrap();
+        cm.checkpoint().unwrap();
+        cm.close();
+        id
+    };
+
+    let cm2 = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+    let fact = cm2
+        .get_all_facts(100)
+        .into_iter()
+        .find(|f| f.node_id == id)
+        .expect("fact survived reopen");
+    assert_eq!(fact.usage_count, 1, "usage_count must persist");
+    assert!(
+        fact.last_accessed_at.is_some(),
+        "last_accessed_at must persist"
+    );
+}
+
+#[cfg(feature = "persistent")]
+#[test]
+fn ranked_recall_orders_results_on_persistent_backend() {
+    let (_tmp, path) = temp_db_path();
+    let mut cm = CognitiveMemory::open_persistent(&path, "agent").unwrap();
+
+    cm.store_fact("match", "rust async tokio", 0.9, "", None, None)
+        .unwrap();
+    cm.store_fact("other", "banana smoothie", 0.1, "", None, None)
+        .unwrap();
+
+    let res = cm
+        .recall_facts_ranked("rust async", RecallOptions::default())
+        .unwrap();
+    assert!(!res.is_empty());
+    assert_eq!(
+        res[0].item.concept, "match",
+        "best keyword match ranks first"
+    );
+    for s in &res {
+        assert!(!s.reasons.is_empty());
+    }
+}
+
+#[cfg(feature = "persistent")]
+#[test]
+fn cross_agent_isolation_on_shared_persistent_store() {
+    // Two agents share one durable store; agent A must not see agent B's facts,
+    // and record_access on B's node is denied.
+    let (_tmp, path) = temp_db_path();
+
+    let b_id = {
+        let mut cm_b = CognitiveMemory::open_persistent(&path, "agent-b").unwrap();
+        let id = cm_b
+            .store_fact("secret", "rust async confidential", 0.9, "", None, None)
+            .unwrap();
+        cm_b.checkpoint().unwrap();
+        cm_b.close();
+        id
+    };
+
+    let mut cm_a = CognitiveMemory::open_persistent(&path, "agent-a").unwrap();
+    cm_a.store_fact("mine", "rust async public", 0.9, "", None, None)
+        .unwrap();
+
+    let res = cm_a
+        .recall_facts_ranked("rust async", read_only_opts())
+        .unwrap();
+    assert!(
+        res.iter().all(|s| s.item.node_id != b_id),
+        "agent A must not recall agent B's fact"
+    );
+
+    let err = cm_a.record_access(&b_id, AccessKind::Recall).unwrap_err();
+    assert!(
+        matches!(err, MemoryError::SecurityViolation(_)),
+        "record_access on B's node must be denied, got {err:?}"
+    );
+}

--- a/rust/amplihack-memory/src/lib.rs
+++ b/rust/amplihack-memory/src/lib.rs
@@ -152,6 +152,10 @@ pub use cognitive_memory::{
     compute_content_hash, DedupAction, DedupMode, DedupOptions, DuplicateFactGroup, FactInput,
     ProvenanceOptions, PruneReport, RetentionPolicy, StoreFactOutcome,
 };
+/// Ranked-recall scoring types and pure scoring primitives.
+pub use cognitive_memory::{
+    exp_decay, keyword_jaccard, usage_boost, AccessKind, RecallOptions, RecallWeights, Scored,
+};
 /// Automatic `SIMILAR_TO` linking options and report types.
 pub use cognitive_memory::{SimilarityOptions, SimilarityReport, StoreFactOptions};
 /// Backend selector and memory connector entry point.


### PR DESCRIPTION
## Summary

Adds a **scored / ranked recall** path to `CognitiveMemory` alongside the existing keyword-only `search_facts` / `search_episodes_by_keyword` (issue #90). Ranking blends six deterministic signals into one un-normalized score:

```
score(x) = w_text       · keyword_jaccard(q, text(x))
         + w_confidence  · confidence(x)            // facts only; 0 for episodes
         + w_importance  · importance(x)            // facts only; 0 for episodes
         + w_recency     · exp_decay(age(x), half_life)
         + w_usage       · usage_boost(usage_count(x))
         + w_graph       · best_edge_score(x, q, max_graph_hops)
```

So a recent, high-importance, frequently-used fact outranks an old low-confidence keyword match. No embeddings, no network calls — plain arithmetic over fields the crate already stores, plus neighbor overlap over existing `DERIVES_FROM` / `SIMILAR_TO` edges.

## New public API (additive, backward compatible)

- `RecallWeights`, `RecallOptions`, `Scored<T>`, `AccessKind` — with documented `Default`s (`text 1.0, confidence 0.7, importance 0.5, recency 0.4, usage 0.3, graph 0.6`; `limit 10`, `max_graph_hops 1`, `recency_half_life_seconds 604_800`, `record_access true`).
- `CognitiveMemory::recall_facts_ranked(query, RecallOptions) -> Result<Vec<Scored<SemanticFact>>>`
- `CognitiveMemory::recall_episodes_ranked(query, RecallOptions) -> Result<Vec<Scored<EpisodicMemory>>>`
- `CognitiveMemory::record_access(node_id, AccessKind) -> Result<()>` — increments `usage_count` and sets `last_accessed_at`, persisted across reopen.
- Pure scoring primitives `keyword_jaccard`, `exp_decay`, `usage_boost` (re-exported from `lib.rs`).

## Behavior

- **Lifecycle-aware:** archived / superseded facts and compressed episodes excluded unless opted in; `min_confidence` floor (facts only).
- **Access tracking:** ranked recall records a `Recall` access for each returned item (opt out via `record_access: false`); returned items carry the pre-bump value, affecting the *next* call.
- **Graph term:** bounded BFS over `DERIVES_FROM` (facts `Outgoing` / episodes `Incoming`) and `SIMILAR_TO` (`Both`); hops clamped to ≤ 3.
- **Tenant isolation:** agent-scoped candidates *and* neighbors; `record_access` on a foreign node returns `SecurityViolation` with no write.
- **Robust:** NaN-safe ordering via `f64::total_cmp` (never panics on hostile float weights/half-life); `reasons` are numeric/label-only and never leak content or the query.
- **One implementation** serves the in-memory and `--features persistent` (LadybugDB) backends — no schema migration, no `GraphStore` change.

Existing `search_facts` / `get_all_facts` / `search_episodes_by_keyword` signatures and orderings are unchanged.

## Tests (TDD)

`src/cognitive_memory/tests/ranked_tests.rs` — 41 ranked tests covering combined-score ranking, recency decay, usage boost, `DERIVES_FROM` / `SIMILAR_TO` graph boost, lifecycle exclusion + opt-in, access tracking, tenant isolation, NaN safety, and backward compatibility. 3 are `#[cfg(feature = "persistent")]` (durability across reopen + cross-agent isolation on a shared store).

- `cargo test` (default): **all green** (incl. 38 ranked).
- `cargo test --features persistent`: **all green** (incl. all 41 ranked).
- `cargo fmt --check`: clean. `cargo clippy`: no new findings from this change (pre-existing repo lints under a newer local toolchain are untouched).

## Docs

- `docs/ranked_recall.md` — full reference (scoring model, graph term, weight tuning, access tracking, security model, worked tutorial).
- `README.md` — ranked-recall section + module-table update.

Closes #90