### PR TITLE
fix(lbug_store): typed per-rel-type scans (drop label-less multi-rel scans) + reproduce #100 CSR rel-delete corruption

### DIFF
--- a/rust/amplihack-memory/src/graph/lbug_store/store_impl.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/store_impl.rs
@@ -180,34 +180,52 @@ impl LbugGraphStore {
         self.get_node(node_id).map(|n| n.node_type)
     }
 
-    /// Fetch neighbors in a single direction with one label-less query.
+    /// Distinct relationship-type names currently known to the catalog, sorted
+    /// for a deterministic scan order.
     ///
-    /// When `edge_type` is `None` every relationship type is matched at once
-    /// (the rel's actual type is recovered from [`lbug::RelVal::get_label_name`]),
-    /// so an N-hop traversal no longer issues one query per rel table per node.
-    fn query_neighbors_directed(
+    /// A rel name can appear in [`known_rel_tables`](LbugGraphStore::known_rel_tables)
+    /// with several `(from, to)` endpoint pairs, but each edge lives in exactly
+    /// one rel table, so deduplicating by name lets a typed fan-out
+    /// (`MATCH (a)-[r:NAME]->(b)`) visit every edge exactly once without the
+    /// double-counting a per-tuple iteration would cause.
+    fn distinct_rel_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .known_rel_tables
+            .borrow()
+            .iter()
+            .map(|(rel, _, _)| rel.clone())
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    /// Fetch neighbors of one rel type in a single direction with a *typed*
+    /// `MATCH (a)-[r:rel_type]->(b)` scan.
+    ///
+    /// `rel_type` must already be a valid identifier (the caller checks);
+    /// it is interpolated bare as a rel label. A typed scan touches a single
+    /// rel table's CSR storage and never enters lbug's multi-rel-table scanner
+    /// — see [`query_neighbors_directed`](Self::query_neighbors_directed).
+    fn query_neighbors_one_type(
         &self,
         node_id: &str,
-        edge_type: Option<&str>,
+        rel_type: &str,
         direction: &str,
         limit: usize,
     ) -> Vec<(GraphEdge, GraphNode)> {
         let lc = limit_clause(limit);
         let escaped = escape_cypher(node_id);
-        let rel_pat = match edge_type {
-            Some(et) => format!("r:{et}"),
-            None => "r".to_string(),
-        };
         let cypher = if direction == "outgoing" {
-            format!("MATCH (a)-[{rel_pat}]->(b) WHERE a.node_id = '{escaped}' RETURN r, b{lc}")
+            format!("MATCH (a)-[r:{rel_type}]->(b) WHERE a.node_id = '{escaped}' RETURN r, b{lc}")
         } else {
-            format!("MATCH (a)-[{rel_pat}]->(b) WHERE b.node_id = '{escaped}' RETURN r, a{lc}")
+            format!("MATCH (a)-[r:{rel_type}]->(b) WHERE b.node_id = '{escaped}' RETURN r, a{lc}")
         };
 
         let rows = match self.query_rows(&cypher) {
             Ok(r) => r,
             Err(e) => {
-                warn!("query_neighbors_directed failed: {e}");
+                warn!("query_neighbors_one_type({rel_type}) failed: {e}");
                 return Vec::new();
             }
         };
@@ -222,15 +240,69 @@ impl LbugGraphStore {
                 _ => continue,
             };
             let edge = match rel_v {
+                // The rel type is fixed by the typed query, so take it from
+                // `rel_type` rather than `RelVal::get_label_name` (which only
+                // mattered for the old label-less multi-table scan).
                 Some(Value::Rel(rv)) => {
-                    let rel_name = rv.get_label_name().clone();
-                    self.rel_val_to_edge(&rv, &rel_name, node_id, direction, &neighbor.node_id)
+                    self.rel_val_to_edge(&rv, rel_type, node_id, direction, &neighbor.node_id)
                 }
                 _ => continue,
             };
             pairs.push((edge, neighbor));
         }
         pairs
+    }
+
+    /// Fetch neighbors in a single direction.
+    ///
+    /// When `edge_type` is `Some(t)` a single typed scan is issued. When it is
+    /// `None` we **fan out one typed scan per known rel type** and union the
+    /// results, instead of issuing a single label-less `MATCH (a)-[r]->(b)`
+    /// across every rel table at once.
+    ///
+    /// A label-less multi-rel-table scan is exactly what drives lbug's
+    /// `RelTableCollectionScanner::scan` / `ScanMultiRelTable` /
+    /// `CSRNodeGroup::scanCommittedInMemRandom` into a `getGroup(UINT32_MAX)`
+    /// null-pointer dereference and SIGSEGVs the process (#100). Each typed
+    /// scan touches a single rel table's CSR and avoids that scanner entirely.
+    /// Because every edge lives in exactly one rel table, the per-type union
+    /// returns each edge exactly once (matching the old single-query result
+    /// set; ordering across rel types was never part of the contract).
+    ///
+    /// Defense-in-depth note (Step 3, #100): skipping node groups whose CSR
+    /// index is the `UINT32_MAX` sentinel before dereferencing is internal to
+    /// lbug's C++ engine and is not exposed to the Rust bindings, so it cannot
+    /// be done here. Avoiding the multi-rel-table scanner via typed scans (this
+    /// function) and keeping `known_rel_tables` the authoritative rel-type list
+    /// is the feasible, durability-neutral mitigation.
+    fn query_neighbors_directed(
+        &self,
+        node_id: &str,
+        edge_type: Option<&str>,
+        direction: &str,
+        limit: usize,
+    ) -> Vec<(GraphEdge, GraphNode)> {
+        match edge_type {
+            Some(et) => self.query_neighbors_one_type(node_id, et, direction, limit),
+            None => {
+                let mut pairs = Vec::new();
+                for rel in self.distinct_rel_names() {
+                    // Catalog names are always valid identifiers; skip anything
+                    // else rather than interpolate an unsafe rel label.
+                    if !is_valid_identifier(&rel) {
+                        continue;
+                    }
+                    pairs.extend(self.query_neighbors_one_type(node_id, &rel, direction, limit));
+                    if pairs.len() >= limit {
+                        break;
+                    }
+                }
+                if limit < pairs.len() {
+                    pairs.truncate(limit);
+                }
+                pairs
+            }
+        }
     }
 }
 
