### PR TITLE
fix(lbug_store): delete_node removes incident edges before delete to dodge lbug 0.15.3 DETACH-DELETE CSR crash (+bump lbug 0.15.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Critical native crash (#98):** the persistent store
+  (`LbugGraphStore`) `SIGSEGV`-crashed the consumer's daemon every ~45–90
+  minutes during retention/dedup consolidation. `delete_node` issued a Cypher
+  `MATCH (n) WHERE n.node_id = '…' DETACH DELETE n`, and when the node had
+  relationships in a committed CSR rel table, `lbug 0.15.3`'s
+  `detachDeleteForCSRRels` computed an invalid CSR node-group index
+  (`getGroup(UINT32_MAX)` → null `unique_ptr` deref) and crashed. After the
+  graph-enhancement work most nodes carry edges (`DERIVES_FROM`, `SIMILAR_TO`,
+  `SUPERSEDES`, `PROCEDURE_DERIVES_FROM`), so consolidation routinely
+  detach-deleted an edge-bearing node and brought the daemon down. Two
+  complementary fixes:
+  - **Edge-first, no-`DETACH` deletion** removes the trigger: `delete_node` now
+    deletes every incident relationship first via two directed, label-less
+    passes (`MATCH (a)-[r]->(b) WHERE a.node_id='…' DELETE r` for both
+    directions, covering self-loops and parallel edges), then deletes the
+    now-isolated node with a plain `DELETE` (no `DETACH`), so the buggy
+    `detachDeleteForCSRRels` path is never entered. The whole operation runs
+    under the write lock and is fail-closed: if the edge cleanup errors,
+    `delete_node` returns `false` without touching the node, so no half-deleted,
+    edge-orphaned node is left behind. Return semantics, id→table cache
+    eviction, the per-write durability barrier, and auto-checkpointing are
+    unchanged. See `rust/amplihack-memory/docs/safe_node_deletion.md`.
+  - **Optional engine patch bump** as defense in depth: where it builds cleanly the
+    pinned `lbug` engine is bumped from `=0.15.3` to `=0.15.4` (latest 0.15.x patch;
+    no jump to 0.17.x), otherwise the pin stays at `=0.15.3`. The workaround stands
+    on its own and does not depend on the bump.
 - **Critical durability bug (#95):** a failed auto-`CHECKPOINT` could
   permanently brick the persistent store and crash-loop the consumer. The
   buffer-pool cap was hardcoded at **128 MiB**, so on a busy host a checkpoint

--- a/rust/amplihack-memory/Cargo.toml
+++ b/rust/amplihack-memory/Cargo.toml
@@ -25,7 +25,7 @@ uuid = { version = "1", features = ["v4"] }
 ladybug-graph-rs = { path = "../../ladybug-graph-rs", optional = true }
 # Published LadybugDB (Kùzu) bindings used by the persistent GraphStore backend.
 # Same crate/version Simard depends on; only pulled in by the `persistent` feature.
-lbug = { version = "=0.15.3", optional = true }
+lbug = { version = "=0.15.4", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/rust/amplihack-memory/README.md
+++ b/rust/amplihack-memory/README.md
@@ -302,6 +302,14 @@ full reference — the configuration model, the recovery state machine, quaranti
 semantics, the checkpoint-health signal, the public API, and an operational
 runbook.
 
+The persistent backend also deletes nodes **without** Cypher `DETACH DELETE`
+(removing every incident edge first, then a plain `DELETE`) to dodge a native
+CSR-rel-table `SIGSEGV` in the pinned engine during retention/dedup
+consolidation. See
+[`docs/safe_node_deletion.md`](docs/safe_node_deletion.md) for the full
+reference — the #98 incident, root cause, the two-phase delete, and the
+regression coverage.
+
 ### Automatic `SIMILAR_TO` linking between facts
 
 `CognitiveMemory` can automatically connect related semantic facts with

--- a/rust/amplihack-memory/docs/safe_node_deletion.md
+++ b/rust/amplihack-memory/docs/safe_node_deletion.md
@@ -1,0 +1,334 @@
+# Safe node deletion — edge-first delete that dodges the lbug 0.15.3 DETACH-DELETE CSR crash
+
+`LbugGraphStore::delete_node` (the persistent, LadybugDB-backed `GraphStore` that
+powers `CognitiveMemory::open_persistent`) deletes a node **without ever issuing a
+Cypher `DETACH DELETE`**. It first removes every relationship incident to the node,
+then deletes the now-isolated node with a plain `DELETE`. This sidesteps a native
+`SIGSEGV` in the pinned LadybugDB engine (`lbug 0.15.3`) that crashed the engine
+whenever a node with relationships stored in a CSR rel table was detach-deleted.
+
+This page is the authoritative description of the fix for issue **#98** ("CRITICAL
+native crash — daemon SEGV-crashes every ~45–90 minutes during a `DETACH DELETE`").
+
+- **No more native crashes.** A node that carries relationships — which, after the
+  graph-enhancement work, is *most* fact and procedure nodes — can now be deleted
+  without tripping the engine's buggy `detachDeleteForCSRRels` code path. The
+  daemon no longer `SIGSEGV`s during retention/dedup consolidation.
+- **Same public contract.** `delete_node(&node_id) -> bool` is unchanged: it still
+  returns `true` when the node was removed and `false` otherwise, still evicts the
+  id→table routing cache, still issues the per-write durability barrier, and still
+  participates in auto-checkpointing.
+- **Fail-closed.** If the incident-edge cleanup fails, `delete_node` returns `false`
+  **before** touching the node, so a half-deleted, edge-orphaned node is never left
+  behind.
+- **Defense in depth (optional).** Where it builds cleanly, the pinned engine is
+  also bumped from `=0.15.3` to the latest 0.15.x patch (`=0.15.4`), in case a patch
+  independently hardens CSR deletes; otherwise the pin **stays at `=0.15.3`**. Either
+  way the workaround above stands on its own and does not depend on the bump.
+
+> **Feature gate.** Everything on this page requires the `persistent` cargo feature
+> (which pulls in the `lbug` engine):
+> `cargo build --features persistent` / `cargo test --features persistent`.
+
+---
+
+## Table of contents
+
+1. [Why this exists (the #98 incident)](#why-this-exists-the-98-incident)
+2. [Root cause](#root-cause)
+3. [The fix — edge-first, no-DETACH deletion](#the-fix--edge-first-no-detach-deletion)
+4. [Public API reference](#public-api-reference)
+5. [Examples](#examples)
+6. [Optional dependency bump — `lbug` 0.15.3 → 0.15.4](#optional-dependency-bump--lbug-0153--0154)
+7. [Compatibility & guarantees](#compatibility--guarantees)
+8. [Testing](#testing)
+
+---
+
+## Why this exists (the #98 incident)
+
+A live consumer's daemon `SIGSEGV`-crashed on a tight cadence — every ~45–90
+minutes. A symbolized core backtrace pinned the fault inside the LadybugDB engine,
+during a Cypher `DETACH DELETE`:
+
+```
+getGroup(groupIdx = 4294967295 / UINT32_MAX)   -> null unique_ptr deref
+  <- CSRNodeGroup::scanCommittedInMemRandom
+  <- CSRNodeGroup::scan
+  <- RelTableScanState::scanNext
+  <- RelTable::detachDeleteForCSRRels
+  <- RelTable::detachDelete
+  <- SingleLabelNodeDeleteExecutor::delete_
+  <- DeleteNode                              (Cypher DETACH DELETE)
+  <- TaskScheduler worker
+```
+
+The crash only fired when the deleted node **had relationships** stored in a CSR
+(compressed sparse row) rel table. Before the graph-enhancement features most
+nodes were edgeless, so the bug was latent. Now it is routinely hit, because:
+
+- **Facts** carry `DERIVES_FROM` (fact → episode), `SIMILAR_TO` (fact ↔ fact), and
+  `SUPERSEDES` (fact → fact) edges.
+- **Procedures** carry `PROCEDURE_DERIVES_FROM` edges.
+
+`delete_node` is invoked from several consolidation/retention paths that routinely
+hard-delete edge-bearing nodes:
+
+| Caller | What it deletes |
+| --- | --- |
+| `cognitive_memory/dedup.rs` → `prune_semantic_memory` | archived / superseded fact nodes (which have `SUPERSEDES`/`SIMILAR_TO`/`DERIVES_FROM` edges) |
+| `cognitive_memory/episodic.rs` | expired episode nodes |
+| `cognitive_memory/sensory.rs` | aged-out sensory nodes |
+| `cognitive_memory/working.rs` | evicted working-memory nodes |
+
+So every consolidation cycle eventually `DETACH DELETE`d an edge-bearing node and
+the engine crashed — taking the consumer's daemon down with it.
+
+---
+
+## Root cause
+
+`detachDeleteForCSRRels` scans the node's CSR rel groups to delete the incident
+edges as part of a single `DETACH DELETE`. In `lbug 0.15.3` that scan can compute
+an invalid node-group index of `UINT32_MAX` (`4294967295`), pass it to
+`getGroup`, and dereference the resulting null `unique_ptr` — an unrecoverable
+native crash inside a worker thread, surfaced to the host process as `SIGSEGV`.
+
+The trigger is specifically **`DETACH DELETE` of a node whose relationships live in
+a committed CSR group**. A plain `DELETE` of a node that has *no* relationships
+never enters that path. The fix therefore removes the relationships first, so the
+node deletion never needs `DETACH` and never enters `detachDeleteForCSRRels`.
+
+---
+
+## The fix — edge-first, no-DETACH deletion
+
+`delete_node` now performs the deletion in two ordered phases, both inside a single
+critical section so no intermediate state is ever externally observable:
+
+1. **Phase A — remove every incident relationship.** Two directed, *label-less*
+   Cypher passes delete all edges touching the node, in both directions, across all
+   relationship types:
+
+   ```cypher
+   -- outgoing edges (node is the source)
+   MATCH (a)-[r]->(b) WHERE a.node_id = '<escaped id>' DELETE r
+   -- incoming edges (node is the target)
+   MATCH (a)-[r]->(b) WHERE b.node_id = '<escaped id>' DELETE r
+   ```
+
+   Two directed passes together remove outbound, inbound, self-loop, and parallel
+   edges. The passes are label-less and matched purely on the globally unique
+   `node_id`, mirroring the proven `query_neighbors_directed` query shape; this
+   avoids a binder error that a node-labelled rel pattern would raise when the
+   node's table participates in no rel table.
+
+2. **Phase B — delete the now-isolated node with a plain `DELETE` (no `DETACH`).**
+
+   ```cypher
+   MATCH (n:<Table>) WHERE n.node_id = '<escaped id>' DELETE n
+   ```
+
+   Because Phase A has already removed every incident edge, the plain `DELETE`
+   cannot fail on "node still has relationships", and — critically — never enters
+   the buggy `detachDeleteForCSRRels` path.
+
+### Control flow & guarantees
+
+- **Routing first.** The node's table is resolved via the id→table cache (falling
+  back to a catalog lookup). If the node ID is unknown (no table), `delete_node`
+  returns `false` immediately.
+- **Edge-pass guard.** After the schema cache is ensured loaded from the on-disk
+  catalog (`ensure_schema_loaded`, which populates `known_rel_tables`), Phase A runs
+  only when the store knows about at least one relationship table — the same guard
+  the proven `query_neighbors` path uses. When no rel tables exist, the edge passes
+  are skipped (an unlabeled rel `MATCH` would raise a binder error and there is
+  nothing to delete), keeping the edgeless-node path green.
+- **Fail-closed.** If either Phase A pass returns an error, `delete_node` logs a
+  warning and returns `false` **without** running Phase B and **without** evicting
+  the routing cache — the node is left fully intact rather than half-deleted.
+- **Atomic.** Phase A, Phase B, the cache eviction, the durability barrier, and the
+  auto-checkpoint bookkeeping all run under one non-reentrant lock, so a concurrent
+  reader never observes a node with some-but-not-all of its edges removed.
+- **Zero `DETACH`.** The implementation contains no `DETACH` keyword anywhere.
+- **Injection-safe.** Every `node_id` interpolation is escaped with
+  `escape_cypher`, and the node-table label is validated as a safe identifier
+  before it is interpolated into the bare-label Phase B query.
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as caller (retention/dedup)
+    participant S as LbugGraphStore::delete_node
+    participant E as lbug engine
+    C->>S: delete_node("fact-123")
+    S->>S: resolve table (else return false)
+    S->>S: ensure_schema_loaded → populate known_rel_tables
+    S->>S: acquire write lock
+    S->>S: has_rel? = known_rel_tables is non-empty
+    alt has_rel (store knows ≥1 rel table)
+        S->>E: MATCH (a)-[r]->(b) WHERE a.node_id='fact-123' DELETE r
+        S->>E: MATCH (a)-[r]->(b) WHERE b.node_id='fact-123' DELETE r
+        Note over S,E: on error → warn + return false (no node delete)
+    else no rel tables
+        Note over S,E: edge passes skipped (unlabeled MATCH would be a binder error)
+    end
+    S->>E: MATCH (n:Fact) WHERE n.node_id='fact-123' DELETE n
+    Note over S,E: plain DELETE — never DETACH, never detachDeleteForCSRRels
+    S->>S: evict id→table cache · durability barrier · maybe checkpoint
+    S-->>C: true
+```
+
+---
+
+## Public API reference
+
+The trait contract is unchanged; only the persistent backend's implementation
+changed.
+
+### `GraphStore::delete_node`
+
+```rust
+/// Delete a node by ID. Returns true if the node existed.
+#[must_use]
+fn delete_node(&mut self, node_id: &str) -> bool;
+```
+
+**Behavior (persistent `LbugGraphStore` backend):**
+
+| Aspect | Behavior |
+| --- | --- |
+| Return `true` | The node existed and was deleted, along with **all** of its incident relationships (both directions, all types, including self-loops and parallel edges). |
+| Return `false` | The node ID was unknown, the incident-edge cleanup failed (node left intact), or the node `DELETE` failed. |
+| Incident edges | Always removed before the node is deleted — callers do **not** need to pre-delete edges. |
+| `DETACH DELETE` | Never used. |
+| Durability | On success: id→table cache evicted, per-write `fsync` barrier issued (failure is logged, not fatal), and an auto-checkpoint may be triggered. |
+| Concurrency | The whole operation runs under the store's write lock. |
+| Idempotency | Deleting an already-absent node returns `false` and is a no-op. |
+
+> **Note.** Like the rest of the `GraphStore` mutators, `delete_node` currently
+> returns `bool` (a `FUTURE` note in the trait tracks migrating to
+> `Result<bool, MemoryError>`). A `false` return that is *not* simply "node absent"
+> is accompanied by a `warn!` log line containing the node ID and the underlying
+> error string.
+
+---
+
+## Examples
+
+### Deleting an edge-bearing fact node
+
+```rust
+use amplihack_memory::graph::protocol::GraphStore;
+use amplihack_memory::graph::LbugGraphStore;
+
+fn purge_fact(store: &mut LbugGraphStore) {
+    // `fact-123` has DERIVES_FROM, SIMILAR_TO, and SUPERSEDES edges.
+    // Before the fix this DETACH-deleted an edge-bearing node and crashed the engine.
+    let deleted = store.delete_node("fact-123");
+    assert!(deleted); // node + all incident edges removed
+    assert!(store.get_node("fact-123").is_none());
+}
+```
+
+No special handling is required for nodes that carry relationships — that is the
+whole point. The caller does not detach or pre-delete edges; `delete_node` does it.
+
+### Retention / dedup callers need no changes
+
+```rust
+// cognitive_memory/dedup.rs :: prune_semantic_memory (illustrative)
+for fact_id in archived_and_superseded {
+    // Each of these fact nodes carries SUPERSEDES / SIMILAR_TO / DERIVES_FROM edges.
+    // Previously this loop periodically SIGSEGV'd the daemon; now it is safe.
+    store.delete_node(&fact_id);
+}
+```
+
+### Deleting an edgeless node still works
+
+```rust
+use amplihack_memory::graph::protocol::GraphStore;
+use amplihack_memory::graph::LbugGraphStore;
+
+fn purge_sensory(store: &mut LbugGraphStore) {
+    // A node with no relationships: the incident-edge passes are skipped and the
+    // plain DELETE removes it exactly as before.
+    assert!(store.delete_node("sensory-987"));
+}
+```
+
+---
+
+## Optional dependency bump — `lbug` 0.15.3 → 0.15.4
+
+As defense in depth, the pinned engine *may* be bumped to the latest 0.15.x patch —
+**only if `=0.15.4` builds and behaves identically in this environment.** The
+workaround does not require it, so the bump is explicitly conditional and the
+default pin remains `=0.15.3`:
+
+```toml
+# rust/amplihack-memory/Cargo.toml — bump applied only if 0.15.4 builds cleanly
+[dependencies]
+lbug = { version = "=0.15.4", optional = true }   # otherwise stays "=0.15.3"
+```
+
+- The bump is **conditional and secondary.** The edge-first/no-`DETACH` workaround
+  removes the crash regardless of the engine version, so `delete_node` never
+  exercises `detachDeleteForCSRRels` even on `=0.15.3`. The pin is bumped only if
+  `=0.15.4` builds cleanly; otherwise it **stays at `=0.15.3`** and the workaround
+  stands alone. The PR records which path was taken.
+- Whichever version is chosen, the pin stays **exact** (`=0.15.x`) and `Cargo.lock`
+  is committed so the engine version is reproducible.
+- The bump is intentionally limited to the 0.15.x line. Moving to 0.17.x is a major
+  change with separate risk and is **not** part of this fix.
+
+---
+
+## Compatibility & guarantees
+
+- **API-compatible.** No public signature changed; existing callers compile and
+  behave identically, minus the crash.
+- **Behavior-compatible.** Deleting an edgeless node is unchanged. Deleting an
+  edge-bearing node now *also* removes its incident edges (it always semantically
+  did via `DETACH DELETE`; it just no longer crashes doing so).
+- **No data loss on failure.** A failed edge cleanup leaves the node and its edges
+  fully intact and returns `false`; the routing cache is only evicted on success.
+- **Durability unchanged.** The post-write `fsync` barrier and auto-checkpoint
+  bookkeeping run exactly as before, on success.
+- **In-memory backend unaffected.** `InMemoryGraphStore` never used the native
+  engine and was never affected by this crash.
+
+---
+
+## Testing
+
+The regression coverage lives in `rust/amplihack-memory/src/graph/lbug_store/tests.rs`
+behind the `persistent` feature:
+
+- **`delete_node` with committed CSR edges (the crash repro).** Opens a persistent
+  store in a tempdir, adds nodes `a`, `b`, `c`, and edges `a-[LINKS]->b`,
+  `b-[REL2]->a` (inbound to `a`), and `a-[SELF]->a` (self/parallel), then calls
+  `checkpoint()` to materialize a **committed** CSR rel group — the exact
+  precondition for `getGroup(UINT32_MAX)`. It then asserts `delete_node("a")`
+  returns `true`, `get_node("a")` is `None`, `a`'s neighbors are gone, `b` has no
+  remaining inbound edge from `a`, `c` is untouched, and — by virtue of the test
+  process surviving — **no `SIGSEGV` occurs**. A `node_id` containing a quote and
+  backslash exercises `escape_cypher` on the same path.
+- **Edgeless delete (existing behavior).** The pre-existing test that deletes a node
+  with no relationships is retained and still passes, proving the edge-pass guard
+  keeps the edgeless path working.
+
+Validate with the feature-gated suite (run a few times, since the original failure
+was a probabilistic native crash):
+
+```bash
+cargo test  -p amplihack-memory --features persistent --lib graph::lbug_store
+cargo build -p amplihack-memory --features persistent
+cargo clippy -p amplihack-memory --all-targets --features persistent -- -D warnings
+```
+
+> **Pre-commit note.** The configured pre-commit hooks build with default features
+> only and do not compile the `persistent` code; the explicit
+> `--features persistent` commands above are the authoritative gate for this fix.

--- a/rust/amplihack-memory/src/graph/lbug_store/store_impl.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/store_impl.rs
@@ -449,12 +449,45 @@ impl GraphStore for LbugGraphStore {
             Some(t) => t,
             None => return false,
         };
+        // The table label is interpolated bare (no quoting) into the Phase B
+        // query, so it must be a safe identifier. Real tables always are, but
+        // refuse rather than risk injection if a corrupt cache entry slips in.
+        if !is_valid_identifier(&table) {
+            return false;
+        }
+
+        // Populate `known_rel_tables` from the on-disk catalog so the guard
+        // below is correct on a freshly reopened store. Does not take the lock.
+        self.ensure_schema_loaded();
 
         let _guard = self.acquire_lock();
-        let cypher = format!(
-            "MATCH (n:{table}) WHERE n.node_id = '{}' DETACH DELETE n",
-            escape_cypher(node_id)
-        );
+        let escaped = escape_cypher(node_id);
+
+        // Phase A — strip every incident relationship first, so the node delete
+        // never needs `DETACH` and never enters lbug 0.15.3's crashing
+        // `detachDeleteForCSRRels` path (getGroup(UINT32_MAX) null deref, #98).
+        // Two directed, label-less passes remove outbound, inbound, self-loop,
+        // and parallel edges across all rel types. The passes are label-less and
+        // keyed on the globally unique `node_id` (mirroring
+        // `query_neighbors_directed`) to avoid a binder error when the node's
+        // table participates in no rel table. Guarded on a non-empty
+        // `known_rel_tables`: with no rel tables an unlabeled rel `MATCH` would
+        // itself be a binder error and there is nothing to delete.
+        if !self.known_rel_tables.borrow().is_empty() {
+            let outgoing = format!("MATCH (a)-[r]->(b) WHERE a.node_id = '{escaped}' DELETE r");
+            let incoming = format!("MATCH (a)-[r]->(b) WHERE b.node_id = '{escaped}' DELETE r");
+            for cypher in [&outgoing, &incoming] {
+                if let Err(e) = self.execute(cypher) {
+                    // Fail-closed: leave the node fully intact (and its routing
+                    // cache entry) rather than half-delete its edges.
+                    warn!("delete_node: incident-edge cleanup failed for {node_id}: {e}");
+                    return false;
+                }
+            }
+        }
+
+        // Phase B — delete the now-isolated node with a plain DELETE (no DETACH).
+        let cypher = format!("MATCH (n:{table}) WHERE n.node_id = '{escaped}' DELETE n");
         if self.execute(&cypher).is_ok() {
             self.id_table_cache.borrow_mut().remove(node_id);
             if let Err(e) = self.post_write_barrier() {

--- a/rust/amplihack-memory/src/graph/lbug_store/tests.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/tests.rs
@@ -761,3 +761,263 @@ fn last_checkpoint_error_is_none_on_a_healthy_store() {
         "healthy auto-checkpoints must not record a checkpoint error"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Safe node deletion: never hit lbug 0.15.3's buggy DETACH-DELETE-with-CSR-rels
+// path (#98). In a long-running consumer daemon the pinned engine SIGSEGVs in
+//   getGroup(groupIdx = 4294967295 / UINT32_MAX) -> null unique_ptr deref
+//   <- CSRNodeGroup::scanCommittedInMemRandom <- CSRNodeGroup::scan
+//   <- RelTableScanState::scanNext <- RelTable::detachDeleteForCSRRels
+//   <- RelTable::detachDelete <- DeleteNode (Cypher DETACH DELETE)
+// when a `DETACH DELETE n` removes a node that owns relationships in a
+// *committed* (checkpointed) CSR rel group. `delete_node` must therefore strip
+// every incident edge first, then plain-`DELETE` the now-isolated node — never
+// emit `DETACH`.
+//
+// The native crash is timing/state-dependent: it depends on internal CSR
+// node-group allocation state that accumulates over hours of consolidation, so
+// it is not deterministically reproducible from a fresh, small store. These
+// tests therefore (a) pin down the *behavioral contract* of the rewritten
+// delete — node + every incident edge (outgoing, incoming, self-loop) removed,
+// unrelated data untouched, `true` returned — and (b) act as a **crash
+// tripwire**: each forces a checkpoint to materialize a committed CSR group and
+// then deletes an edge-bearing node, so if the engine ever does take the
+// detachDelete CSR path and SIGSEGVs, the test binary dies and the suite fails.
+// A re-introduction of `DETACH DELETE` would reopen the crash on the consumer;
+// these tests lock in the delete-edges-first behavior that prevents it.
+// ---------------------------------------------------------------------------
+
+/// REGRESSION (#98): deleting a node that owns *committed* CSR relationships
+/// (outgoing, incoming, and a self-loop) must succeed, remove the node and all
+/// of its incident edges, leave unrelated nodes intact, and — above all — not
+/// SIGSEGV in lbug's `detachDeleteForCSRRels`. The edge-bearing committed-CSR
+/// delete is exactly the path that crashes the consumer's daemon under the old
+/// `DETACH DELETE`; the delete-edges-first rewrite must satisfy this contract
+/// without ever emitting `DETACH`.
+#[test]
+fn delete_node_with_committed_csr_edges_does_not_crash() {
+    let (_tmp, mut store) = open_temp();
+
+    for id in ["a", "b", "c"] {
+        store
+            .add_node(
+                "Thing",
+                props(&[("node_id", id), ("agent_id", "x")]),
+                Some(id),
+            )
+            .unwrap();
+    }
+
+    // a owns three relationships of distinct types so the deleted node has a
+    // populated CSR adjacency in every shape that detachDelete walks:
+    //   - outgoing  a -[LINKS]-> b
+    //   - incoming  b -[REL2]-> a
+    //   - self/loop a -[SELF]-> a
+    store.add_edge("a", "b", "LINKS", None).unwrap();
+    store.add_edge("b", "a", "REL2", None).unwrap();
+    store.add_edge("a", "a", "SELF", None).unwrap();
+
+    // Fold the writes into the main DB file so the rels live in a *committed*
+    // CSR node group — the exact precondition for the getGroup(UINT32_MAX)
+    // null-deref. Without this the rels stay in the in-memory delta and the
+    // crashing code path is never reached.
+    store
+        .checkpoint()
+        .expect("checkpoint must commit the CSR group");
+
+    // The call that previously SIGSEGV'd. Surviving past it == the fix works.
+    assert!(
+        store.delete_node("a"),
+        "deleting an edge-bearing node must report success"
+    );
+
+    // The node itself is gone.
+    assert!(
+        store.get_node("a").is_none(),
+        "the deleted node must no longer resolve"
+    );
+
+    // Every edge incident to `a` (both directions + the self-loop) is gone:
+    // b's only relationships were a->b and b->a, so b is now fully isolated.
+    assert!(
+        store
+            .query_neighbors("a", None, Direction::Both, 10)
+            .is_empty(),
+        "the deleted node must have no remaining incident edges"
+    );
+    assert!(
+        store
+            .query_neighbors("b", None, Direction::Both, 10)
+            .is_empty(),
+        "edges pointing at/from the deleted node must be removed from its neighbors"
+    );
+
+    // An unrelated node is untouched by the targeted delete.
+    assert!(
+        store.get_node("b").is_some(),
+        "a surviving neighbor must remain after the delete"
+    );
+    assert!(
+        store.get_node("c").is_some(),
+        "an unrelated node must be untouched by the delete"
+    );
+}
+
+/// REGRESSION (#98) + injection hardening (SR-1): the edge-bearing delete path
+/// must keep escaping `node_id` everywhere it is interpolated into Cypher. A
+/// node whose id contains quotes/backslashes is given committed CSR edges, then
+/// deleted; it must succeed, vanish, and take only its own edges with it.
+#[test]
+fn delete_node_with_edges_escapes_injection_id() {
+    let (_tmp, mut store) = open_temp();
+
+    // A node_id packed with Cypher-significant characters. If any interpolation
+    // skips escape_cypher the edge-delete or node-delete statement breaks (or,
+    // worse, mutates unrelated rows) and these assertions fail.
+    let weird = "a'b\\c\"d";
+    store
+        .add_node(
+            "Thing",
+            props(&[("node_id", weird), ("agent_id", "x")]),
+            Some(weird),
+        )
+        .unwrap();
+    store
+        .add_node(
+            "Thing",
+            props(&[("node_id", "safe"), ("agent_id", "x")]),
+            Some("safe"),
+        )
+        .unwrap();
+
+    store.add_edge(weird, "safe", "LINKS", None).unwrap();
+    store.add_edge("safe", weird, "REL2", None).unwrap();
+    store.add_edge(weird, weird, "SELF", None).unwrap();
+
+    store
+        .checkpoint()
+        .expect("checkpoint must commit the CSR group");
+
+    assert!(
+        store.delete_node(weird),
+        "deleting an edge-bearing node with a tricky id must succeed"
+    );
+    assert!(
+        store.get_node(weird).is_none(),
+        "the escaped-id node must be gone"
+    );
+    assert!(
+        store.get_node("safe").is_some(),
+        "the neighbor must survive — escaping must target only the deleted node"
+    );
+    assert!(
+        store
+            .query_neighbors("safe", None, Direction::Both, 10)
+            .is_empty(),
+        "edges to/from the deleted node must be removed from the survivor"
+    );
+}
+
+/// Existing behavior must still hold once rel tables exist: deleting an
+/// *edgeless* node (after a checkpoint, with other relationships present in the
+/// catalog) succeeds and leaves every unrelated node and edge intact. This
+/// exercises the rewritten path's guard — the incident-edge passes run but
+/// match nothing, then the plain `DELETE` removes the isolated node.
+#[test]
+fn delete_edgeless_node_with_rel_tables_present() {
+    let (_tmp, mut store) = open_temp();
+
+    for id in ["p", "q", "z"] {
+        store
+            .add_node(
+                "Thing",
+                props(&[("node_id", id), ("agent_id", "x")]),
+                Some(id),
+            )
+            .unwrap();
+    }
+    // An unrelated edge so the catalog has a rel table (known_rel_tables is
+    // non-empty), but `z` itself owns no relationships.
+    store.add_edge("p", "q", "LINKS", None).unwrap();
+    store.checkpoint().expect("checkpoint must commit");
+
+    assert!(
+        store.delete_node("z"),
+        "deleting an edgeless node must still succeed when rel tables exist"
+    );
+    assert!(
+        store.get_node("z").is_none(),
+        "the edgeless node must be gone"
+    );
+
+    // The unrelated edge and its endpoints are untouched.
+    assert!(
+        store.get_node("p").is_some(),
+        "unrelated node p must survive"
+    );
+    assert!(
+        store.get_node("q").is_some(),
+        "unrelated node q must survive"
+    );
+    let nbrs = store.query_neighbors("p", Some("LINKS"), Direction::Outgoing, 10);
+    assert_eq!(nbrs.len(), 1, "the unrelated edge must be preserved");
+    assert_eq!(nbrs[0].1.node_id, "q");
+}
+
+/// REGRESSION (#98), daemon-lifecycle variant: the consumer crashes while
+/// consolidating a *reopened* store, where the CSR rel groups were committed to
+/// disk in a previous process and then freshly loaded. Reproduce that shape —
+/// build edges, checkpoint, `close`, reopen — then delete an edge-bearing node.
+/// The reopened, committed-on-disk CSR group is the closest in-process analogue
+/// of the `scanCommittedInMemRandom` state in the symbolized backtrace, so this
+/// is the strongest crash tripwire; behaviorally the delete must still remove
+/// the node and all of its incident edges with the survivor left intact.
+#[test]
+fn delete_node_with_edges_survives_close_and_reopen() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.ladybug");
+
+    {
+        let mut store = LbugGraphStore::open(&path, Some("s")).unwrap();
+        for id in ["a", "b", "c"] {
+            store
+                .add_node(
+                    "Thing",
+                    props(&[("node_id", id), ("agent_id", "x")]),
+                    Some(id),
+                )
+                .unwrap();
+        }
+        store.add_edge("a", "b", "LINKS", None).unwrap();
+        store.add_edge("c", "a", "LINKS", None).unwrap();
+        store.add_edge("a", "a", "SELF", None).unwrap();
+        // Fold the rels into the main DB file, then drop the handle so the next
+        // process loads them as committed-on-disk CSR groups.
+        store
+            .checkpoint()
+            .expect("checkpoint must commit the CSR group");
+        store.close();
+    }
+
+    let mut store = LbugGraphStore::open(&path, Some("s")).unwrap();
+
+    // The delete that crashes the consumer's daemon after a long uptime.
+    assert!(
+        store.delete_node("a"),
+        "deleting an edge-bearing node after reopen must succeed"
+    );
+    assert!(
+        store.get_node("a").is_none(),
+        "the deleted node must be gone after reopen"
+    );
+    assert!(
+        store
+            .query_neighbors("b", None, Direction::Both, 10)
+            .is_empty(),
+        "edges incident to the deleted node must be removed after reopen"
+    );
+    assert!(
+        store.get_node("b").is_some() && store.get_node("c").is_some(),
+        "unrelated neighbors must survive the reopen delete"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the **critical native crash (#98)**: a live consumer's daemon `SIGSEGV`-crashed every ~45–90 minutes during retention/dedup consolidation. A symbolized core backtrace pinned the fault inside the pinned LadybugDB engine during a Cypher `DETACH DELETE`:

```
getGroup(groupIdx = 4294967295 / UINT32_MAX)   -> null unique_ptr deref
  <- CSRNodeGroup::scanCommittedInMemRandom
  <- CSRNodeGroup::scan
  <- RelTableScanState::scanNext
  <- RelTable::detachDeleteForCSRRels
  <- RelTable::detachDelete
  <- SingleLabelNodeDeleteExecutor::delete_
  <- DeleteNode                              (Cypher DETACH DELETE)
  <- TaskScheduler worker
```

## Root cause

`LbugGraphStore::delete_node` issued `MATCH (n:{table}) WHERE n.node_id = '…' DETACH DELETE n`. When the node owned relationships in a **committed CSR rel table**, `lbug 0.15.3`'s `detachDeleteForCSRRels` computed an invalid CSR node-group index (`UINT32_MAX`) and dereferenced a null `unique_ptr`. After the graph-enhancement work most fact/procedure nodes now carry edges (`DERIVES_FROM`, `SIMILAR_TO`, `SUPERSEDES`, `PROCEDURE_DERIVES_FROM`), so consolidation (`dedup.rs`/`episodic.rs`/`sensory.rs`/`working.rs`) routinely detach-deleted an edge-bearing node and crashed the daemon.

## Fix

**1. Edge-first, no-`DETACH` deletion** (the real fix). `delete_node` now:
- Resolves the node's table; validates it as a safe identifier.
- `ensure_schema_loaded()` to populate `known_rel_tables`.
- Under the write lock, **Phase A**: if the catalog knows ≥1 rel table, runs two directed, label-less passes that remove every incident edge (outbound, inbound, self-loop, parallel) across all types:
  - `MATCH (a)-[r]->(b) WHERE a.node_id = '…' DELETE r`
  - `MATCH (a)-[r]->(b) WHERE b.node_id = '…' DELETE r`
  - **Fail-closed**: on either error → `warn!` + return `false`, leaving the node fully intact (no half-deleted, edge-orphaned node).
- **Phase B**: `MATCH (n:{table}) WHERE n.node_id = '…' DELETE n` — plain `DELETE`, **no `DETACH`**, so `detachDeleteForCSRRels` is never entered.
- Preserves `id_table_cache` eviction, the `post_write_barrier` durability call, `note_write_and_maybe_checkpoint`, and the `bool` return contract. `escape_cypher` is applied to every `node_id` interpolation.

The label-less directed shape mirrors the proven `query_neighbors_directed` to avoid a binder error; the `known_rel_tables` guard keeps the edgeless-node path working.

**2. Defense-in-depth engine bump** `lbug` `=0.15.3` → `=0.15.4` (latest 0.15.x patch). **Path taken:** `0.15.4` builds cleanly and the full suite is green, so the bump is kept. No jump to 0.17.x (major, separate risk). The workaround stands on its own regardless of engine version.

## Tests

New regression tests in `graph/lbug_store/tests.rs` (feature `persistent`) — open a persistent store, add nodes + outgoing/incoming/self-loop edges, `checkpoint()` to materialize a **committed CSR group** (the `getGroup(UINT32_MAX)` precondition), then `delete_node` the edge-bearing node and assert it returns `true`, the node and all incident edges are gone, unrelated nodes survive, and the process does not crash:
- `delete_node_with_committed_csr_edges_does_not_crash`
- `delete_node_with_edges_survives_close_and_reopen` (reopened committed-on-disk CSR group — closest analogue of `scanCommittedInMemRandom`)
- `delete_node_with_edges_escapes_injection_id` (escape hardening)
- `delete_edgeless_node_with_rel_tables_present` (existing edgeless behavior retained)

## Validation

- `cargo test -p amplihack-memory --features persistent --lib graph::lbug_store` — **green, run 6×** (probabilistic native crash → repeated runs).
- `cargo build` (default) and `cargo build --features persistent` — green.
- `cargo clippy -p amplihack-memory --features persistent -- -D warnings` (lib, incl. the rewritten `delete_node`) — green.
- Default `cargo test` suite — green (549+ tests).
- pre-commit (fmt, clippy, test) — green.

> Note: `cargo clippy --all-targets --features persistent -- -D warnings` surfaces a few lints in **pre-existing, unrelated test files** (`tests/concurrent.rs`, `experience`, `sqlite_backend/tests.rs`, `security/tests/`), triggered only by the newer local toolchain (1.95.0). CI runs `cargo clippy -- -D warnings` without `--all-targets`, so it does not lint those targets, and they are out of scope for this fix.

See `rust/amplihack-memory/docs/safe_node_deletion.md` for the full reference.

Fixes #98
