### PR TITLE
fix(lbug_store): rebuild rel tables on delete to fix lbug CSR getGroup(UINT32_MAX) SEGV (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Critical native crash (#100):** the persistent store (`LbugGraphStore`)
+  `SIGSEGV`-crashed the consumer's daemon every ~45–90 minutes during
+  retention/dedup consolidation, in the same `getGroup(UINT32_MAX)` null-pointer
+  dereference family as #98. Bisection pinned the root cause to **deleting
+  relationships in place out of a *committed* CSR rel group** (`delete_edge`, and
+  `delete_node`'s incident-edge strip) while checkpoints are interleaved: that
+  sets the CSR node-group index to the `UINT32_MAX` sentinel, and the next scan or
+  checkpoint to touch the table dereferences it (debug: a recoverable
+  `group_collection.h ... groupIdx < groups.size()` assertion; release: a raw
+  `SIGSEGV`). It is **version-independent** (reproduced on lbug `0.15.3`, `0.15.4`,
+  and `0.17.1`), i.e. an engine bug not fixable by changing *which* scans are
+  issued. Two complementary changes:
+  - **Rebuild-on-delete** removes the trigger: `delete_edge` and `delete_node`'s
+    Phase-A edge strip never issue an in-place `DELETE r` against a committed CSR
+    group. To drop a set of edges from a rel table they **rebuild** it — snapshot
+    the surviving edges (endpoint ids + every column), build a
+    `<rel>__rebuild_tmp` scratch table, `fsync`, then `DROP` the original and
+    `RENAME` the scratch over it. The original is kept fully intact until the
+    replacement is durable, so no acknowledged edge is lost; a crash in the
+    one-statement rename window leaves a `__rebuild_tmp` table that the next open
+    recovers (promote if the canonical is missing, else drop). Edgeless nodes keep
+    the plain-`DELETE` fast path (bisection: deleting an edgeless node is safe), and
+    only rel tables a node is incident to are rebuilt, so the common
+    working-/sensory-memory eviction path rebuilds nothing.
+  - **Typed per-rel-type read scans** as read-side hardening: every label-less
+    multi-rel-table `MATCH (a)-[r]->(b)` in the read hot path (`query_neighbors` /
+    `traverse` with no edge type) now fans out one typed `MATCH (a)-[r:TYPE]->(b)`
+    scan per known rel type and unions the results, so the backend never enters
+    lbug's multi-rel-table scanner (#100's second crash backtrace).
+
+  No `GraphStore` trait or public-API change; durability/recovery is preserved and
+  extended. See `rust/amplihack-memory/docs/csr_rel_delete_corruption.md`.
 - **Critical native crash (#98):** the persistent store
   (`LbugGraphStore`) `SIGSEGV`-crashed the consumer's daemon every ~45–90
   minutes during retention/dedup consolidation. `delete_node` issued a Cypher

--- a/rust/amplihack-memory/README.md
+++ b/rust/amplihack-memory/README.md
@@ -310,6 +310,16 @@ consolidation. See
 reference — the #98 incident, root cause, the two-phase delete, and the
 regression coverage.
 
+As a follow-up (#100), every label-less multi-rel-table scan in the persistent
+hot path — neighbor reads, traversals, and the delete edge-strip — now issues
+**typed, per-rel-type** scans (`MATCH (a)-[r:TYPE]->(b)`), so the backend never
+drives lbug's multi-rel-table scanner. This is hardening, not a complete fix: the
+underlying `getGroup(UINT32_MAX)` CSR corruption is an **unresolved**, version-
+independent lbug engine bug in committed-CSR relationship deletion plus
+checkpointing. See
+[`docs/csr_rel_delete_corruption.md`](docs/csr_rel_delete_corruption.md) for the
+two backtraces, the bisecting reproduction, and follow-up options.
+
 ### Automatic `SIMILAR_TO` linking between facts
 
 `CognitiveMemory` can automatically connect related semantic facts with

--- a/rust/amplihack-memory/README.md
+++ b/rust/amplihack-memory/README.md
@@ -310,15 +310,19 @@ consolidation. See
 reference — the #98 incident, root cause, the two-phase delete, and the
 regression coverage.
 
-As a follow-up (#100), every label-less multi-rel-table scan in the persistent
-hot path — neighbor reads, traversals, and the delete edge-strip — now issues
-**typed, per-rel-type** scans (`MATCH (a)-[r:TYPE]->(b)`), so the backend never
-drives lbug's multi-rel-table scanner. This is hardening, not a complete fix: the
-underlying `getGroup(UINT32_MAX)` CSR corruption is an **unresolved**, version-
-independent lbug engine bug in committed-CSR relationship deletion plus
-checkpointing. See
+A follow-up (#100) fixes the underlying `getGroup(UINT32_MAX)` CSR corruption — a
+version-independent lbug engine bug triggered by deleting relationships **in
+place** out of a *committed* CSR rel group plus checkpointing. `delete_edge` and
+`delete_node`'s incident-edge strip no longer issue an in-place `DELETE r`; they
+**rebuild** the affected rel table (copy the survivors into a scratch table and
+atomically swap it in), so the corrupting operation never runs. As additional
+read-side hardening, every label-less multi-rel-table scan in the persistent hot
+path (neighbor reads, traversals) now issues **typed, per-rel-type** scans
+(`MATCH (a)-[r:TYPE]->(b)`), so the backend never drives lbug's multi-rel-table
+scanner either. See
 [`docs/csr_rel_delete_corruption.md`](docs/csr_rel_delete_corruption.md) for the
-two backtraces, the bisecting reproduction, and follow-up options.
+two backtraces, the rebuild design and its crash recovery, and the regression
+coverage.
 
 ### Automatic `SIMILAR_TO` linking between facts
 

--- a/rust/amplihack-memory/docs/csr_rel_delete_corruption.md
+++ b/rust/amplihack-memory/docs/csr_rel_delete_corruption.md
@@ -1,22 +1,21 @@
-# CSR rel-delete corruption — typed per-rel-type scans (#100) and the unresolved `getGroup(UINT32_MAX)` root cause
+# CSR rel-delete corruption (#100) — rebuild-on-delete + typed per-rel-type scans
 
-Issue **#100** is a native `SIGSEGV` in the pinned LadybugDB engine, the same
+Issue **#100** was a native `SIGSEGV` in the pinned LadybugDB engine, the same
 `getGroup(UINT32_MAX)` null-pointer dereference family as the
-[`DETACH DELETE` crash](safe_node_deletion.md) (#98). This page documents the
-**two** things the #100 work delivered:
+[`DETACH DELETE` crash](safe_node_deletion.md) (#98). It crashed the consumer
+daemon every ~45–90 min during retention/dedup consolidation.
 
-1. A **read-side + delete-side hardening** — every label-less multi-rel-table
-   scan in the `lbug_store` hot path was replaced with **typed, per-rel-type
-   scans**, so amplihack-memory never drives lbug's multi-rel-table scanner.
-2. A faithful, bisecting **reproduction** that pins the *actual* root cause to an
-   lbug **engine** bug: deleting relationships out of a *committed* CSR rel group
-   while interleaving checkpoints. That root cause is **not yet resolved**; the
-   typed-scan rewrite is hardening, **not** a fix.
+The #100 work delivered **two** complementary changes:
 
-> **Read this first.** The typed-scan rewrite removes one of #100's two crash
-> *messengers* and is worth keeping, but it does **not** make `delete_edge` /
-> retention deletes safe on its own. The unresolved engine bug and its follow-up
-> options are in [§4](#4-the-unresolved-root-cause) and [§5](#5-follow-up).
+1. **The fix — rebuild-on-delete.** `delete_edge` and `delete_node`'s incident-edge
+   strip no longer issue an in-place `DELETE r` against a committed CSR rel group
+   (the operation that corrupts the group). They instead **rebuild** the affected
+   rel table: copy the surviving edges into a scratch table and atomically swap it
+   in. This removes the corrupting operation entirely.
+2. **Read-side hardening — typed per-rel-type scans.** Every label-less
+   multi-rel-table scan in the `lbug_store` read hot path was replaced with
+   **typed, per-rel-type scans**, so amplihack-memory never drives lbug's
+   multi-rel-table scanner (one of #100's two crash backtraces).
 
 > **Feature gate.** Everything here requires the `persistent` cargo feature
 > (which pulls in the `lbug` engine):
@@ -27,11 +26,12 @@ Issue **#100** is a native `SIGSEGV` in the pinned LadybugDB engine, the same
 ## Table of contents
 
 1. [The two #100 backtraces](#1-the-two-100-backtraces)
-2. [The hardening — typed per-rel-type scans](#2-the-hardening--typed-per-rel-type-scans)
-3. [What did *not* change](#3-what-did-not-change)
-4. [The unresolved root cause](#4-the-unresolved-root-cause)
-5. [Follow-up](#5-follow-up)
-6. [Testing](#6-testing)
+2. [The root cause](#2-the-root-cause)
+3. [The fix — rebuild-on-delete](#3-the-fix--rebuild-on-delete)
+4. [Read-side hardening — typed per-rel-type scans](#4-read-side-hardening--typed-per-rel-type-scans)
+5. [What did *not* change](#5-what-did-not-change)
+6. [Trade-offs and follow-up](#6-trade-offs-and-follow-up)
+7. [Testing](#7-testing)
 
 ---
 
@@ -67,17 +67,104 @@ once via lbug's multi-rel-table scanner. The `lbug_store` read path
 (`query_neighbors(.., None, ..)` and the `traverse(.., None, ..)` BFS that calls
 it) used to emit exactly this shape.
 
+Both backtraces are only *messengers*: they dereference a CSR group whose index
+has **already** been set to the `UINT32_MAX` sentinel. The corruption happens
+earlier — see §2.
+
 ---
 
-## 2. The hardening — typed per-rel-type scans
+## 2. The root cause
 
-The fix removes **every** label-less rel `MATCH` from the `lbug_store` hot path
-(`src/graph/lbug_store/store_impl.rs`) and replaces each with a typed
+A bisecting reproduction (`run_csr_delete_churn` in
+`src/graph/lbug_store/tests.rs`) isolates the trigger:
+
+| Workload | Outcome |
+| --- | --- |
+| writes only | OK |
+| writes + label-less reads | OK |
+| writes + **deletes** (interleaved with checkpoints) | **CORRUPT** |
+| `delete_edge` alone | sufficient to corrupt |
+| deleting **edgeless** nodes | safe |
+
+The driver is **deleting relationships out of a *committed* CSR rel group**
+(`delete_edge`, and `delete_node`'s Phase-A edge strip) while checkpoints are
+interleaved. That sets the CSR node group's index to the `UINT32_MAX` sentinel;
+the **next** scan to touch that table dereferences it — a checkpoint flush, a
+typed read, *or* the label-less read of backtrace 2.
+
+This is **version-independent** — reproduced on lbug `0.15.3`, `0.15.4`, and
+`0.17.1` — i.e. an engine bug in committed-CSR relationship deletion plus
+checkpointing. Skipping a CSR node group whose index is the `UINT32_MAX` sentinel
+*before* dereferencing it would be the direct engine fix, but that check lives
+inside lbug's C++ and is not exposed to the Rust bindings. The feasible Rust-side
+fix is therefore to **never perform the corrupting operation** — see §3.
+
+**Debug vs release surfacing.** In a debug/assertions build lbug reports the bad
+group as a *recoverable* `Storage` error from the bindings containing
+`group_collection.h ... groupIdx < groups.size()`. In a release/NDEBUG build the
+same condition is the raw null-pointer-deref `SIGSEGV` that killed the consumer
+daemon.
+
+---
+
+## 3. The fix — rebuild-on-delete
+
+`delete_edge` and `delete_node`'s incident-edge strip never delete relationship
+rows in place. To remove a set of edges from rel table `T`, they **rebuild** `T`:
+
+1. **Snapshot survivors** — `MATCH (a)-[r:T]->(b) WHERE <keep>` returns the
+   endpoint ids and every (`STRING`) column of the edges that must *survive*
+   (`<keep>` is "not incident to the deleted node", or "not the deleted edge").
+2. **Build a scratch table** — `CREATE REL TABLE T__rebuild_tmp(FROM … TO …, …)`
+   and re-insert the survivors into it. The original `T` is still fully intact.
+3. **fsync** — the durability barrier makes the scratch table durable while the
+   original still holds every edge, so a crash here loses nothing (the delete
+   simply has not happened yet).
+4. **Swap** — `DROP TABLE T; ALTER TABLE T__rebuild_tmp RENAME TO T;` then fsync.
+
+This is implemented in `LbugGraphStore::rebuild_rel_table_keeping`
+(`src/graph/lbug_store/mod.rs`). Because the deleted edges are simply absent from
+the rebuilt table, lbug never runs an in-place rel delete against a committed CSR
+group, so the group is never corrupted.
+
+### 3.1 Survivor safety and crash recovery
+
+lbug DDL (`DROP` / `CREATE` / `ALTER … RENAME`) auto-commits, so the rebuild
+cannot be wrapped in one explicit transaction. The ordering above keeps survivors
+safe regardless: the original table is dropped **only after** the scratch table is
+built and fsync'd. The single crash-loss window is between the `DROP` and the
+`RENAME`. A leftover `T__rebuild_tmp` from a crash in that window is recovered on
+the next open by `recover_rebuild_tmp_tables` (called from `ensure_schema_loaded`):
+
+- If the canonical `T` still exists, the scratch table is a **pre-swap straggler**
+  (the original is intact, the delete never took effect) → **drop** it.
+- If `T` is missing, the crash landed mid-swap and the rebuilt survivors live only
+  in the scratch table → **promote** it (`RENAME T__rebuild_tmp TO T`).
+
+Either way no acknowledged edge is lost, and the catalog converges to a clean
+state. This is strictly *more* durable than the pre-fix behaviour, where the
+delete corrupted the catalog and forced a quarantine + rebuild
+([durability_and_recovery.md](durability_and_recovery.md)).
+
+### 3.2 The edgeless fast path
+
+Deleting an **edgeless** node is safe (bisection: it never corrupts a CSR group),
+so `delete_node` keeps the plain `DELETE n` fast path for it. Only rel tables the
+node actually has an incident edge in are rebuilt (`rel_has_incident_node` gates
+each rebuild). The common working-/sensory-memory eviction case — evicting a node
+with no relationships — therefore rebuilds nothing.
+
+---
+
+## 4. Read-side hardening — typed per-rel-type scans
+
+Independently of the delete fix, every label-less rel `MATCH` was removed from the
+`lbug_store` read hot path (`store_impl.rs`) and replaced with a typed
 `MATCH (a)-[r:TYPE]->(b)` fan-out over the rel types the catalog knows about. A
 typed scan resolves to a single rel table's CSR storage (lbug's `ScanRelTable`)
-and **never** enters the multi-rel-table scanner.
+and **never** enters the multi-rel-table scanner of backtrace 2.
 
-### 2.1 Source of truth — `distinct_rel_names()`
+### 4.1 Source of truth — `distinct_rel_names()`
 
 The known rel types come from the `known_rel_tables` catalog cache (keyed
 `(rel_name, from, to)`, populated reopen-safely by `ensure_schema_loaded`). A rel
@@ -102,145 +189,96 @@ Catalog names are always valid identifiers; callers still re-check with
 `is_valid_identifier` before interpolating a name as a bare rel label, and skip
 (reads) or fail-closed (deletes) anything that is not.
 
-### 2.2 Reads — `query_neighbors_directed`
+### 4.2 Reads — `query_neighbors_directed`
 
 `edge_type = Some(t)` issues a single typed scan as before. `edge_type = None`
 now **fans out one typed scan per distinct known rel type and unions the
-results**, instead of one label-less scan:
-
-- The edge's type is taken from the **loop variable**, not
-  `RelVal::get_label_name` (which only mattered for the old multi-table scan).
-- Because every edge lives in exactly one rel table, the union returns each edge
-  **exactly once** — matching the old single-query result set. Ordering across
-  rel types was never part of the contract.
-- `limit` is honored across the union: the loop breaks once `pairs.len() >=
-  limit` and the result is truncated to `limit`.
-- A failure on one rel type is logged and skipped (best-effort read), consistent
-  with the prior read semantics.
-
-`traverse(.., None, ..)` inherits the fix for free — its BFS calls
-`query_neighbors` and dedups by visited set, so the per-type fan-out cannot
-duplicate nodes or paths.
-
-### 2.3 Deletes — `delete_node` Phase A
-
-The incident-edge strip in [`delete_node`](safe_node_deletion.md) likewise moved
-from a single label-less pass to **typed, per-rel-type** directed `DELETE` passes
-(outgoing + incoming) over `distinct_rel_names()`, fail-closed on a non-identifier
-rel name. An empty rel-type set means no passes run and control falls through to
-the plain Phase-B `DELETE`. (`delete_edge` already emitted a typed
-`-[r:TYPE]->` and was unaffected.)
+results**. Because every edge lives in exactly one rel table the union returns
+each edge **exactly once** (ordering across rel types was never part of the
+contract), `limit` is honored across the union, and a failure on one rel type is
+logged and skipped (best-effort read). `traverse(.., None, ..)` inherits the fix
+for free — its BFS calls `query_neighbors` and dedups by visited set.
 
 ---
 
-## 3. What did *not* change
+## 5. What did *not* change
 
 - **No trait or public-API change.** `GraphStore` is untouched; no
   `cognitive_memory/*` consumer changed. The `query_neighbors` / `traverse` /
-  `delete_node` contracts (edge type populated, `≤ limit`, all incident edges
-  removed or none) are preserved.
-- **Other backends are untouched.** Only `lbug` has the C++ CSR multi-rel-table
-  scanner, so `in_memory_store`, `hive_store`, `federated_store`, and
-  `kuzu_store` keep their label-less semantics. The fix is contained in the
-  `lbug_store` brick.
-- **Durability/recovery unchanged.** Skipping a CSR node group whose index is the
-  `UINT32_MAX` sentinel *before* dereferencing it would be the direct fix, but
-  that check lives inside lbug's C++ engine and is **not exposed to the Rust
-  bindings**, so it cannot be done here. Avoiding the multi-rel-table scanner via
-  typed scans is the feasible, durability-neutral mitigation; the post-write
-  barrier and auto-checkpoint bookkeeping are unchanged.
+  `delete_node` / `delete_edge` contracts (edge type populated, `≤ limit`, all
+  incident edges removed or none, idempotent no-op delete of a missing edge) are
+  preserved.
+- **Other backends are untouched.** Only `lbug` has the C++ CSR storage, so
+  `in_memory_store`, `hive_store`, `federated_store`, and `kuzu_store` keep their
+  existing semantics. The fix is contained in the `lbug_store` brick.
+- **Durability/recovery is preserved and extended.** The per-write barrier and
+  auto-checkpoint bookkeeping are unchanged; the rebuild adds its own fsync before
+  the swap and a `__rebuild_tmp` recovery step on open (§3.1). It never loses an
+  acknowledged write.
 
 ---
 
-## 4. The unresolved root cause
+## 6. Trade-offs and follow-up
 
-The typed-scan rewrite changes *which* scans are issued; it does not stop the CSR
-group from being corrupted in the first place. A bisecting reproduction
-(`run_csr_delete_churn` / `reproduces_issue_100_csr_delete_corruption` in
-`src/graph/lbug_store/tests.rs`) isolates the trigger:
-
-| Workload | Outcome |
-| --- | --- |
-| writes only | OK |
-| writes + label-less reads | OK |
-| writes + **deletes** (interleaved with checkpoints) | **CORRUPT** |
-| `delete_edge` alone | sufficient to corrupt |
-| deleting **edgeless** nodes | safe |
-
-So the driver is **deleting relationships out of a *committed* CSR rel group**
-(`delete_edge`, and `delete_node`'s Phase-A edge strip) while checkpoints are
-interleaved. That sets the CSR node group's index to the `UINT32_MAX` sentinel;
-the **next** scan to touch that table dereferences it — which can be a checkpoint
-flush, a typed read, *or* the label-less read of backtrace 2. The label-less read
-is one possible messenger, **not** the cause, which is why removing it does not
-remove the crash.
-
-This is **version-independent** — reproduced on lbug `0.15.3`, `0.15.4`, and
-`0.17.1` — i.e. an engine bug in CSR relationship deletion plus checkpointing, not
-a single-version regression and not something the Rust-side scan rewrite can fix.
-
-**Debug vs release surfacing.** In a debug/assertions build lbug reports the bad
-group as a *recoverable* `Storage` error from the bindings containing
-`group_collection.h ... groupIdx < groups.size()`. In a release/NDEBUG build the
-same condition is the raw null-pointer-deref `SIGSEGV` that kills the consumer
-daemon. **Do not run the reproduction under `--release`** — there it aborts the
-test binary via `SIGSEGV` instead of returning an error.
+- **Cost.** A rebuild is `O(edges in the affected rel table)` per delete, and the
+  reinsert is one `CREATE` per surviving edge. Deletes are infrequent
+  (retention/dedup, eviction) and the edgeless fast path skips them entirely, so
+  this trades a rare, bounded slow-down for the elimination of a daemon-killing
+  crash. Very large rel tables with frequent edge-bearing deletes are the worst
+  case; batch the survivor reinsert (`UNWIND`) if that ever becomes hot.
+- **Upstream lbug fix still desirable.** Guarding `getGroup` against the
+  `UINT32_MAX` sentinel / fixing the committed-CSR rel-delete + checkpoint path
+  would let us delete in place again and drop the rebuild. The rebuild stands on
+  its own until then.
 
 ---
 
-## 5. Follow-up
-
-Until lbug fixes the engine bug, candidate workarounds (none landed yet):
-
-- **Upstream lbug fix** — guard `getGroup` against the `UINT32_MAX` sentinel /
-  fix the committed-CSR rel-delete + checkpoint path. This is the real fix.
-- **Rust-side soft-delete** — tombstone edges (e.g. a `deleted` property) and
-  filter them in reads instead of issuing `DELETE r` against committed CSR
-  groups, so the corrupting operation never runs.
-- **Rel-table rebuild** — periodically rebuild affected rel tables out of band
-  rather than deleting in place.
-
-The reproduction test is marked `#[ignore]` so CI stays green; **un-ignore it
-once the root cause is fixed** (it asserts the desired post-fix outcome: the
-delete + checkpoint churn completes with no CSR-corruption error).
-
----
-
-## 6. Testing
+## 7. Testing
 
 Coverage lives in `rust/amplihack-memory/src/graph/lbug_store/tests.rs` behind the
 `persistent` feature.
 
-**Behavioral regression — typed reads (run in CI, must stay green):**
+**Root-cause regression (runs in CI, must stay green):**
 
-- `label_less_neighbor_read_over_committed_multi_rel_tables_does_not_crash` —
-  a `query_neighbors(.., None, ..)` over a node owning *committed* edges in
-  several rel tables returns every incident edge of every type exactly once
-  (directions correct) and does not crash.
-- `label_less_traverse_over_committed_multi_rel_tables_does_not_crash` — the BFS
-  `traverse(.., None, ..)` analogue crosses every rel type, visiting each
-  reachable node once.
-- `consolidation_cycle_with_label_less_reads_does_not_crash` — a full
-  consolidation cycle (idempotent edge churn → `delete_edge` → `delete_node` of an
-  edge-bearing fact via typed Phase-A deletes → checkpoint → label-less
-  reads/traverse) completes consistently.
-- `label_less_reads_survive_close_and_reopen_with_committed_csr` — the same reads
-  over CSR groups committed in a previous process and freshly reloaded.
+- `csr_delete_checkpoint_churn_stays_consistent` — the former `#[ignore]`d
+  reproduction, now a passing guard. Drives the delete + checkpoint consolidation
+  churn that corrupted a committed CSR rel group within ~10 rounds pre-fix; with
+  rebuild-on-delete it completes cleanly. A regression that reintroduces an
+  in-place rel delete fails it (debug: `getGroup(UINT32_MAX)` corruption error;
+  release: `SIGSEGV` aborts the binary).
 
-**Root-cause reproduction (`#[ignore]`d — reproduces the *unresolved* bug):**
+**Rebuild correctness:**
 
-- `reproduces_issue_100_csr_delete_corruption` — drives the delete + checkpoint
-  consolidation churn and asserts it completes without corrupting a committed CSR
-  rel group. It currently fails (debug: `getGroup(UINT32_MAX)` corruption error;
-  release: `SIGSEGV`), so it is ignored until the engine bug is fixed.
+- `delete_edge_rebuild_preserves_other_edges_and_props` — deleting one edge keeps
+  every other edge (and its properties) across a checkpoint and a reopen.
+- `delete_missing_edge_is_noop_success` — deleting a non-existent edge is an
+  idempotent success that does not disturb the table.
+- `delete_node_rebuild_preserves_unrelated_edges` — deleting an edge-bearing node
+  removes only its incident edges, leaving unrelated edges in the same and other
+  rel tables intact.
+- `delete_edgeless_node_fast_path_after_fix` — an edgeless node deletes via the
+  plain-`DELETE` fast path with rel tables present.
+- `stale_rebuild_tmp_is_dropped_on_open` / `interrupted_rebuild_tmp_is_promoted_on_open`
+  — the `__rebuild_tmp` crash-recovery cases (§3.1).
+
+**Behavioral regression — typed reads:**
+
+- `label_less_neighbor_read_over_committed_multi_rel_tables_does_not_crash`,
+  `label_less_traverse_over_committed_multi_rel_tables_does_not_crash`,
+  `consolidation_cycle_with_label_less_reads_does_not_crash`,
+  `label_less_reads_survive_close_and_reopen_with_committed_csr` — the typed
+  per-rel-type read fan-out returns every incident edge exactly once and never
+  enters the multi-rel-table scanner.
 
 Validate the green suite with the feature-gated tests (the original failure was a
-probabilistic native crash, so run a few times):
+probabilistic native crash, so run a few times, including `--release` for the
+NDEBUG configuration the daemon uses):
 
 ```bash
 cargo test  -p amplihack-memory --features persistent --lib graph::lbug_store
+cargo test  -p amplihack-memory --release --features persistent --lib graph::lbug_store
 cargo build -p amplihack-memory --features persistent
-cargo clippy -p amplihack-memory --all-targets --features persistent -- -D warnings
+cargo clippy -p amplihack-memory --features persistent -- -D warnings
 ```
 
 > **Pre-commit note.** The configured pre-commit hooks build with default
@@ -252,7 +290,7 @@ cargo clippy -p amplihack-memory --all-targets --features persistent -- -D warni
 ## See also
 
 - [`docs/safe_node_deletion.md`](safe_node_deletion.md) — the resolved #98/#99
-  edge-first, no-`DETACH` node deletion (whose Phase A now uses the typed deletes
-  described above).
+  edge-first, no-`DETACH` node deletion (whose Phase A now rebuilds incident rel
+  tables rather than deleting edges in place).
 - [`docs/durability_and_recovery.md`](durability_and_recovery.md) — checkpointing,
   recovery, and quarantine behavior.

--- a/rust/amplihack-memory/docs/csr_rel_delete_corruption.md
+++ b/rust/amplihack-memory/docs/csr_rel_delete_corruption.md
@@ -1,0 +1,258 @@
+# CSR rel-delete corruption — typed per-rel-type scans (#100) and the unresolved `getGroup(UINT32_MAX)` root cause
+
+Issue **#100** is a native `SIGSEGV` in the pinned LadybugDB engine, the same
+`getGroup(UINT32_MAX)` null-pointer dereference family as the
+[`DETACH DELETE` crash](safe_node_deletion.md) (#98). This page documents the
+**two** things the #100 work delivered:
+
+1. A **read-side + delete-side hardening** — every label-less multi-rel-table
+   scan in the `lbug_store` hot path was replaced with **typed, per-rel-type
+   scans**, so amplihack-memory never drives lbug's multi-rel-table scanner.
+2. A faithful, bisecting **reproduction** that pins the *actual* root cause to an
+   lbug **engine** bug: deleting relationships out of a *committed* CSR rel group
+   while interleaving checkpoints. That root cause is **not yet resolved**; the
+   typed-scan rewrite is hardening, **not** a fix.
+
+> **Read this first.** The typed-scan rewrite removes one of #100's two crash
+> *messengers* and is worth keeping, but it does **not** make `delete_edge` /
+> retention deletes safe on its own. The unresolved engine bug and its follow-up
+> options are in [§4](#4-the-unresolved-root-cause) and [§5](#5-follow-up).
+
+> **Feature gate.** Everything here requires the `persistent` cargo feature
+> (which pulls in the `lbug` engine):
+> `cargo build --features persistent` / `cargo test --features persistent`.
+
+---
+
+## Table of contents
+
+1. [The two #100 backtraces](#1-the-two-100-backtraces)
+2. [The hardening — typed per-rel-type scans](#2-the-hardening--typed-per-rel-type-scans)
+3. [What did *not* change](#3-what-did-not-change)
+4. [The unresolved root cause](#4-the-unresolved-root-cause)
+5. [Follow-up](#5-follow-up)
+6. [Testing](#6-testing)
+
+---
+
+## 1. The two #100 backtraces
+
+Both fault on the same null `unique_ptr` deref —
+`getGroup(groupIdx = 4294967295 / UINT32_MAX)` inside a CSR rel group — but reach
+it from different call sites:
+
+**Backtrace 1 — `DETACH DELETE` (already handled by #98/#99).**
+
+```
+getGroup(UINT32_MAX) -> null deref
+  <- CSRNodeGroup::scanCommittedInMemRandom
+  <- RelTable::detachDeleteForCSRRels
+  <- RelTable::detachDelete            (Cypher DETACH DELETE)
+```
+
+The [edge-first, no-`DETACH` deletion](safe_node_deletion.md) already keeps
+amplihack-memory out of `detachDeleteForCSRRels` entirely.
+
+**Backtrace 2 — label-less multi-rel-table *read* (the #100 read scan).**
+
+```
+getGroup(UINT32_MAX) -> null deref
+  <- CSRNodeGroup::scanCommittedInMemRandom
+  <- RelTableCollectionScanner::scan
+  <- ScanMultiRelTable::getNextTuplesInternal   (MATCH (a)-[r]->(b), no rel label)
+```
+
+A `MATCH (a)-[r]->(b)` with **no rel-type label** fans across *every* rel table at
+once via lbug's multi-rel-table scanner. The `lbug_store` read path
+(`query_neighbors(.., None, ..)` and the `traverse(.., None, ..)` BFS that calls
+it) used to emit exactly this shape.
+
+---
+
+## 2. The hardening — typed per-rel-type scans
+
+The fix removes **every** label-less rel `MATCH` from the `lbug_store` hot path
+(`src/graph/lbug_store/store_impl.rs`) and replaces each with a typed
+`MATCH (a)-[r:TYPE]->(b)` fan-out over the rel types the catalog knows about. A
+typed scan resolves to a single rel table's CSR storage (lbug's `ScanRelTable`)
+and **never** enters the multi-rel-table scanner.
+
+### 2.1 Source of truth — `distinct_rel_names()`
+
+The known rel types come from the `known_rel_tables` catalog cache (keyed
+`(rel_name, from, to)`, populated reopen-safely by `ensure_schema_loaded`). A rel
+name can appear with several endpoint pairs, but each edge lives in exactly one
+rel table, so the helper collapses to **distinct, sorted names**:
+
+```rust
+fn distinct_rel_names(&self) -> Vec<String> {
+    let mut names: Vec<String> = self
+        .known_rel_tables
+        .borrow()
+        .iter()
+        .map(|(rel, _, _)| rel.clone())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+```
+
+Catalog names are always valid identifiers; callers still re-check with
+`is_valid_identifier` before interpolating a name as a bare rel label, and skip
+(reads) or fail-closed (deletes) anything that is not.
+
+### 2.2 Reads — `query_neighbors_directed`
+
+`edge_type = Some(t)` issues a single typed scan as before. `edge_type = None`
+now **fans out one typed scan per distinct known rel type and unions the
+results**, instead of one label-less scan:
+
+- The edge's type is taken from the **loop variable**, not
+  `RelVal::get_label_name` (which only mattered for the old multi-table scan).
+- Because every edge lives in exactly one rel table, the union returns each edge
+  **exactly once** — matching the old single-query result set. Ordering across
+  rel types was never part of the contract.
+- `limit` is honored across the union: the loop breaks once `pairs.len() >=
+  limit` and the result is truncated to `limit`.
+- A failure on one rel type is logged and skipped (best-effort read), consistent
+  with the prior read semantics.
+
+`traverse(.., None, ..)` inherits the fix for free — its BFS calls
+`query_neighbors` and dedups by visited set, so the per-type fan-out cannot
+duplicate nodes or paths.
+
+### 2.3 Deletes — `delete_node` Phase A
+
+The incident-edge strip in [`delete_node`](safe_node_deletion.md) likewise moved
+from a single label-less pass to **typed, per-rel-type** directed `DELETE` passes
+(outgoing + incoming) over `distinct_rel_names()`, fail-closed on a non-identifier
+rel name. An empty rel-type set means no passes run and control falls through to
+the plain Phase-B `DELETE`. (`delete_edge` already emitted a typed
+`-[r:TYPE]->` and was unaffected.)
+
+---
+
+## 3. What did *not* change
+
+- **No trait or public-API change.** `GraphStore` is untouched; no
+  `cognitive_memory/*` consumer changed. The `query_neighbors` / `traverse` /
+  `delete_node` contracts (edge type populated, `≤ limit`, all incident edges
+  removed or none) are preserved.
+- **Other backends are untouched.** Only `lbug` has the C++ CSR multi-rel-table
+  scanner, so `in_memory_store`, `hive_store`, `federated_store`, and
+  `kuzu_store` keep their label-less semantics. The fix is contained in the
+  `lbug_store` brick.
+- **Durability/recovery unchanged.** Skipping a CSR node group whose index is the
+  `UINT32_MAX` sentinel *before* dereferencing it would be the direct fix, but
+  that check lives inside lbug's C++ engine and is **not exposed to the Rust
+  bindings**, so it cannot be done here. Avoiding the multi-rel-table scanner via
+  typed scans is the feasible, durability-neutral mitigation; the post-write
+  barrier and auto-checkpoint bookkeeping are unchanged.
+
+---
+
+## 4. The unresolved root cause
+
+The typed-scan rewrite changes *which* scans are issued; it does not stop the CSR
+group from being corrupted in the first place. A bisecting reproduction
+(`run_csr_delete_churn` / `reproduces_issue_100_csr_delete_corruption` in
+`src/graph/lbug_store/tests.rs`) isolates the trigger:
+
+| Workload | Outcome |
+| --- | --- |
+| writes only | OK |
+| writes + label-less reads | OK |
+| writes + **deletes** (interleaved with checkpoints) | **CORRUPT** |
+| `delete_edge` alone | sufficient to corrupt |
+| deleting **edgeless** nodes | safe |
+
+So the driver is **deleting relationships out of a *committed* CSR rel group**
+(`delete_edge`, and `delete_node`'s Phase-A edge strip) while checkpoints are
+interleaved. That sets the CSR node group's index to the `UINT32_MAX` sentinel;
+the **next** scan to touch that table dereferences it — which can be a checkpoint
+flush, a typed read, *or* the label-less read of backtrace 2. The label-less read
+is one possible messenger, **not** the cause, which is why removing it does not
+remove the crash.
+
+This is **version-independent** — reproduced on lbug `0.15.3`, `0.15.4`, and
+`0.17.1` — i.e. an engine bug in CSR relationship deletion plus checkpointing, not
+a single-version regression and not something the Rust-side scan rewrite can fix.
+
+**Debug vs release surfacing.** In a debug/assertions build lbug reports the bad
+group as a *recoverable* `Storage` error from the bindings containing
+`group_collection.h ... groupIdx < groups.size()`. In a release/NDEBUG build the
+same condition is the raw null-pointer-deref `SIGSEGV` that kills the consumer
+daemon. **Do not run the reproduction under `--release`** — there it aborts the
+test binary via `SIGSEGV` instead of returning an error.
+
+---
+
+## 5. Follow-up
+
+Until lbug fixes the engine bug, candidate workarounds (none landed yet):
+
+- **Upstream lbug fix** — guard `getGroup` against the `UINT32_MAX` sentinel /
+  fix the committed-CSR rel-delete + checkpoint path. This is the real fix.
+- **Rust-side soft-delete** — tombstone edges (e.g. a `deleted` property) and
+  filter them in reads instead of issuing `DELETE r` against committed CSR
+  groups, so the corrupting operation never runs.
+- **Rel-table rebuild** — periodically rebuild affected rel tables out of band
+  rather than deleting in place.
+
+The reproduction test is marked `#[ignore]` so CI stays green; **un-ignore it
+once the root cause is fixed** (it asserts the desired post-fix outcome: the
+delete + checkpoint churn completes with no CSR-corruption error).
+
+---
+
+## 6. Testing
+
+Coverage lives in `rust/amplihack-memory/src/graph/lbug_store/tests.rs` behind the
+`persistent` feature.
+
+**Behavioral regression — typed reads (run in CI, must stay green):**
+
+- `label_less_neighbor_read_over_committed_multi_rel_tables_does_not_crash` —
+  a `query_neighbors(.., None, ..)` over a node owning *committed* edges in
+  several rel tables returns every incident edge of every type exactly once
+  (directions correct) and does not crash.
+- `label_less_traverse_over_committed_multi_rel_tables_does_not_crash` — the BFS
+  `traverse(.., None, ..)` analogue crosses every rel type, visiting each
+  reachable node once.
+- `consolidation_cycle_with_label_less_reads_does_not_crash` — a full
+  consolidation cycle (idempotent edge churn → `delete_edge` → `delete_node` of an
+  edge-bearing fact via typed Phase-A deletes → checkpoint → label-less
+  reads/traverse) completes consistently.
+- `label_less_reads_survive_close_and_reopen_with_committed_csr` — the same reads
+  over CSR groups committed in a previous process and freshly reloaded.
+
+**Root-cause reproduction (`#[ignore]`d — reproduces the *unresolved* bug):**
+
+- `reproduces_issue_100_csr_delete_corruption` — drives the delete + checkpoint
+  consolidation churn and asserts it completes without corrupting a committed CSR
+  rel group. It currently fails (debug: `getGroup(UINT32_MAX)` corruption error;
+  release: `SIGSEGV`), so it is ignored until the engine bug is fixed.
+
+Validate the green suite with the feature-gated tests (the original failure was a
+probabilistic native crash, so run a few times):
+
+```bash
+cargo test  -p amplihack-memory --features persistent --lib graph::lbug_store
+cargo build -p amplihack-memory --features persistent
+cargo clippy -p amplihack-memory --all-targets --features persistent -- -D warnings
+```
+
+> **Pre-commit note.** The configured pre-commit hooks build with default
+> features only and do not compile the `persistent` code; the explicit
+> `--features persistent` commands above are the authoritative gate.
+
+---
+
+## See also
+
+- [`docs/safe_node_deletion.md`](safe_node_deletion.md) — the resolved #98/#99
+  edge-first, no-`DETACH` node deletion (whose Phase A now uses the typed deletes
+  described above).
+- [`docs/durability_and_recovery.md`](durability_and_recovery.md) — checkpointing,
+  recovery, and quarantine behavior.

--- a/rust/amplihack-memory/docs/safe_node_deletion.md
+++ b/rust/amplihack-memory/docs/safe_node_deletion.md
@@ -10,6 +10,15 @@ whenever a node with relationships stored in a CSR rel table was detach-deleted.
 This page is the authoritative description of the fix for issue **#98** ("CRITICAL
 native crash — daemon SEGV-crashes every ~45–90 minutes during a `DETACH DELETE`").
 
+> **Related work (#100).** Phase A's incident-edge strip later moved from a
+> single *label-less* pass to **typed, per-rel-type passes** as a follow-up
+> hardening for issue **#100** (a second `getGroup(UINT32_MAX)` backtrace that
+> originates in a label-less multi-rel-table *read* scan). This page reflects the
+> current typed-delete implementation. #100's read-side hardening **and the
+> still-unresolved CSR rel-delete root cause** are covered in
+> [`docs/csr_rel_delete_corruption.md`](csr_rel_delete_corruption.md); the
+> edge-first/no-`DETACH` contract described here is unchanged by that work.
+
 - **No more native crashes.** A node that carries relationships — which, after the
   graph-enhancement work, is *most* fact and procedure nodes — can now be deleted
   without tripping the engine's buggy `detachDeleteForCSRRels` code path. The
@@ -106,22 +115,32 @@ node deletion never needs `DETACH` and never enters `detachDeleteForCSRRels`.
 `delete_node` now performs the deletion in two ordered phases, both inside a single
 critical section so no intermediate state is ever externally observable:
 
-1. **Phase A — remove every incident relationship.** Two directed, *label-less*
-   Cypher passes delete all edges touching the node, in both directions, across all
-   relationship types:
+1. **Phase A — remove every incident relationship.** For each relationship type
+   the store knows about (`distinct_rel_names()`, derived from the
+   `known_rel_tables` catalog cache), two directed, *typed* Cypher passes delete
+   all edges of that type touching the node, in both directions:
 
    ```cypher
+   -- for each known rel type TYPE:
    -- outgoing edges (node is the source)
-   MATCH (a)-[r]->(b) WHERE a.node_id = '<escaped id>' DELETE r
+   MATCH (a)-[r:TYPE]->(b) WHERE a.node_id = '<escaped id>' DELETE r
    -- incoming edges (node is the target)
-   MATCH (a)-[r]->(b) WHERE b.node_id = '<escaped id>' DELETE r
+   MATCH (a)-[r:TYPE]->(b) WHERE b.node_id = '<escaped id>' DELETE r
    ```
 
-   Two directed passes together remove outbound, inbound, self-loop, and parallel
-   edges. The passes are label-less and matched purely on the globally unique
-   `node_id`, mirroring the proven `query_neighbors_directed` query shape; this
-   avoids a binder error that a node-labelled rel pattern would raise when the
-   node's table participates in no rel table.
+   Two directed passes per type together remove outbound, inbound, self-loop, and
+   parallel edges; iterating over every known rel type covers all of them. The
+   passes are matched on the globally unique `node_id`.
+
+   Each pass is **typed** (`-[r:TYPE]->`) rather than label-less
+   (`-[r]->`): a single label-less rel `MATCH` fans across *every* rel table at
+   once through lbug's multi-rel-table scanner, which is the second
+   `getGroup(UINT32_MAX)` SIGSEGV backtrace in **#100**. A typed pass only ever
+   touches one rel table's CSR storage and never enters that scanner. See
+   [`docs/csr_rel_delete_corruption.md`](csr_rel_delete_corruption.md). Rel-type
+   names come straight from the catalog and are always safe identifiers; a
+   non-identifier name (a corrupt cache) is refused fail-closed (the node and its
+   edges are left fully intact) rather than interpolated as a bare rel label.
 
 2. **Phase B — delete the now-isolated node with a plain `DELETE` (no `DETACH`).**
 
@@ -139,14 +158,15 @@ critical section so no intermediate state is ever externally observable:
   back to a catalog lookup). If the node ID is unknown (no table), `delete_node`
   returns `false` immediately.
 - **Edge-pass guard.** After the schema cache is ensured loaded from the on-disk
-  catalog (`ensure_schema_loaded`, which populates `known_rel_tables`), Phase A runs
-  only when the store knows about at least one relationship table — the same guard
-  the proven `query_neighbors` path uses. When no rel tables exist, the edge passes
-  are skipped (an unlabeled rel `MATCH` would raise a binder error and there is
-  nothing to delete), keeping the edgeless-node path green.
-- **Fail-closed.** If either Phase A pass returns an error, `delete_node` logs a
-  warning and returns `false` **without** running Phase B and **without** evicting
-  the routing cache — the node is left fully intact rather than half-deleted.
+  catalog (`ensure_schema_loaded`, which populates `known_rel_tables`), Phase A
+  iterates over the distinct known rel-type names. When the store knows of no rel
+  tables, that list is empty, so no edge passes run and control falls straight
+  through to the plain Phase-B `DELETE` — keeping the edgeless-node path green
+  (and there is nothing to delete anyway).
+- **Fail-closed.** If any Phase A pass returns an error — or a known rel-type name
+  is not a safe identifier — `delete_node` logs a warning and returns `false`
+  **without** running Phase B and **without** evicting the routing cache, so the
+  node is left fully intact rather than half-deleted.
 - **Atomic.** Phase A, Phase B, the cache eviction, the durability barrier, and the
   auto-checkpoint bookkeeping all run under one non-reentrant lock, so a concurrent
   reader never observes a node with some-but-not-all of its edges removed.
@@ -166,14 +186,14 @@ sequenceDiagram
     S->>S: resolve table (else return false)
     S->>S: ensure_schema_loaded → populate known_rel_tables
     S->>S: acquire write lock
-    S->>S: has_rel? = known_rel_tables is non-empty
-    alt has_rel (store knows ≥1 rel table)
-        S->>E: MATCH (a)-[r]->(b) WHERE a.node_id='fact-123' DELETE r
-        S->>E: MATCH (a)-[r]->(b) WHERE b.node_id='fact-123' DELETE r
-        Note over S,E: on error → warn + return false (no node delete)
-    else no rel tables
-        Note over S,E: edge passes skipped (unlabeled MATCH would be a binder error)
+    S->>S: rel_types = distinct_rel_names() (from known_rel_tables)
+    loop for each known rel TYPE
+        S->>E: MATCH (a)-[r:TYPE]->(b) WHERE a.node_id='fact-123' DELETE r
+        S->>E: MATCH (a)-[r:TYPE]->(b) WHERE b.node_id='fact-123' DELETE r
+        Note over S,E: typed scan — never lbug's multi-rel-table scanner (#100)
+        Note over S,E: on error / unsafe name → warn + return false (no node delete)
     end
+    Note over S,E: empty rel_types ⇒ no passes ⇒ fall through to plain DELETE
     S->>E: MATCH (n:Fact) WHERE n.node_id='fact-123' DELETE n
     Note over S,E: plain DELETE — never DETACH, never detachDeleteForCSRRels
     S->>S: evict id→table cache · durability barrier · maybe checkpoint
@@ -319,6 +339,12 @@ behind the `persistent` feature:
 - **Edgeless delete (existing behavior).** The pre-existing test that deletes a node
   with no relationships is retained and still passes, proving the edge-pass guard
   keeps the edgeless path working.
+
+The typed Phase-A deletes also run inside the broader **#100** regression suite
+(`consolidation_cycle_with_label_less_reads_does_not_crash` exercises
+`delete_node` over committed CSR groups during a full consolidation cycle) and are
+discussed alongside the still-unresolved CSR rel-delete root cause in
+[`docs/csr_rel_delete_corruption.md`](csr_rel_delete_corruption.md).
 
 Validate with the feature-gated suite (run a few times, since the original failure
 was a probabilistic native crash):

--- a/rust/amplihack-memory/docs/safe_node_deletion.md
+++ b/rust/amplihack-memory/docs/safe_node_deletion.md
@@ -10,12 +10,16 @@ whenever a node with relationships stored in a CSR rel table was detach-deleted.
 This page is the authoritative description of the fix for issue **#98** ("CRITICAL
 native crash — daemon SEGV-crashes every ~45–90 minutes during a `DETACH DELETE`").
 
-> **Related work (#100).** Phase A's incident-edge strip later moved from a
-> single *label-less* pass to **typed, per-rel-type passes** as a follow-up
-> hardening for issue **#100** (a second `getGroup(UINT32_MAX)` backtrace that
-> originates in a label-less multi-rel-table *read* scan). This page reflects the
-> current typed-delete implementation. #100's read-side hardening **and the
-> still-unresolved CSR rel-delete root cause** are covered in
+> **Related work (#100).** Phase A's incident-edge strip evolved twice as
+> follow-up work for issue **#100** (a `getGroup(UINT32_MAX)` corruption driven by
+> deleting relationships out of a *committed* CSR rel group). It first moved from a
+> single *label-less* `DELETE r` pass to **typed, per-rel-type** passes (read-side
+> hardening), and then — because an in-place `DELETE r` against a committed group
+> is itself the corruption trigger — to **rebuilding** each incident rel table
+> (copy the survivors into a scratch table and swap it in) instead of deleting
+> edges in place. This page reflects the current **rebuild-on-delete**
+> implementation. The full #100 analysis, the rebuild design, and the read-side
+> typed-scan hardening are in
 > [`docs/csr_rel_delete_corruption.md`](csr_rel_delete_corruption.md); the
 > edge-first/no-`DETACH` contract described here is unchanged by that work.
 
@@ -117,30 +121,35 @@ critical section so no intermediate state is ever externally observable:
 
 1. **Phase A — remove every incident relationship.** For each relationship type
    the store knows about (`distinct_rel_names()`, derived from the
-   `known_rel_tables` catalog cache), two directed, *typed* Cypher passes delete
-   all edges of that type touching the node, in both directions:
+   `known_rel_tables` catalog cache) that the node actually has an edge in, the
+   incident edges are removed by **rebuilding** that rel table — not by an
+   in-place `DELETE r`:
 
-   ```cypher
-   -- for each known rel type TYPE:
-   -- outgoing edges (node is the source)
-   MATCH (a)-[r:TYPE]->(b) WHERE a.node_id = '<escaped id>' DELETE r
-   -- incoming edges (node is the target)
-   MATCH (a)-[r:TYPE]->(b) WHERE b.node_id = '<escaped id>' DELETE r
+   ```text
+   -- for each known rel type TYPE the node is incident to:
+   --   keep := edges NOT touching the node
+   --     a.node_id <> '<escaped id>' AND b.node_id <> '<escaped id>'
+   --   1. snapshot the survivors (endpoint ids + every STRING column)
+   --   2. CREATE REL TABLE TYPE__rebuild_tmp(FROM .. TO .., ..); reinsert survivors
+   --   3. fsync  (original TYPE still intact ⇒ a crash here loses nothing)
+   --   4. DROP TABLE TYPE;  ALTER TABLE TYPE__rebuild_tmp RENAME TO TYPE;  fsync
    ```
 
-   Two directed passes per type together remove outbound, inbound, self-loop, and
-   parallel edges; iterating over every known rel type covers all of them. The
-   passes are matched on the globally unique `node_id`.
+   The deleted edges are simply absent from the rebuilt table, so lbug never runs
+   an in-place rel delete against a **committed** CSR rel group — the operation
+   that sets the group index to the `UINT32_MAX` sentinel and `SIGSEGV`s the next
+   scan/checkpoint (**#100**). The survivor-safe ordering and the
+   `TYPE__rebuild_tmp` crash-recovery (promote or drop on the next open) are
+   detailed in [`docs/csr_rel_delete_corruption.md`](csr_rel_delete_corruption.md)
+   (`LbugGraphStore::rebuild_rel_table_keeping`).
 
-   Each pass is **typed** (`-[r:TYPE]->`) rather than label-less
-   (`-[r]->`): a single label-less rel `MATCH` fans across *every* rel table at
-   once through lbug's multi-rel-table scanner, which is the second
-   `getGroup(UINT32_MAX)` SIGSEGV backtrace in **#100**. A typed pass only ever
-   touches one rel table's CSR storage and never enters that scanner. See
-   [`docs/csr_rel_delete_corruption.md`](csr_rel_delete_corruption.md). Rel-type
-   names come straight from the catalog and are always safe identifiers; a
-   non-identifier name (a corrupt cache) is refused fail-closed (the node and its
-   edges are left fully intact) rather than interpolated as a bare rel label.
+   Only rel tables the node is **incident to** are rebuilt (`rel_has_incident_node`
+   gates each one), so an edgeless node rebuilds nothing and falls straight through
+   to the plain Phase-B `DELETE` — which is safe (bisection: deleting an edgeless
+   node never corrupts a CSR group). Rel-type and endpoint-table names come straight
+   from the catalog and are always safe identifiers; a non-identifier name (a
+   corrupt cache) is refused fail-closed (the node and its edges are left fully
+   intact) rather than interpolated as a bare label.
 
 2. **Phase B — delete the now-isolated node with a plain `DELETE` (no `DETACH`).**
 
@@ -159,14 +168,16 @@ critical section so no intermediate state is ever externally observable:
   returns `false` immediately.
 - **Edge-pass guard.** After the schema cache is ensured loaded from the on-disk
   catalog (`ensure_schema_loaded`, which populates `known_rel_tables`), Phase A
-  iterates over the distinct known rel-type names. When the store knows of no rel
-  tables, that list is empty, so no edge passes run and control falls straight
-  through to the plain Phase-B `DELETE` — keeping the edgeless-node path green
-  (and there is nothing to delete anyway).
-- **Fail-closed.** If any Phase A pass returns an error — or a known rel-type name
-  is not a safe identifier — `delete_node` logs a warning and returns `false`
+  iterates over the distinct known rel-type names and rebuilds only those the node
+  is incident to. When the store knows of no rel tables, or the node has no
+  incident edges, nothing is rebuilt and control falls straight through to the
+  plain Phase-B `DELETE` — keeping the edgeless-node path green and fast.
+- **Fail-closed.** If any Phase A rebuild returns an error — or a known rel-type
+  name is not a safe identifier — `delete_node` logs a warning and returns `false`
   **without** running Phase B and **without** evicting the routing cache, so the
-  node is left fully intact rather than half-deleted.
+  node is left fully intact rather than half-deleted. The rebuild keeps the
+  original rel table intact until its replacement is built and fsync'd, so a
+  mid-rebuild failure or crash never loses surviving edges.
 - **Atomic.** Phase A, Phase B, the cache eviction, the durability barrier, and the
   auto-checkpoint bookkeeping all run under one non-reentrant lock, so a concurrent
   reader never observes a node with some-but-not-all of its edges removed.
@@ -187,13 +198,14 @@ sequenceDiagram
     S->>S: ensure_schema_loaded → populate known_rel_tables
     S->>S: acquire write lock
     S->>S: rel_types = distinct_rel_names() (from known_rel_tables)
-    loop for each known rel TYPE
-        S->>E: MATCH (a)-[r:TYPE]->(b) WHERE a.node_id='fact-123' DELETE r
-        S->>E: MATCH (a)-[r:TYPE]->(b) WHERE b.node_id='fact-123' DELETE r
-        Note over S,E: typed scan — never lbug's multi-rel-table scanner (#100)
+    loop for each known rel TYPE the node is incident to
+        S->>E: snapshot survivors (edges NOT touching fact-123)
+        S->>E: CREATE TYPE__rebuild_tmp; reinsert survivors; fsync
+        S->>E: DROP TABLE TYPE; RENAME TYPE__rebuild_tmp TO TYPE; fsync
+        Note over S,E: rebuild — no in-place DELETE r on a committed CSR group (#100)
         Note over S,E: on error / unsafe name → warn + return false (no node delete)
     end
-    Note over S,E: empty rel_types ⇒ no passes ⇒ fall through to plain DELETE
+    Note over S,E: edgeless node ⇒ no rebuilds ⇒ fall through to plain DELETE
     S->>E: MATCH (n:Fact) WHERE n.node_id='fact-123' DELETE n
     Note over S,E: plain DELETE — never DETACH, never detachDeleteForCSRRels
     S->>S: evict id→table cache · durability barrier · maybe checkpoint
@@ -273,8 +285,8 @@ use amplihack_memory::graph::protocol::GraphStore;
 use amplihack_memory::graph::LbugGraphStore;
 
 fn purge_sensory(store: &mut LbugGraphStore) {
-    // A node with no relationships: the incident-edge passes are skipped and the
-    // plain DELETE removes it exactly as before.
+    // A node with no relationships: no rel tables are rebuilt and the plain
+    // DELETE removes it exactly as before.
     assert!(store.delete_node("sensory-987"));
 }
 ```
@@ -340,10 +352,11 @@ behind the `persistent` feature:
   with no relationships is retained and still passes, proving the edge-pass guard
   keeps the edgeless path working.
 
-The typed Phase-A deletes also run inside the broader **#100** regression suite
-(`consolidation_cycle_with_label_less_reads_does_not_crash` exercises
-`delete_node` over committed CSR groups during a full consolidation cycle) and are
-discussed alongside the still-unresolved CSR rel-delete root cause in
+The Phase-A rebuilds also run inside the broader **#100** regression suite
+(`csr_delete_checkpoint_churn_stays_consistent` drives `delete_node`/`delete_edge`
+over committed CSR groups across interleaved checkpoints, and
+`delete_node_rebuild_preserves_unrelated_edges` checks the rebuild keeps unrelated
+edges intact); these and the resolved CSR rel-delete root cause are discussed in
 [`docs/csr_rel_delete_corruption.md`](csr_rel_delete_corruption.md).
 
 Validate with the feature-gated suite (run a few times, since the original failure

--- a/rust/amplihack-memory/src/backends/sqlite_backend/tests.rs
+++ b/rust/amplihack-memory/src/backends/sqlite_backend/tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod tests {
     use crate::backends::base::MemoryBackend;
     use crate::backends::sqlite_backend::{escape_fts5_query, SqliteBackend};

--- a/rust/amplihack-memory/src/graph/lbug_store/mod.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/mod.rs
@@ -106,6 +106,19 @@ pub(crate) const DEFAULT_MAX_DB_BYTES: u64 = 16 << 30;
 /// Floor for the maximum database size (1 GiB).
 pub(crate) const MIN_MAX_DB_BYTES: u64 = 1 << 30;
 
+/// Suffix for the scratch rel table used by the #100 rebuild-delete swap.
+///
+/// Deleting relationship rows in place from a *committed* CSR rel group is what
+/// corrupts the group (its index is set to the `UINT32_MAX` sentinel) and
+/// SIGSEGVs the next scan/checkpoint — version-independent across lbug
+/// 0.15.3/0.15.4/0.17.1. `delete_edge` / `delete_node` therefore never issue an
+/// in-place `DELETE r`; they rebuild the affected rel table by copying the
+/// surviving edges into `<rel><suffix>` and swapping it in (see
+/// [`LbugGraphStore::rebuild_rel_table_keeping`]). A crash in the one-statement
+/// rename window leaves a `<rel><suffix>` table that
+/// [`ensure_schema_loaded`](LbugGraphStore::ensure_schema_loaded) recovers.
+pub(crate) const REBUILD_TMP_SUFFIX: &str = "__rebuild_tmp";
+
 /// How [`LbugGraphStore::open_with_recovery`] opened the store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WalRecoveryOutcome {
@@ -661,13 +674,26 @@ impl LbugGraphStore {
         }
         self.schema_loaded.set(true);
 
-        let rows = match self.query_rows("CALL show_tables() RETURN *") {
+        let mut rows = match self.query_rows("CALL show_tables() RETURN *") {
             Ok(r) => r,
             Err(e) => {
                 warn!("lbug_store: show_tables introspection failed: {e}");
                 return;
             }
         };
+
+        // Recover a #100 rebuild-delete that was interrupted in its one-statement
+        // rename window: a leftover `<rel>__rebuild_tmp` holds the rebuilt
+        // survivors. If the catalog changed, re-read it before populating caches.
+        if self.recover_rebuild_tmp_tables(&rows) {
+            rows = match self.query_rows("CALL show_tables() RETURN *") {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("lbug_store: show_tables re-introspection after rebuild recovery failed: {e}");
+                    return;
+                }
+            };
+        }
 
         for row in rows {
             let (name, ttype) = match table_row_name_and_type(&row) {
@@ -685,6 +711,51 @@ impl LbugGraphStore {
                 self.node_table_columns.borrow_mut().insert(name, cols);
             }
         }
+    }
+
+    /// Resolve any leftover `<rel>__rebuild_tmp` rel tables from a #100
+    /// rebuild-delete (see [`rebuild_rel_table_keeping`](Self::rebuild_rel_table_keeping))
+    /// that was interrupted in its drop→rename swap. Returns `true` if the
+    /// catalog was changed. Best-effort: failures are logged, not fatal.
+    ///
+    /// * If the canonical `<rel>` still exists, the tmp is a *pre-swap*
+    ///   straggler (the original is intact, the delete never took effect): drop
+    ///   the tmp.
+    /// * If `<rel>` is missing, the crash landed between the `DROP` and the
+    ///   `RENAME`, so the rebuilt survivors live only in the tmp: promote it by
+    ///   renaming it back to `<rel>`.
+    fn recover_rebuild_tmp_tables(&self, rows: &[Vec<Value>]) -> bool {
+        let names: HashSet<String> = rows
+            .iter()
+            .filter_map(|row| table_row_name_and_type(row).map(|(name, _)| name))
+            .collect();
+        let tmps: Vec<String> = names
+            .iter()
+            .filter(|n| n.ends_with(REBUILD_TMP_SUFFIX))
+            .cloned()
+            .collect();
+
+        let mut changed = false;
+        for tmp in tmps {
+            let canonical = &tmp[..tmp.len() - REBUILD_TMP_SUFFIX.len()];
+            if !is_valid_identifier(canonical) || !is_valid_identifier(&tmp) {
+                continue;
+            }
+            if names.contains(canonical) {
+                if let Err(e) = self.execute(&format!("DROP TABLE {tmp}")) {
+                    warn!("lbug_store: failed to drop stale rebuild tmp {tmp}: {e}");
+                } else {
+                    changed = true;
+                }
+            } else if let Err(e) = self.execute(&format!("ALTER TABLE {tmp} RENAME TO {canonical}"))
+            {
+                warn!("lbug_store: failed to promote interrupted rebuild tmp {tmp}: {e}");
+            } else {
+                warn!("lbug_store: promoted interrupted #100 rebuild tmp {tmp} -> {canonical}");
+                changed = true;
+            }
+        }
+        changed
     }
 
     /// Return the user-defined column names of `table` from the catalog.
@@ -718,6 +789,148 @@ impl LbugGraphStore {
             [from, to, ..] => Some((from.clone(), to.clone())),
             _ => None,
         }
+    }
+
+    /// Endpoint node tables for `rel` from the schema cache, or `None` if the
+    /// rel table is unknown. Avoids a `show_connection` round-trip on the hot
+    /// delete path; the cache is authoritative because rebuild swaps preserve
+    /// the rel name and its `FROM`/`TO`.
+    fn rel_endpoints_cached(&self, rel: &str) -> Option<(String, String)> {
+        self.known_rel_tables
+            .borrow()
+            .iter()
+            .find(|(name, _, _)| name == rel)
+            .map(|(_, from, to)| (from.clone(), to.clone()))
+    }
+
+    /// User-defined column names of rel table `rel`, in catalog order
+    /// (`edge_id`, `graph_origin`, then any extra property columns). Every rel
+    /// column in this store is `STRING`, so the rebuild can copy values as
+    /// escaped string literals without tracking types.
+    fn introspect_rel_columns(&self, rel: &str) -> Vec<String> {
+        let cypher = format!("CALL table_info('{}') RETURN *", escape_cypher(rel));
+        let mut cols = Vec::new();
+        if let Ok(rows) = self.query_rows(&cypher) {
+            for row in rows {
+                // `table_info` rows are [property_id, name, type, default,
+                // storage]; the column name is the first String value (the
+                // numeric id is not a String).
+                if let Some(name) = row.iter().find_map(value_as_str) {
+                    cols.push(name.to_string());
+                }
+            }
+        }
+        cols
+    }
+
+    /// `true` if `node_id` is an endpoint of at least one edge in rel table
+    /// `rel`. A typed single-rel-table `LIMIT 1` scan (never the label-less
+    /// multi-rel scanner). Lets [`delete_node`](crate::graph::protocol::GraphStore::delete_node)
+    /// skip rebuilding tables the node has no edges in — and skip rebuilding
+    /// entirely for an edgeless node (the common eviction case), which deletes
+    /// safely with a plain `DELETE`.
+    pub(crate) fn rel_has_incident_node(
+        &self,
+        rel: &str,
+        from: &str,
+        to: &str,
+        node_id: &str,
+    ) -> bool {
+        let esc = escape_cypher(node_id);
+        let q = format!(
+            "MATCH (a:{from})-[r:{rel}]->(b:{to}) WHERE a.node_id = '{esc}' OR b.node_id = '{esc}' RETURN r LIMIT 1"
+        );
+        matches!(self.query_rows(&q), Ok(rows) if !rows.is_empty())
+    }
+
+    /// Rebuild rel table `rel` (`FROM from TO to`) keeping only the edges that
+    /// satisfy `keep_where` — a Cypher predicate over the bound `a` (the `FROM`
+    /// endpoint) and `b` (the `TO` endpoint).
+    ///
+    /// This is the #100 fix: it deletes relationships **without** an in-place
+    /// `DELETE r`, which corrupts a committed CSR rel group (see
+    /// [`REBUILD_TMP_SUFFIX`]). Survivors are copied into a scratch table and
+    /// the scratch table is swapped in.
+    ///
+    /// Survivor-safe ordering (lbug DDL auto-commits, so the whole rebuild
+    /// cannot be wrapped in one transaction): the original table is left fully
+    /// intact until the scratch table is built **and fsync'd**; only then is the
+    /// original dropped and the scratch renamed over it. The single crash window
+    /// is between that `DROP` and `RENAME`; a leftover scratch table is recovered
+    /// by [`recover_rebuild_tmp_tables`](Self::recover_rebuild_tmp_tables) on the
+    /// next open. The caller must hold the write lock.
+    pub(crate) fn rebuild_rel_table_keeping(
+        &self,
+        rel: &str,
+        from: &str,
+        to: &str,
+        keep_where: &str,
+    ) -> crate::Result<()> {
+        // All three names come from the catalog/cache and are always valid;
+        // they are interpolated bare, so refuse rather than risk injection.
+        if !is_valid_identifier(rel) || !is_valid_identifier(from) || !is_valid_identifier(to) {
+            return Err(MemoryError::Storage(format!(
+                "refusing to rebuild rel table with non-identifier names ({rel}, {from}, {to})"
+            )));
+        }
+        let cols = self.introspect_rel_columns(rel);
+        for c in &cols {
+            if !is_valid_identifier(c) {
+                return Err(MemoryError::Storage(format!(
+                    "refusing to rebuild rel table {rel}: non-identifier column {c:?}"
+                )));
+            }
+        }
+
+        // Snapshot the survivors: endpoint ids + every (STRING) column.
+        let ret_cols: String = cols.iter().map(|c| format!(", r.{c}")).collect();
+        let snapshot_q = format!(
+            "MATCH (a:{from})-[r:{rel}]->(b:{to}) WHERE {keep_where} \
+             RETURN a.node_id, b.node_id{ret_cols}"
+        );
+        let survivors = self.query_rows(&snapshot_q)?;
+
+        let tmp = format!("{rel}{REBUILD_TMP_SUFFIX}");
+        // Drop a straggler from an earlier interrupted rebuild (best-effort).
+        let _ = self.execute(&format!("DROP TABLE {tmp}"));
+        let col_defs: String = cols
+            .iter()
+            .map(|c| format!(", {c} STRING DEFAULT ''"))
+            .collect();
+        self.execute(&format!(
+            "CREATE REL TABLE {tmp}(FROM {from} TO {to}{col_defs})"
+        ))?;
+
+        for row in &survivors {
+            let a = value_to_string(&row[0]);
+            let b = value_to_string(&row[1]);
+            let props: Vec<String> = cols
+                .iter()
+                .enumerate()
+                .map(|(i, c)| format!("{c}: '{}'", escape_cypher(&value_to_string(&row[2 + i]))))
+                .collect();
+            let prop_clause = if props.is_empty() {
+                String::new()
+            } else {
+                format!(" {{{}}}", props.join(", "))
+            };
+            self.execute(&format!(
+                "MATCH (a:{from}), (b:{to}) WHERE a.node_id = '{}' AND b.node_id = '{}' \
+                 CREATE (a)-[:{tmp}{prop_clause}]->(b)",
+                escape_cypher(&a),
+                escape_cypher(&b),
+            ))?;
+        }
+
+        // Survivors are now durable in `tmp`; the original is still intact, so a
+        // crash here loses nothing (the delete simply did not happen yet).
+        self.post_write_barrier()?;
+
+        // Swap. The only crash-loss window is between these two statements.
+        self.execute(&format!("DROP TABLE {rel}"))?;
+        self.execute(&format!("ALTER TABLE {tmp} RENAME TO {rel}"))?;
+        self.post_write_barrier()?;
+        Ok(())
     }
 
     /// Ensure a node table exists with (at least) the reserved columns plus the

--- a/rust/amplihack-memory/src/graph/lbug_store/store_impl.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/store_impl.rs
@@ -536,38 +536,40 @@ impl GraphStore for LbugGraphStore {
         let escaped = escape_cypher(node_id);
 
         // Phase A — strip every incident relationship first, so the node delete
-        // never needs `DETACH` and never enters lbug 0.15.3's crashing
+        // never needs `DETACH` and never enters lbug's crashing
         // `detachDeleteForCSRRels` path (getGroup(UINT32_MAX) null deref, #98).
         //
-        // Each rel type is deleted with its own *typed* directed passes
-        // (`MATCH (a)-[r:TYPE]->(b) ... DELETE r`) rather than a single
-        // label-less `MATCH (a)-[r]->(b)` across all rel tables: a label-less
-        // multi-rel-table scan is exactly what drives lbug's
-        // `ScanMultiRelTable` / `CSRNodeGroup::scanCommittedInMemRandom` into
-        // the `getGroup(UINT32_MAX)` SEGV (#100). Two directed passes per type
-        // remove outbound, inbound, self-loop, and parallel edges. The passes
-        // are keyed on the globally unique `node_id`. With no rel tables the
-        // distinct-name list is empty, nothing is deleted, and we fall through
-        // to the plain `DELETE` below.
+        // Each incident rel table is stripped by *rebuilding* it (copy the
+        // surviving edges into a scratch table, swap it in) rather than issuing
+        // an in-place `MATCH (a)-[r:TYPE]->(b) ... DELETE r`. An in-place rel
+        // delete out of a *committed* CSR group is exactly what sets the group
+        // index to the UINT32_MAX sentinel and SIGSEGVs the next scan/checkpoint
+        // (#100) — version-independent across lbug 0.15.3/0.15.4/0.17.1. See
+        // [`rebuild_rel_table_keeping`](LbugGraphStore::rebuild_rel_table_keeping).
+        //
+        // Only rel tables the node actually has an edge in are rebuilt; an
+        // edgeless node (the common working-/sensory-memory eviction case)
+        // rebuilds nothing and falls straight through to the plain `DELETE`
+        // below, which is safe (bisection: deleting an edgeless node never
+        // corrupts a CSR group). Fail-closed (leave the node and all its edges
+        // intact) on any rebuild error rather than half-delete its edges.
+        let keep = format!("a.node_id <> '{escaped}' AND b.node_id <> '{escaped}'");
         for rel in self.distinct_rel_names() {
             // The rel label is interpolated bare; catalog names are always
-            // valid identifiers. Fail-closed (leave the node and its edges
-            // fully intact) rather than risk injecting an unsafe label.
+            // valid identifiers. Fail-closed rather than risk an unsafe label.
             if !is_valid_identifier(&rel) {
                 warn!("delete_node: refusing non-identifier rel type {rel:?} for {node_id}");
                 return false;
             }
-            let outgoing =
-                format!("MATCH (a)-[r:{rel}]->(b) WHERE a.node_id = '{escaped}' DELETE r");
-            let incoming =
-                format!("MATCH (a)-[r:{rel}]->(b) WHERE b.node_id = '{escaped}' DELETE r");
-            for cypher in [&outgoing, &incoming] {
-                if let Err(e) = self.execute(cypher) {
-                    // Fail-closed: leave the node fully intact (and its routing
-                    // cache entry) rather than half-delete its edges.
-                    warn!("delete_node: incident-edge cleanup failed for {node_id} on {rel}: {e}");
-                    return false;
-                }
+            let Some((from, to)) = self.rel_endpoints_cached(&rel) else {
+                continue;
+            };
+            if !self.rel_has_incident_node(&rel, &from, &to, node_id) {
+                continue;
+            }
+            if let Err(e) = self.rebuild_rel_table_keeping(&rel, &from, &to, &keep) {
+                warn!("delete_node: incident-edge rebuild failed for {node_id} on {rel}: {e}");
+                return false;
             }
         }
 
@@ -701,33 +703,50 @@ impl GraphStore for LbugGraphStore {
             return false;
         }
 
-        let src = match self.get_node(source_id) {
-            Some(n) => n,
-            None => return false,
-        };
-        let tgt = match self.get_node(target_id) {
-            Some(n) => n,
-            None => return false,
+        if self.get_node(source_id).is_none() || self.get_node(target_id).is_none() {
+            return false;
+        }
+
+        self.ensure_schema_loaded();
+        let _guard = self.acquire_lock();
+
+        // Unknown rel type → no such edge (matches the prior binder-error path,
+        // which returned false). `rel_endpoints_cached` also yields the FROM/TO
+        // tables to bind the typed scans below.
+        let Some((from, to)) = self.rel_endpoints_cached(edge_type) else {
+            return false;
         };
 
-        let _guard = self.acquire_lock();
-        let cypher = format!(
-            "MATCH (a:{})-[r:{edge_type}]->(b:{}) \
-             WHERE a.node_id = '{}' AND b.node_id = '{}' DELETE r",
-            src.node_type,
-            tgt.node_type,
-            escape_cypher(source_id),
-            escape_cypher(target_id)
+        let es = escape_cypher(source_id);
+        let et = escape_cypher(target_id);
+
+        // Nothing to delete → idempotent success without touching the table (so
+        // we never rebuild for a no-op). A typed single-rel-table scan, never
+        // the label-less multi-rel scanner.
+        let exists_q = format!(
+            "MATCH (a:{from})-[r:{edge_type}]->(b:{to}) \
+             WHERE a.node_id = '{es}' AND b.node_id = '{et}' RETURN r LIMIT 1"
         );
-        if self.execute(&cypher).is_ok() {
-            if let Err(e) = self.post_write_barrier() {
-                warn!("delete_edge: durability barrier failed for {source_id}->{target_id}: {e}");
+        match self.query_rows(&exists_q) {
+            Ok(rows) if rows.is_empty() => return true,
+            Ok(_) => {}
+            Err(e) => {
+                warn!("delete_edge: existence probe failed for {source_id}->{target_id}: {e}");
+                return false;
             }
-            self.note_write_and_maybe_checkpoint();
-            true
-        } else {
-            false
         }
+
+        // Remove the (source)->(target) edges of this type by rebuilding the rel
+        // table (keep everything else), never an in-place `DELETE r` against a
+        // committed CSR group — the #100 corruption driver. See
+        // [`rebuild_rel_table_keeping`](LbugGraphStore::rebuild_rel_table_keeping).
+        let keep = format!("NOT (a.node_id = '{es}' AND b.node_id = '{et}')");
+        if let Err(e) = self.rebuild_rel_table_keeping(edge_type, &from, &to, &keep) {
+            warn!("delete_edge: rebuild failed for {source_id}->{target_id} on {edge_type}: {e}");
+            return false;
+        }
+        self.note_write_and_maybe_checkpoint();
+        true
     }
 
     fn traverse(

--- a/rust/amplihack-memory/src/graph/lbug_store/tests.rs
+++ b/rust/amplihack-memory/src/graph/lbug_store/tests.rs
@@ -1035,20 +1035,22 @@ fn delete_node_with_edges_survives_close_and_reopen() {
 // ..)` / `traverse(.., None, ..)` therefore now issue one *typed* scan per known
 // rel type and union the results, never a single label-less scan.
 //
-// IMPORTANT (see `reproduces_issue_100_csr_delete_corruption` below): the
-// typed-scan rewrite is a hardening, NOT a fix for #100. Bisection shows the
-// CSR group is corrupted (its index set to the UINT32_MAX sentinel) by *deleting
-// relationships out of a committed CSR group* (`delete_edge` / `delete_node`
-// Phase A) interleaved with checkpoints; the `getGroup(UINT32_MAX)` deref then
-// fires on whatever scan next touches that table — a checkpoint flush, a typed
-// read, OR the label-less read above. A label-less read is one possible
-// messenger, not the cause, so removing it does not remove the crash.
+// IMPORTANT (see `csr_delete_checkpoint_churn_stays_consistent` below): the
+// typed-scan rewrite is hardening for the READ backtrace, but #100's root cause
+// is the DELETE side. Bisection showed the CSR group is corrupted (its index set
+// to the UINT32_MAX sentinel) by *deleting relationships out of a committed CSR
+// group* (`delete_edge` / `delete_node` Phase A) interleaved with checkpoints;
+// the `getGroup(UINT32_MAX)` deref then fires on whatever scan next touches that
+// table — a checkpoint flush, a typed read, OR the label-less read above. The
+// fix is therefore on the delete side: `delete_edge` / `delete_node` never issue
+// an in-place `DELETE r` against a committed group, but *rebuild* the rel table
+// (copy survivors into a scratch table and swap it in). See
+// `rebuild_rel_table_keeping`.
 //
-// These tests therefore pin the *behavioral contract* of the typed per-rel-type
-// neighbor read across multiple committed rel tables — every edge of every type
-// returned exactly once, directions correct, unrelated data untouched — and
-// guard against a regression back to a label-less scan. On a small, fresh store
-// the delete-driven corruption does not reproduce, so they also pass cleanly.
+// These tests pin the *behavioral contract* of the typed per-rel-type neighbor
+// read across multiple committed rel tables — every edge of every type returned
+// exactly once, directions correct, unrelated data untouched — and guard against
+// a regression back to a label-less scan.
 // ---------------------------------------------------------------------------
 
 /// Add a node of `node_type` with the given id (reused across the #100 tests).
@@ -1295,31 +1297,30 @@ fn label_less_reads_survive_close_and_reopen_with_committed_csr() {
 }
 
 // ---------------------------------------------------------------------------
-// ROOT-CAUSE REPRODUCTION (#100) — currently UNRESOLVED, hence #[ignore]d.
+// ROOT-CAUSE REGRESSION (#100) — was the #[ignore]d reproduction, now a guard.
 //
 // Bisection (writes-only OK, writes+label-less-reads OK, writes+DELETES corrupt;
-// and `delete_edge` alone is sufficient) pins the driver of the
+// and `delete_edge` alone is sufficient) pinned the driver of the
 // getGroup(UINT32_MAX) crash to *deleting relationships out of a committed CSR
 // rel group* — `delete_edge` and `delete_node`'s Phase-A edge strip — when
-// interleaved with checkpoints. The CSR node group's index is set to the
-// UINT32_MAX sentinel; the next scan to touch that table dereferences it:
-//   - a CHECKPOINT flush (what this reproduction trips, in a debug build),
+// interleaved with checkpoints. The CSR node group's index was set to the
+// UINT32_MAX sentinel; the next scan to touch that table dereferenced it:
+//   - a CHECKPOINT flush (what this churn trips, in a debug build),
 //   - a label-less multi-rel read (issue backtrace 2), or
 //   - DETACH-DELETE's CSR walk (issue backtrace 1).
-// This is version-independent (0.15.3 / 0.15.4 / 0.17.1), i.e. an lbug engine
-// bug in CSR relationship deletion + checkpoint, not something the Rust-side
-// typed-scan rewrite (which only changes *which* scans are issued) can fix.
+// This was version-independent (0.15.3 / 0.15.4 / 0.17.1), i.e. an lbug engine
+// bug in in-place CSR relationship deletion + checkpoint.
 //
-// In this DEBUG build lbug surfaces the bad group as an assertion that the
-// bindings return as a recoverable `Storage` error containing
-// "group_collection.h ... groupIdx < groups.size()"; in a RELEASE/NDEBUG build
-// the same condition is the raw null-pointer-deref SIGSEGV that kills the
-// consumer daemon. This test therefore asserts the DESIRED post-fix behavior —
-// the delete+checkpoint churn completes with no CSR-corruption error — and
-// currently FAILS, reproducing the bug. It is #[ignore]d so CI stays green;
-// un-ignore it once the root cause (an lbug fix, or a Rust-side soft-delete /
-// rel-table-rebuild workaround) lands. Do NOT run under `--release`: there it
-// aborts the test binary via SIGSEGV instead of returning an error.
+// FIX: `delete_edge` / `delete_node` no longer delete relationship rows in
+// place. They rebuild the affected rel table — copy the surviving edges into a
+// `<rel>__rebuild_tmp` scratch table and swap it in — so a committed CSR group
+// is never the target of an in-place `DELETE r`. With that change the
+// consolidation-style delete+checkpoint churn below, which previously corrupted
+// a committed group within ~10 rounds (debug: recoverable `Storage` error
+// "group_collection.h ... groupIdx < groups.size()"; release: SIGSEGV), now
+// completes cleanly. The test asserts that consistent outcome; if a regression
+// reintroduces an in-place rel delete it FAILS (debug error) or aborts the test
+// binary (release SIGSEGV).
 // ---------------------------------------------------------------------------
 
 /// True if `e` is the #100 CSR `getGroup(UINT32_MAX)` corruption surfaced as a
@@ -1328,8 +1329,8 @@ fn is_csr_group_corruption(e: &str) -> bool {
     e.contains("group_collection.h") && e.contains("groupIdx < groups.size()")
 }
 
-/// Drive the consolidation-style delete + checkpoint churn that corrupts a
-/// committed CSR rel group. Returns `Err(detail)` on the first CSR-corruption
+/// Drive the consolidation-style delete + checkpoint churn that USED to corrupt
+/// a committed CSR rel group. Returns `Err(detail)` on the first CSR-corruption
 /// (or other) error, `Ok(())` if the whole sequence stays consistent.
 fn run_csr_delete_churn(rounds: usize) -> Result<(), String> {
     let tmp = tempfile::tempdir().unwrap();
@@ -1362,7 +1363,9 @@ fn run_csr_delete_churn(rounds: usize) -> Result<(), String> {
         }
 
         // Retention/dedup: delete an edge-bearing fact, then re-create its id —
-        // the exact per-cycle pattern that drives the committed-CSR corruption.
+        // the exact per-cycle pattern that used to drive the committed-CSR
+        // corruption. `delete_node` now strips the fact's edges by rebuilding
+        // each incident rel table rather than deleting rows in place.
         if round % 7 == 0 {
             let victim = format!("f{}", (round % 5) + 1);
             let _ = store.delete_node(&victim);
@@ -1382,21 +1385,237 @@ fn run_csr_delete_churn(rounds: usize) -> Result<(), String> {
     Ok(())
 }
 
-/// REPRODUCTION (#100, UNRESOLVED): the delete + checkpoint consolidation churn
-/// must complete without corrupting a committed CSR rel group. It currently
-/// does not — the run returns the `getGroup(UINT32_MAX)` corruption error
-/// (debug) / SIGSEGVs (release). #[ignore]d until the root cause is fixed.
+/// REGRESSION (#100): the delete + checkpoint consolidation churn must complete
+/// without corrupting a committed CSR rel group. Pre-fix this corrupted within
+/// ~10 rounds; the rebuild-on-delete fix keeps it consistent. 40 rounds is 4x
+/// the historical corruption point — a comfortable regression margin.
 #[test]
-#[ignore = "reproduces unresolved lbug #100 CSR rel-delete corruption; un-ignore when fixed"]
-fn reproduces_issue_100_csr_delete_corruption() {
-    match run_csr_delete_churn(120) {
-        Ok(()) => { /* desired post-fix outcome */ }
+fn csr_delete_checkpoint_churn_stays_consistent() {
+    match run_csr_delete_churn(40) {
+        Ok(()) => { /* fixed: committed CSR groups stay intact across deletes */ }
         Err(e) if is_csr_group_corruption(&e) => {
             panic!(
-                "REPRODUCED #100: committed CSR rel group corrupted by \
-                 relationship deletes + checkpoints (getGroup(UINT32_MAX)): {e}"
+                "REGRESSION #100: a committed CSR rel group was corrupted by \
+                 relationship deletes + checkpoints (getGroup(UINT32_MAX)) — an \
+                 in-place rel DELETE crept back into delete_edge/delete_node: {e}"
             );
         }
         Err(e) => panic!("unexpected error during CSR-delete churn: {e}"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Rebuild-on-delete correctness (#100 fix). delete_edge / delete_node strip
+// relationships by rebuilding the rel table (copy survivors into a scratch
+// table and swap it in) instead of an in-place `DELETE r`. These pin that the
+// rebuild preserves every surviving edge, its properties, and unrelated data —
+// and that an interrupted rebuild's `__rebuild_tmp` scratch table is recovered
+// on reopen.
+// ---------------------------------------------------------------------------
+
+/// REGRESSION (#100): `delete_edge` rebuilds the rel table; it must drop only
+/// the targeted edge and leave every other edge — with its properties — intact,
+/// across a checkpoint (committed CSR group) and a reopen.
+#[test]
+fn delete_edge_rebuild_preserves_other_edges_and_props() {
+    let (_tmp, mut store) = open_temp();
+    for id in ["a1", "b1", "c1"] {
+        add(&mut store, "Thing", id);
+    }
+    store
+        .add_edge("a1", "b1", "LINKS", Some(props(&[("weight", "5")])))
+        .unwrap();
+    store
+        .add_edge("a1", "c1", "LINKS", Some(props(&[("weight", "9")])))
+        .unwrap();
+    store
+        .checkpoint()
+        .expect("checkpoint must commit the CSR group");
+
+    assert!(store.delete_edge("a1", "b1", "LINKS"));
+
+    let out = store.query_neighbors("a1", Some("LINKS"), Direction::Outgoing, 10);
+    assert_eq!(
+        neighbor_ids(&out),
+        vec!["c1".to_string()],
+        "only the survivor remains"
+    );
+    assert_eq!(
+        out[0].0.properties.get("weight").map(String::as_str),
+        Some("9"),
+        "survivor edge keeps its property through the rebuild"
+    );
+
+    store.close();
+    drop(store);
+    let store2 =
+        LbugGraphStore::open(&_tmp.path().join("graph.ladybug"), Some("test-store")).unwrap();
+    let out2 = store2.query_neighbors("a1", Some("LINKS"), Direction::Outgoing, 10);
+    assert_eq!(
+        neighbor_ids(&out2),
+        vec!["c1".to_string()],
+        "survivor persists across reopen"
+    );
+    assert_eq!(
+        out2[0].0.properties.get("weight").map(String::as_str),
+        Some("9")
+    );
+}
+
+/// REGRESSION (#100): deleting an edge that does not exist is an idempotent
+/// success and must not disturb the rel table's other edges.
+#[test]
+fn delete_missing_edge_is_noop_success() {
+    let (_tmp, mut store) = open_temp();
+    for id in ["a1", "b1"] {
+        add(&mut store, "Thing", id);
+    }
+    store.add_edge("a1", "b1", "LINKS", None).unwrap();
+    store.checkpoint().unwrap();
+
+    // No b1->a1 LINKS edge exists; deleting it is a no-op success.
+    assert!(store.delete_edge("b1", "a1", "LINKS"));
+    let out = store.query_neighbors("a1", Some("LINKS"), Direction::Outgoing, 10);
+    assert_eq!(
+        neighbor_ids(&out),
+        vec!["b1".to_string()],
+        "the real edge is untouched"
+    );
+}
+
+/// REGRESSION (#100): `delete_node` rebuilds only the rel tables the node has
+/// edges in and must leave unrelated edges (in the same and other rel tables)
+/// fully intact while removing the node and all its incident edges.
+#[test]
+fn delete_node_rebuild_preserves_unrelated_edges() {
+    let (_tmp, mut store) = open_temp();
+    for id in ["hub", "x1", "x2", "y1"] {
+        add(&mut store, "Fact", id);
+    }
+    add(&mut store, "Episode", "ep1");
+
+    // hub's incident edges span two rel tables, in both directions.
+    store.add_edge("hub", "ep1", "DERIVES_FROM", None).unwrap();
+    store.add_edge("x2", "hub", "SIMILAR_TO", None).unwrap();
+    // Unrelated edges that must survive: one in the SAME table hub uses
+    // (SIMILAR_TO) and one in a table hub never touches.
+    store.add_edge("x1", "x2", "SIMILAR_TO", None).unwrap();
+    store.add_edge("y1", "ep1", "DERIVES_FROM", None).unwrap();
+    store
+        .checkpoint()
+        .expect("checkpoint must commit the CSR groups");
+
+    assert!(store.delete_node("hub"));
+
+    assert!(store.get_node("hub").is_none(), "the node is gone");
+    // Unrelated SIMILAR_TO survivor intact.
+    let x1 = store.query_neighbors("x1", Some("SIMILAR_TO"), Direction::Outgoing, 10);
+    assert_eq!(neighbor_ids(&x1), vec!["x2".to_string()]);
+    // Unrelated DERIVES_FROM survivor intact.
+    let y1 = store.query_neighbors("y1", Some("DERIVES_FROM"), Direction::Outgoing, 10);
+    assert_eq!(neighbor_ids(&y1), vec!["ep1".to_string()]);
+    // hub's incident edges are gone (x2 no longer reaches hub).
+    let x2 = store.query_neighbors("x2", Some("SIMILAR_TO"), Direction::Outgoing, 10);
+    assert!(x2.is_empty(), "hub's incident edge was stripped");
+}
+
+/// REGRESSION (#100): `delete_node` on an edgeless node takes the plain-DELETE
+/// fast path (no rebuild) and still removes the node — even with rel tables
+/// present in the catalog.
+#[test]
+fn delete_edgeless_node_fast_path_after_fix() {
+    let (_tmp, mut store) = open_temp();
+    for id in ["a1", "b1", "lonely"] {
+        add(&mut store, "Fact", id);
+    }
+    store.add_edge("a1", "b1", "SIMILAR_TO", None).unwrap();
+    store.checkpoint().unwrap();
+
+    assert!(store.delete_node("lonely"));
+    assert!(store.get_node("lonely").is_none());
+    // The unrelated edge is untouched.
+    let out = store.query_neighbors("a1", Some("SIMILAR_TO"), Direction::Outgoing, 10);
+    assert_eq!(neighbor_ids(&out), vec!["b1".to_string()]);
+}
+
+/// REGRESSION (#100): a `<rel>__rebuild_tmp` scratch table left by a rebuild
+/// interrupted BEFORE the swap (canonical table still present) is a straggler
+/// and must be dropped on the next open, leaving the canonical table intact.
+#[test]
+fn stale_rebuild_tmp_is_dropped_on_open() {
+    let (_tmp, mut store) = open_temp();
+    for id in ["a1", "b1"] {
+        add(&mut store, "Fact", id);
+    }
+    store.add_edge("a1", "b1", "SIMILAR_TO", None).unwrap();
+    store.checkpoint().unwrap();
+    // Simulate the pre-swap straggler.
+    store
+        .execute("CREATE REL TABLE SIMILAR_TO__rebuild_tmp(FROM Fact TO Fact, edge_id STRING, graph_origin STRING)")
+        .unwrap();
+    store.checkpoint().unwrap();
+    store.close();
+    drop(store);
+
+    let store2 =
+        LbugGraphStore::open(&_tmp.path().join("graph.ladybug"), Some("test-store")).unwrap();
+    // Trigger schema load + recovery.
+    let out = store2.query_neighbors("a1", Some("SIMILAR_TO"), Direction::Outgoing, 10);
+    assert_eq!(
+        neighbor_ids(&out),
+        vec!["b1".to_string()],
+        "canonical edge intact"
+    );
+    let tables = store2.query_rows("CALL show_tables() RETURN *").unwrap();
+    let has_tmp = tables.iter().any(|row| {
+        row.iter()
+            .filter_map(super::value_as_str)
+            .any(|s| s.ends_with("__rebuild_tmp"))
+    });
+    assert!(!has_tmp, "stale rebuild tmp table must be dropped on open");
+}
+
+/// REGRESSION (#100): a `<rel>__rebuild_tmp` left by a rebuild interrupted IN
+/// the swap window (canonical dropped, survivors only in the tmp) must be
+/// promoted — renamed back to the canonical name — on the next open so its
+/// edges are not lost.
+#[test]
+fn interrupted_rebuild_tmp_is_promoted_on_open() {
+    let (_tmp, mut store) = open_temp();
+    for id in ["a1", "b1", "c1"] {
+        add(&mut store, "Fact", id);
+    }
+    store.add_edge("a1", "b1", "SIMILAR_TO", None).unwrap();
+    store.add_edge("a1", "c1", "SIMILAR_TO", None).unwrap();
+    store.checkpoint().unwrap();
+
+    // Simulate a crash mid-swap: survivors copied into the tmp, canonical dropped
+    // before the rename. The survivor here is a1->c1 only.
+    store
+        .execute("CREATE REL TABLE SIMILAR_TO__rebuild_tmp(FROM Fact TO Fact, edge_id STRING, graph_origin STRING)")
+        .unwrap();
+    store
+        .execute("MATCH (a:Fact),(b:Fact) WHERE a.node_id='a1' AND b.node_id='c1' CREATE (a)-[:SIMILAR_TO__rebuild_tmp {edge_id:'e', graph_origin:'test-store'}]->(b)")
+        .unwrap();
+    store.execute("DROP TABLE SIMILAR_TO").unwrap();
+    store.checkpoint().unwrap();
+    store.close();
+    drop(store);
+
+    let store2 =
+        LbugGraphStore::open(&_tmp.path().join("graph.ladybug"), Some("test-store")).unwrap();
+    // Trigger schema load + recovery (promotion of the tmp).
+    let out = store2.query_neighbors("a1", Some("SIMILAR_TO"), Direction::Outgoing, 10);
+    assert_eq!(
+        neighbor_ids(&out),
+        vec!["c1".to_string()],
+        "promoted rebuild tmp must restore the survivor under the canonical name"
+    );
+    let tables = store2.query_rows("CALL show_tables() RETURN *").unwrap();
+    let has_tmp = tables.iter().any(|row| {
+        row.iter()
+            .filter_map(super::value_as_str)
+            .any(|s| s.ends_with("__rebuild_tmp"))
+    });
+    assert!(!has_tmp, "tmp must be renamed away after promotion");
 }

--- a/rust/amplihack-memory/src/security/tests/integration_tests.rs
+++ b/rust/amplihack-memory/src/security/tests/integration_tests.rs
@@ -30,7 +30,7 @@ impl crate::backends::ExperienceBackend for MockBackend {
             .experiences
             .iter()
             .filter(|e| {
-                experience_type.map_or(true, |et| e.experience_type == et)
+                experience_type.is_none_or(|et| e.experience_type == et)
                     && e.confidence >= min_confidence
             })
             .take(limit)

--- a/rust/amplihack-memory/tests/concurrent.rs
+++ b/rust/amplihack-memory/tests/concurrent.rs
@@ -494,7 +494,7 @@ fn test_concurrent_sqlite_backend() {
     let b = backend.lock().unwrap();
     let stats = b.get_statistics().unwrap();
     assert_eq!(
-        stats.total_experiences as usize,
+        stats.total_experiences,
         threads * ops,
         "expected {} total experiences, got {}",
         threads * ops,


### PR DESCRIPTION
## Summary

Fixes #100 — a version-independent lbug engine `SIGSEGV` (`getGroup(groupIdx = 4294967295 / UINT32_MAX)` null-`unique_ptr` deref in `CSRNodeGroup::scanCommittedInMemRandom`) that crashed the consumer daemon every ~45–90 min during retention/dedup consolidation.

**Root cause (bisected):** deleting relationships **in place** out of a *committed* CSR rel group — `delete_edge`, and `delete_node`'s incident-edge strip — while checkpoints are interleaved sets the CSR node-group index to the `UINT32_MAX` sentinel. The next scan/checkpoint to touch that table dereferences it (debug: a recoverable `group_collection.h … groupIdx < groups.size()` assertion; release: the raw SIGSEGV). Reproduced on lbug `0.15.3`, `0.15.4`, and `0.17.1`, so it is **not** a single-version regression.

The earlier typed-per-rel-type scan rewrite (merged in #101) only hardened the **read** messenger (backtrace 2); it did not stop the corruption. Bisection: `writes` OK, `writes+reads` OK, `writes+DELETES` **CORRUPT**; `delete_edge` alone is sufficient; deleting **edgeless** nodes is safe.

## The fix — rebuild-on-delete

`delete_edge` and `delete_node` Phase A never issue an in-place `DELETE r` against a committed CSR group. To drop edges from a rel table they **rebuild** it (`rebuild_rel_table_keeping`):

1. Snapshot the surviving edges (endpoint ids + every `STRING` column).
2. Build a `<rel>__rebuild_tmp` scratch table; reinsert survivors; **fsync** (the original is still intact, so a crash here loses nothing).
3. `DROP` the original; `ALTER TABLE … RENAME` the scratch over it; fsync.

The deleted edges are simply absent from the rebuilt table, so lbug never performs the corrupting in-place rel delete.

**Durability / crash-safety.** lbug DDL auto-commits, so the rebuild can't be one transaction; the ordering keeps survivors safe regardless. The single 1-statement crash window (between `DROP` and `RENAME`) is recovered on the next open by `recover_rebuild_tmp_tables` (wired into `ensure_schema_loaded`): promote the `__rebuild_tmp` if the canonical is missing, else drop it. No acknowledged write is ever lost — strictly more durable than the pre-fix behaviour, which corrupted the catalog and forced a quarantine + rebuild.

**Performance.** A rebuild is `O(edges in the affected rel table)` per delete. Edgeless nodes keep the plain-`DELETE` fast path (bisection: safe) and only incident rel tables are rebuilt, so the common working-/sensory-memory eviction of edgeless nodes rebuilds nothing. This trades a rare, bounded slow-down for the elimination of a daemon-killing crash.

Read-side typed per-rel-type scans (from #101) are retained as hardening.

## Tests (all behind `persistent`, green in debug **and** release/NDEBUG)

- `csr_delete_checkpoint_churn_stays_consistent` — the former `#[ignore]`d reproduction, now a passing regression guard. Drives the delete+checkpoint consolidation churn that corrupted a committed CSR group within ~10 rounds pre-fix; now completes cleanly.
- Rebuild correctness: edge/property preservation across checkpoint+reopen, unrelated-edge preservation across rel tables, edgeless fast path, missing-edge idempotent no-op.
- `__rebuild_tmp` crash recovery: stale straggler dropped; mid-swap tmp promoted.

```
cargo test  -p amplihack-memory --features persistent              # 618+9+1+10+4 pass
cargo test  -p amplihack-memory --release --features persistent     # NDEBUG: no SIGSEGV
cargo clippy -p amplihack-memory --features persistent -- -D warnings
cargo fmt --check
```
(`pre-commit run` passes: fmt, clippy, test.)

> Note: `cargo clippy --all-targets --features persistent -- -D warnings` (the #100 validation gate) is now **green**. It had surfaced 3 pre-existing lint errors in unrelated `#[cfg(test)]`/integration targets (`tests/concurrent.rs` redundant `usize` cast, `backends/sqlite_backend/tests.rs` `module_inception`, `security/tests/integration_tests.rs` `map_or`→`is_none_or`) under the newer local toolchain. These are outside the project's clippy gate (CI runs `cargo clippy -- -D warnings` and `--features python`, without `--all-targets`/`persistent`) and outside the lbug_store change; they are cleared in a separate, clearly-scoped commit so the validation command runs fully green without polluting the fix history.

## Scope

No `GraphStore` trait or public-API change; no `cognitive_memory/*` consumer change. Contained in the `lbug_store` brick. Docs updated: `docs/csr_rel_delete_corruption.md` (rewritten for the rebuild fix), `docs/safe_node_deletion.md`, `README.md`, `CHANGELOG.md`.

Refs #100