@@ -466,21 +538,34 @@ impl GraphStore for LbugGraphStore {
         // Phase A — strip every incident relationship first, so the node delete
         // never needs `DETACH` and never enters lbug 0.15.3's crashing
         // `detachDeleteForCSRRels` path (getGroup(UINT32_MAX) null deref, #98).
-        // Two directed, label-less passes remove outbound, inbound, self-loop,
-        // and parallel edges across all rel types. The passes are label-less and
-        // keyed on the globally unique `node_id` (mirroring
-        // `query_neighbors_directed`) to avoid a binder error when the node's
-        // table participates in no rel table. Guarded on a non-empty
-        // `known_rel_tables`: with no rel tables an unlabeled rel `MATCH` would
-        // itself be a binder error and there is nothing to delete.
-        if !self.known_rel_tables.borrow().is_empty() {
-            let outgoing = format!("MATCH (a)-[r]->(b) WHERE a.node_id = '{escaped}' DELETE r");
-            let incoming = format!("MATCH (a)-[r]->(b) WHERE b.node_id = '{escaped}' DELETE r");
+        //
+        // Each rel type is deleted with its own *typed* directed passes
+        // (`MATCH (a)-[r:TYPE]->(b) ... DELETE r`) rather than a single
+        // label-less `MATCH (a)-[r]->(b)` across all rel tables: a label-less
+        // multi-rel-table scan is exactly what drives lbug's
+        // `ScanMultiRelTable` / `CSRNodeGroup::scanCommittedInMemRandom` into
+        // the `getGroup(UINT32_MAX)` SEGV (#100). Two directed passes per type
+        // remove outbound, inbound, self-loop, and parallel edges. The passes
+        // are keyed on the globally unique `node_id`. With no rel tables the
+        // distinct-name list is empty, nothing is deleted, and we fall through
+        // to the plain `DELETE` below.
+        for rel in self.distinct_rel_names() {
+            // The rel label is interpolated bare; catalog names are always
+            // valid identifiers. Fail-closed (leave the node and its edges
+            // fully intact) rather than risk injecting an unsafe label.
+            if !is_valid_identifier(&rel) {
+                warn!("delete_node: refusing non-identifier rel type {rel:?} for {node_id}");
+                return false;
+            }
+            let outgoing =
+                format!("MATCH (a)-[r:{rel}]->(b) WHERE a.node_id = '{escaped}' DELETE r");
+            let incoming =
+                format!("MATCH (a)-[r:{rel}]->(b) WHERE b.node_id = '{escaped}' DELETE r");
             for cypher in [&outgoing, &incoming] {
                 if let Err(e) = self.execute(cypher) {
                     // Fail-closed: leave the node fully intact (and its routing
                     // cache entry) rather than half-delete its edges.
-                    warn!("delete_node: incident-edge cleanup failed for {node_id}: {e}");
+                    warn!("delete_node: incident-edge cleanup failed for {node_id} on {rel}: {e}");
                     return false;
                 }
             }
@@ -580,9 +665,12 @@ impl GraphStore for LbugGraphStore {
         self.ensure_schema_loaded();
         let _guard = self.acquire_lock();
 
-        // A label-less / typed-rel MATCH binds against the relevant rel tables;
-        // if none exist (or the requested edge_type is unknown) there are no
-        // neighbors and the unlabeled MATCH would be a binder error, so bail out.
+        // Early-out when there are no matching rel tables: an unknown
+        // `edge_type` or an empty catalog yields no neighbors, and skipping the
+        // scan avoids issuing queries against rel tables that do not exist.
+        // (The neighbor fetch itself now uses typed per-rel-type scans, so the
+        // crashing label-less multi-rel-table path is never taken — see
+        // `query_neighbors_directed`.)
         let has_rel = {
             let rels = self.known_rel_tables.borrow();
             match edge_type {

--- a/rust/amplihack-memory/src/graph/lbug_store/tests.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/tests.rs
@@ -1021,3 +1021,382 @@ fn delete_node_with_edges_survives_close_and_reopen() {
         "unrelated neighbors must survive the reopen delete"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Typed per-rel-type reads (no label-less multi-rel-table scan).
+//
+// One of #100's two symbolized backtraces is a LABEL-LESS read scan:
+//   getGroup(groupIdx = 4294967295 / UINT32_MAX) -> null unique_ptr deref
+//   <- CSRNodeGroup::scanCommittedInMemRandom
+//   <- RelTableCollectionScanner::scan
+//   <- ScanMultiRelTable::getNextTuplesInternal   (MATCH (a)-[r]->(b), no label)
+// i.e. a `MATCH (a)-[r]->(b)` with no rel-type label fans across *every* rel
+// table at once via lbug's multi-rel-table scanner. `query_neighbors(.., None,
+// ..)` / `traverse(.., None, ..)` therefore now issue one *typed* scan per known
+// rel type and union the results, never a single label-less scan.
+//
+// IMPORTANT (see `reproduces_issue_100_csr_delete_corruption` below): the
+// typed-scan rewrite is a hardening, NOT a fix for #100. Bisection shows the
+// CSR group is corrupted (its index set to the UINT32_MAX sentinel) by *deleting
+// relationships out of a committed CSR group* (`delete_edge` / `delete_node`
+// Phase A) interleaved with checkpoints; the `getGroup(UINT32_MAX)` deref then
+// fires on whatever scan next touches that table — a checkpoint flush, a typed
+// read, OR the label-less read above. A label-less read is one possible
+// messenger, not the cause, so removing it does not remove the crash.
+//
+// These tests therefore pin the *behavioral contract* of the typed per-rel-type
+// neighbor read across multiple committed rel tables — every edge of every type
+// returned exactly once, directions correct, unrelated data untouched — and
+// guard against a regression back to a label-less scan. On a small, fresh store
+// the delete-driven corruption does not reproduce, so they also pass cleanly.
+// ---------------------------------------------------------------------------
+
+/// Add a node of `node_type` with the given id (reused across the #100 tests).
+fn add(store: &mut LbugGraphStore, node_type: &str, id: &str) {
+    store
+        .add_node(
+            node_type,
+            props(&[("node_id", id), ("agent_id", "x")]),
+            Some(id),
+        )
+        .unwrap();
+}
+
+/// Distinct edge types present in a neighbor result, sorted.
+fn edge_types(
+    pairs: &[(
+        crate::graph::types::GraphEdge,
+        crate::graph::types::GraphNode,
+    )],
+) -> Vec<String> {
+    let mut v: Vec<String> = pairs.iter().map(|(e, _)| e.edge_type.clone()).collect();
+    v.sort();
+    v.dedup();
+    v
+}
+
+/// Neighbor ids in a result, sorted.
+fn neighbor_ids(
+    pairs: &[(
+        crate::graph::types::GraphEdge,
+        crate::graph::types::GraphNode,
+    )],
+) -> Vec<String> {
+    let mut v: Vec<String> = pairs.iter().map(|(_, n)| n.node_id.clone()).collect();
+    v.sort();
+    v
+}
+
+/// Build the real cognitive-memory rel-table shape used by consolidation:
+/// `f1` is a hub with outgoing edges of three distinct types and one incoming
+/// edge, plus a fourth rel table (`PROCEDURE_DERIVES_FROM`) that exists in the
+/// catalog but does not touch `f1`. All four edge types from the issue are
+/// committed into CSR groups via a checkpoint before the caller scans.
+fn build_committed_multi_rel_hub(store: &mut LbugGraphStore) {
+    for id in ["f1", "f2", "f3"] {
+        add(store, "Fact", id);
+    }
+    add(store, "Episode", "ep1");
+    add(store, "Procedure", "pr1");
+
+    // f1's outgoing CSR adjacency spans three rel tables.
+    store.add_edge("f1", "ep1", "DERIVES_FROM", None).unwrap();
+    store.add_edge("f1", "f2", "SIMILAR_TO", None).unwrap();
+    store.add_edge("f1", "f3", "SUPERSEDES", None).unwrap();
+    // An incoming SIMILAR_TO edge so the label-less Incoming/Both scans have
+    // work to do on a *different* endpoint of the same rel table.
+    store.add_edge("f2", "f1", "SIMILAR_TO", None).unwrap();
+    // A fourth rel table that never touches f1 — the typed fan-out must scan it
+    // (it is a known rel type) yet contribute nothing to f1's neighbors.
+    store
+        .add_edge("pr1", "ep1", "PROCEDURE_DERIVES_FROM", None)
+        .unwrap();
+
+    // Fold every rel table into the main DB file so the scans below run against
+    // *committed* CSR groups — the precondition for scanCommittedInMemRandom.
+    store
+        .checkpoint()
+        .expect("checkpoint must commit the CSR groups");
+}
+
+/// REGRESSION (#100): a label-less neighbor read over a node that owns
+/// *committed* relationships in multiple rel tables must return every incident
+/// edge of every type exactly once (directions correct) and, above all, must
+/// not SIGSEGV in lbug's `ScanMultiRelTable` / `scanCommittedInMemRandom`. This
+/// is the READ analogue of the delete-side #98 tripwire and the exact shape of
+/// backtrace (2) in the issue.
+#[test]
+fn label_less_neighbor_read_over_committed_multi_rel_tables_does_not_crash() {
+    let (_tmp, mut store) = open_temp();
+    build_committed_multi_rel_hub(&mut store);
+
+    // The label-less scans that previously SIGSEGV'd. Surviving == fix works.
+    let out = store.query_neighbors("f1", None, Direction::Outgoing, 100);
+    assert_eq!(
+        edge_types(&out),
+        vec![
+            "DERIVES_FROM".to_string(),
+            "SIMILAR_TO".to_string(),
+            "SUPERSEDES".to_string(),
+        ],
+        "outgoing label-less scan must surface all three outgoing rel types"
+    );
+    assert_eq!(
+        neighbor_ids(&out),
+        vec!["ep1".to_string(), "f2".to_string(), "f3".to_string()],
+        "outgoing label-less scan must reach every outgoing neighbor exactly once"
+    );
+
+    let inc = store.query_neighbors("f1", None, Direction::Incoming, 100);
+    assert_eq!(
+        edge_types(&inc),
+        vec!["SIMILAR_TO".to_string()],
+        "incoming label-less scan must surface the single incoming rel type"
+    );
+    assert_eq!(neighbor_ids(&inc), vec!["f2".to_string()]);
+
+    let both = store.query_neighbors("f1", None, Direction::Both, 100);
+    assert_eq!(
+        both.len(),
+        4,
+        "Both must union outgoing (3) + incoming (1) with no double-count"
+    );
+
+    // A typed scan of one of the involved types must agree with the label-less
+    // union for that type (out f1->f2 + in f2->f1).
+    let typed = store.query_neighbors("f1", Some("SIMILAR_TO"), Direction::Both, 100);
+    assert_eq!(
+        typed.len(),
+        2,
+        "typed SIMILAR_TO Both must see the outgoing and incoming edge"
+    );
+}
+
+/// REGRESSION (#100): a label-less BFS `traverse` (no edge-type filter) walks
+/// the same crashing multi-rel-table read path one hop at a time. It must cross
+/// every rel type, visit every reachable node once, and not SIGSEGV.
+#[test]
+fn label_less_traverse_over_committed_multi_rel_tables_does_not_crash() {
+    let (_tmp, mut store) = open_temp();
+    build_committed_multi_rel_hub(&mut store);
+
+    let result = store.traverse("f1", None, 3, Direction::Outgoing, None);
+    let mut ids: Vec<String> = result.nodes.iter().map(|n| n.node_id.clone()).collect();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "ep1".to_string(),
+            "f1".to_string(),
+            "f2".to_string(),
+            "f3".to_string()
+        ],
+        "label-less traverse must reach every outgoing-reachable node exactly once"
+    );
+}
+
+/// REGRESSION (#100), full consolidation-cycle shape: build a committed
+/// multi-rel-table graph, then run the consumer's hot path — idempotent edge
+/// churn (add then delete an edge), retention (`delete_node` of an edge-bearing
+/// node, exercising the typed Phase-A deletes across committed CSR groups),
+/// another checkpoint — and finally the label-less neighbor/traverse reads that
+/// crash the daemon. The whole sequence must complete without a SIGSEGV and
+/// leave a consistent graph (the deleted node and its edges gone, the rest
+/// intact).
+#[test]
+fn consolidation_cycle_with_label_less_reads_does_not_crash() {
+    let (_tmp, mut store) = open_temp();
+    build_committed_multi_rel_hub(&mut store);
+
+    // Procedure-reinforcement-style idempotent churn: add then drop an edge.
+    store.add_edge("f3", "f2", "SIMILAR_TO", None).unwrap();
+    assert!(store.delete_edge("f3", "f2", "SIMILAR_TO"));
+
+    // Retention: delete an edge-bearing fact (f1 -[SUPERSEDES]-> f3 and
+    // f1 -[SIMILAR_TO]-> f2 ... f3 only owns the inbound SUPERSEDES from f1).
+    // delete_node must strip f3's committed incident edges via typed deletes.
+    assert!(store.delete_node("f3"), "retention delete must succeed");
+
+    // Re-commit so the post-delete graph lives in committed CSR groups too.
+    store.checkpoint().expect("post-retention checkpoint");
+
+    // Label-less reads over the mutated, re-committed multi-rel graph.
+    let out = store.query_neighbors("f1", None, Direction::Outgoing, 100);
+    assert_eq!(
+        edge_types(&out),
+        vec!["DERIVES_FROM".to_string(), "SIMILAR_TO".to_string()],
+        "SUPERSEDES edge to the deleted f3 must be gone; the rest remain"
+    );
+    assert_eq!(
+        neighbor_ids(&out),
+        vec!["ep1".to_string(), "f2".to_string()],
+        "f1's outgoing neighbors after retention are ep1 and f2"
+    );
+    assert!(
+        store.get_node("f3").is_none(),
+        "the retired fact must be gone"
+    );
+
+    // A label-less traverse over the survivors must also stay crash-free.
+    let result = store.traverse("f1", None, 3, Direction::Both, None);
+    assert!(
+        result.nodes.iter().any(|n| n.node_id == "f1"),
+        "traverse must still anchor on the start node"
+    );
+    assert!(
+        !result.nodes.iter().any(|n| n.node_id == "f3"),
+        "the retired fact must not reappear in a traversal"
+    );
+}
+
+/// REGRESSION (#100), daemon-lifecycle variant: the consumer crashes while
+/// consolidating a *reopened* store whose CSR rel groups were committed to disk
+/// in a previous process and freshly loaded — the closest in-process analogue
+/// of the `scanCommittedInMemRandom` state in the symbolized read backtrace.
+/// Build the multi-rel graph, checkpoint, `close`, reopen, then run the
+/// label-less neighbor and traverse reads. They must return the full, correct
+/// neighbor set without a SIGSEGV.
+#[test]
+fn label_less_reads_survive_close_and_reopen_with_committed_csr() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.ladybug");
+
+    {
+        let mut store = LbugGraphStore::open(&path, Some("s")).unwrap();
+        build_committed_multi_rel_hub(&mut store);
+        store.close();
+    }
+
+    let store = LbugGraphStore::open(&path, Some("s")).unwrap();
+
+    // Reads over committed-on-disk CSR groups loaded by a fresh process.
+    let both = store.query_neighbors("f1", None, Direction::Both, 100);
+    assert_eq!(
+        both.len(),
+        4,
+        "reopened label-less Both scan must see all four incident edges"
+    );
+    assert_eq!(
+        edge_types(&both),
+        vec![
+            "DERIVES_FROM".to_string(),
+            "SIMILAR_TO".to_string(),
+            "SUPERSEDES".to_string(),
+        ],
+        "reopened label-less scan must surface every incident rel type"
+    );
+
+    let result = store.traverse("f1", None, 3, Direction::Outgoing, None);
+    assert_eq!(
+        result.nodes.len(),
+        4,
+        "reopened label-less traverse must reach every outgoing-reachable node"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ROOT-CAUSE REPRODUCTION (#100) — currently UNRESOLVED, hence #[ignore]d.
+//
+// Bisection (writes-only OK, writes+label-less-reads OK, writes+DELETES corrupt;
+// and `delete_edge` alone is sufficient) pins the driver of the
+// getGroup(UINT32_MAX) crash to *deleting relationships out of a committed CSR
+// rel group* — `delete_edge` and `delete_node`'s Phase-A edge strip — when
+// interleaved with checkpoints. The CSR node group's index is set to the
+// UINT32_MAX sentinel; the next scan to touch that table dereferences it:
+//   - a CHECKPOINT flush (what this reproduction trips, in a debug build),
+//   - a label-less multi-rel read (issue backtrace 2), or
+//   - DETACH-DELETE's CSR walk (issue backtrace 1).
+// This is version-independent (0.15.3 / 0.15.4 / 0.17.1), i.e. an lbug engine
+// bug in CSR relationship deletion + checkpoint, not something the Rust-side
+// typed-scan rewrite (which only changes *which* scans are issued) can fix.
+//
+// In this DEBUG build lbug surfaces the bad group as an assertion that the
+// bindings return as a recoverable `Storage` error containing
+// "group_collection.h ... groupIdx < groups.size()"; in a RELEASE/NDEBUG build
+// the same condition is the raw null-pointer-deref SIGSEGV that kills the
+// consumer daemon. This test therefore asserts the DESIRED post-fix behavior —
+// the delete+checkpoint churn completes with no CSR-corruption error — and
+// currently FAILS, reproducing the bug. It is #[ignore]d so CI stays green;
+// un-ignore it once the root cause (an lbug fix, or a Rust-side soft-delete /
+// rel-table-rebuild workaround) lands. Do NOT run under `--release`: there it
+// aborts the test binary via SIGSEGV instead of returning an error.
+// ---------------------------------------------------------------------------
+
+/// True if `e` is the #100 CSR `getGroup(UINT32_MAX)` corruption surfaced as a
+/// debug-build assertion error.
+fn is_csr_group_corruption(e: &str) -> bool {
+    e.contains("group_collection.h") && e.contains("groupIdx < groups.size()")
+}
+
+/// Drive the consolidation-style delete + checkpoint churn that corrupts a
+/// committed CSR rel group. Returns `Err(detail)` on the first CSR-corruption
+/// (or other) error, `Ok(())` if the whole sequence stays consistent.
+fn run_csr_delete_churn(rounds: usize) -> Result<(), String> {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("graph.ladybug");
+    let mut store = LbugGraphStore::open(&path, Some("s")).unwrap();
+
+    for id in ["f1", "f2", "f3", "f4", "f5"] {
+        add(&mut store, "Fact", id);
+    }
+    add(&mut store, "Episode", "ep1");
+
+    // Fact->Episode and two Fact->Fact rel tables, mirroring DERIVES_FROM,
+    // SIMILAR_TO and SUPERSEDES in cognitive-memory consolidation.
+    let types = ["DERIVES_FROM", "SIMILAR_TO", "SUPERSEDES"];
+    for round in 0..rounds {
+        let a = format!("f{}", (round % 5) + 1);
+        let b = format!("f{}", ((round + 2) % 5) + 1);
+        let t = types[round % 3];
+        // Idempotent-upsert-style edge add (mismatched type/endpoints are no-ops).
+        let _ = if t == "DERIVES_FROM" {
+            store.add_edge(&a, "ep1", t, None)
+        } else {
+            store.add_edge(&a, &b, t, None)
+        };
+
+        if round % 3 == 0 {
+            store
+                .checkpoint()
+                .map_err(|e| format!("checkpoint(3) at round {round}: {e}"))?;
+        }
+
+        // Retention/dedup: delete an edge-bearing fact, then re-create its id —
+        // the exact per-cycle pattern that drives the committed-CSR corruption.
+        if round % 7 == 0 {
+            let victim = format!("f{}", (round % 5) + 1);
+            let _ = store.delete_node(&victim);
+            add(&mut store, "Fact", &victim);
+        }
+
+        if round % 5 == 0 {
+            store
+                .checkpoint()
+                .map_err(|e| format!("checkpoint(5) at round {round}: {e}"))?;
+        }
+    }
+
+    store
+        .checkpoint()
+        .map_err(|e| format!("final checkpoint: {e}"))?;
+    Ok(())
+}
+
+/// REPRODUCTION (#100, UNRESOLVED): the delete + checkpoint consolidation churn
+/// must complete without corrupting a committed CSR rel group. It currently
+/// does not — the run returns the `getGroup(UINT32_MAX)` corruption error
+/// (debug) / SIGSEGVs (release). #[ignore]d until the root cause is fixed.
+#[test]
+#[ignore = "reproduces unresolved lbug #100 CSR rel-delete corruption; un-ignore when fixed"]
+fn reproduces_issue_100_csr_delete_corruption() {
+    match run_csr_delete_churn(120) {
+        Ok(()) => { /* desired post-fix outcome */ }
+        Err(e) if is_csr_group_corruption(&e) => {
+            panic!(
+                "REPRODUCED #100: committed CSR rel group corrupted by \
+                 relationship deletes + checkpoints (getGroup(UINT32_MAX)): {e}"
+            );
+        }
+        Err(e) => panic!("unexpected error during CSR-delete churn: {e}"),
+    }
+}


### PR DESCRIPTION
## Summary

Addresses #100 (the `getGroup(groupIdx = 4294967295 / UINT32_MAX)` null-deref SEGV in lbug's CSR rel-table scan). This PR delivers the requested **Step 2** typed-scan rewrite **and** — per the issue's own fallback instruction ("if the typed-scan approach does not eliminate the crash, report findings + the reproduction for follow-up rather than claiming a fix") — a **deterministic reproduction that bisects the true root cause**.

> ⚠️ **Honest result up front:** the typed per-rel-type scan rewrite is a correct hardening but **does not eliminate the #100 crash.** Bisection shows the corruption is driven by **deleting relationships out of a committed CSR rel group** (`delete_edge` / `delete_node` Phase A) interleaved with checkpoints — *not* by the label-less read scan. The label-less read is only one of several scans that can later dereference the already-corrupted group.

## What changed (Step 2 + Step 3)

`rust/amplihack-memory/src/graph/lbug_store/store_impl.rs`:
- **`query_neighbors_directed`**: when `edge_type == None`, it now **fans out one typed `MATCH (a)-[r:TYPE]->(b)` scan per distinct known rel type** and unions the results, instead of a single label-less `MATCH (a)-[r]->(b)`. New helpers `query_neighbors_one_type` and `distinct_rel_names`. Edge type is taken from the loop variable (not `RelVal::get_label_name`). Direction/limit/truncate semantics and the write-lock are preserved; every edge lives in exactly one rel table, so the union returns each edge exactly once.
- **`delete_node` Phase A**: the two label-less `DELETE r` passes become **typed per-rel-type passes** (outgoing + incoming per known rel type), fail-closed on a non-identifier rel name. An empty rel set falls through to the plain `DELETE` unchanged.
- **Defense-in-depth (Step 3)**: documented that skipping CSR groups whose index is the `UINT32_MAX` sentinel is internal to lbug's C++ engine and **not reachable from the Rust bindings**; `known_rel_tables` remains the authoritative rel-type source. No durability/recovery changes.

These eliminate the label-less multi-rel-table `ScanMultiRelTable` path (issue backtrace 2) from our read and delete code. They are retained as hardening and locked in by behavioral regression tests.

## Reproduction & root-cause bisection (Step 1)

`rust/amplihack-memory/src/graph/lbug_store/tests.rs`:
- **`reproduces_issue_100_csr_delete_corruption`** (`#[ignore]`d): drives a consolidation-style **delete + checkpoint churn** and deterministically reproduces the exact #100 signature on lbug 0.15.4:

  ```
  Assertion failed in .../storage/table/group_collection.h on line 52:
  groupIdx < groups.size()
  ```
  This is `GroupCollection<ChunkedNodeGroup>::getGroup(UINT32_MAX)`. In this **debug** build lbug surfaces it as a recoverable `Storage` error; in a **release/NDEBUG** build the same condition is the raw null-pointer-deref **SIGSEGV** that kills the consumer daemon. Reproduces at round 10, deterministically across runs.
- Behavioral regression guards for the typed-scan reads: `label_less_neighbor_read_over_committed_multi_rel_tables_does_not_crash`, `label_less_traverse_*`, `consolidation_cycle_with_label_less_reads_*`, `label_less_reads_survive_close_and_reopen_with_committed_csr`.

### Bisection results (patched code, 400-round churn unless noted)

| Scenario | Result |
|---|---|
| writes only (add_edge + checkpoint) | ✅ OK |
| writes + **label-less reads** (`query_neighbors`/`traverse` None) | ✅ OK |
| writes + **deletes** (`delete_node` + re-add) | ❌ CORRUPT (`groupIdx`) |
| writes + reads + deletes (everything) | ❌ CORRUPT (same round as deletes-only) |
| `delete_edge` **alone** (no `delete_node`, no label-less) | ❌ CORRUPT |
| `delete_node` of **edgeless** nodes only | ✅ OK |

**Conclusion:** the corruption source is **physically deleting a relationship from a committed CSR group** (`DELETE r`), not the scan. Adding the label-less reads to the delete churn did not change the corruption round; the typed-scan rewrite (applied in this PR) does not prevent it. This matches the issue's note that the bug reproduces identically on lbug 0.15.3 / 0.15.4 / 0.17.1 — i.e. an lbug CSR rel-delete engine bug, not something the Rust-side scan rewrite can fix.

## Why both issue backtraces fit this root cause

The corrupt CSR group (index = `UINT32_MAX`) is written by a relationship delete; the deref then fires on the **next scan to touch that table**:
- a CHECKPOINT flush (what the reproduction trips),
- DETACH-DELETE's CSR walk → backtrace 1 (pre-#99),
- a label-less multi-rel read → backtrace 2 (post-#99).

The crash "consistently follows the per-cycle procedure-reinforcement step" because that step's dedup/retention deletes edge-bearing facts, corrupting the group that the subsequent consolidation read then dereferences.

## Recommended follow-up (not in this PR — high blast radius)

Eliminate physical `DELETE r` against committed CSR groups. Options to evaluate:
- **Soft-delete / tombstone** edges (and edge-bearing nodes) via a property + read-time filtering, never emitting `DELETE r` / `DELETE n` on relationship-bearing nodes.
- **Rebuild** a rel table (COPY to a fresh table) after a batch of deletions instead of in-place CSR deletes.
- Upstream lbug fix for CSR group-index management on relationship delete + checkpoint.

A spike confirmed a write-only/tombstone churn does not corrupt, so a tombstone architecture is the most promising Rust-side mitigation, but it changes delete semantics/durability and needs its own design + review.

## Validation
- `cargo test -p amplihack-memory --features persistent` — green (611 passed, 1 ignored) across multiple runs; the ignored test is the unresolved reproduction.
- `cargo clippy --lib --features persistent -- -D warnings` — clean for changed code. (Pre-existing, unrelated `--all-targets` lints in `security/tests`, `sqlite_backend/tests`, `tests/concurrent.rs` are not touched here.)
- `pre-commit run` — all hooks pass (fmt, clippy, test).

Refs #100


---

## ✅ Merge-readiness evidence

Driven to merge-ready per the six-gate criteria. Head `e6370e7`.

**(1) QA — internal-only justification.** This is a library-internal change to `LbugGraphStore`'s scan/delete *strategy*; no user-facing API surface or observable behavior changes. `query_neighbors` / `traverse` / `delete_node` keep identical signatures and result sets — a typed per-rel-type fan-out returns the same neighbor set as the prior label-less scan (every edge lives in exactly one rel table), and delete semantics are unchanged. Behavior is covered by `cargo test -p amplihack-memory --features persistent` (611 passed, 1 ignored) — green in CI — plus the four new behavioral regression guards added here that pin the typed-scan contract over committed multi-rel-table CSR groups (including close/reopen). `gadugi-test` scenarios target user-facing agent flows, none of which change; internal-only justification recorded.

**(2) Documentation — internal-only justification.** No user-facing memory-backend docs/README need updating. The swap (label-less multi-rel scan → typed per-rel-type fan-out) is observationally identical for reads and deletes. `docs/safe_node_deletion.md` documents the #98 edge-first/no-`DETACH` delete contract, which remains accurate (deletion is still edge-first with no `DETACH`; only each pass is now typed). The follow-up #100 root-cause fix (tombstone/soft-delete) will carry its own CHANGELOG/doc update where delete *semantics* actually change. Scope intentionally held to the two implementation files (gate 6).

**(3) quality-audit — ≥3 SEEK→VALIDATE→FIX cycles, final cycle clean.** A 3-cycle audit of the full diff was performed and ended clean (zero critical/high; zero medium correctness/security). *(The `quality-audit` skill itself was not invoked because a recipe-managed workflow is active in this session; an equivalent manual multi-cycle audit was conducted.)*
- *Cycle 1 — correctness:* the typed fan-out in `query_neighbors_directed` returns each edge exactly once (dedup-by-name in `distinct_rel_names`; one edge ⇒ one rel table); the per-type `limit` early-break + final `truncate(limit)` preserve the `LIMIT` contract; `delete_node`'s empty-rel-set path falls through to the plain `DELETE` (equivalent to the prior non-empty `known_rel_tables` guard). VALIDATE: new regression tests assert exact neighbor sets/types/directions and pass in CI. No fix needed.
- *Cycle 2 — security/injection:* every catalog-derived rel name is interpolated bare only after an `is_valid_identifier` check (strict `[A-Za-z_][A-Za-z0-9_]*`) — fail-closed (`return false`) in `delete_node`, skip in reads; `node_id` literals are escaped via `escape_cypher`. No new injection surface vs. baseline (the `Some(edge_type)` path interpolates identically to the prior code). No fix needed.
- *Cycle 3 — resource/panic safety:* `distinct_rel_names` drops its `RefCell` borrow before the scan loop (the loop iterates an owned `Vec<String>`), so there is no re-entrant `borrow()` panic; the per-type fan-out adds O(#rel types) bounded queries (≤4 in the cognitive-memory schema). No fix needed.
- *Final cycle:* clean.

**(4) CI 100% green.** All 4 checks pass on `e6370e7`: GitGuardian, MSRV (1.85), Python Tests, Rust Tests & Lints (9m10s). Run: https://github.com/rysweet/amplihack-memory-lib/actions/runs/27961141826

**(6) Focused diff.** Exactly two files: `rust/amplihack-memory/src/graph/lbug_store/store_impl.rs` (+117/−29) and `rust/amplihack-memory/src/graph/lbug_store/tests.rs` (+379/−0). No unrelated edits.

> Note: this PR **hardens** the read/delete paths and lands a deterministic root-cause reproduction (kept `#[ignore]`d so CI stays green); it does **not** fix the underlying lbug CSR rel-delete corruption (#100). The real durable-recall fix (tombstone/soft-delete + read-time filtering) follows in a focused follow-up PR that un-ignores `reproduces_issue_100_csr_delete_corruption`.
